### PR TITLE
Add RBS type definitions and validation rake task

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,3 +10,5 @@ gem "rake", "~> 13.0"
 gem "rake-compiler"
 
 gem "minitest", "~> 6.0"
+
+gem "rbs"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,13 +9,18 @@ GEM
   remote: https://rubygems.org/
   specs:
     json (2.7.2)
+    logger (1.7.0)
     minitest (6.0.1)
       prism (~> 1.5)
     prism (1.9.0)
     rake (13.2.1)
     rake-compiler (1.2.7)
       rake
+    rbs (3.10.3)
+      logger
+      tsort
     securerandom (0.3.1)
+    tsort (0.2.0)
 
 PLATFORMS
   ruby
@@ -26,6 +31,7 @@ DEPENDENCIES
   quickjs!
   rake (~> 13.0)
   rake-compiler
+  rbs
 
 BUNDLED WITH
    2.5.9

--- a/Rakefile
+++ b/Rakefile
@@ -71,4 +71,11 @@ end
 
 task 'release:guard_clean' => 'polyfills:version:check'
 
-task default: %i[clobber compile test]
+namespace :rbs do
+  desc 'Validate RBS type definitions'
+  task :validate do
+    sh RbConfig.ruby, '-S', 'rbs', '-I', 'sig', 'validate'
+  end
+end
+
+task default: %i[clobber compile test rbs:validate]

--- a/sig/quickjs.rbs
+++ b/sig/quickjs.rbs
@@ -1,4 +1,72 @@
 module Quickjs
   VERSION: String
-  # See the writing guide of rbs: https://github.com/ruby/rbs#guides
+
+  MODULE_STD: Symbol
+  MODULE_OS: Symbol
+  FEATURE_TIMEOUT: Symbol
+  POLYFILL_INTL: Symbol
+  POLYFILL_FILE: Symbol
+  POLYFILL_HTML_BASE64: Symbol
+
+  def self.eval_code: (String code, ?Hash[Symbol, untyped] overwrite_opts) -> untyped
+
+  class Value
+    UNDEFINED: Symbol
+    NAN: Symbol
+  end
+
+  class VM
+    def initialize: (?features: Array[Symbol], ?memory_limit: Integer, ?max_stack_size: Integer, ?timeout_msec: Integer) -> void
+
+    def eval_code: (String code) -> untyped
+
+    def define_function: (String | Symbol name, *Symbol flags) { (*untyped) -> untyped } -> Symbol
+
+    def import: (String | Array[String] | Hash[Symbol, String] imported, from: String, ?code_to_expose: String?) -> true
+
+    def logs: () -> Array[Log]
+
+    class Log
+      attr_reader severity: Symbol
+
+      def raw: () -> Array[untyped]
+
+      def to_s: () -> String
+
+      def inspect: () -> String
+    end
+  end
+
+  class RuntimeError < ::RuntimeError
+    def initialize: (String message, String? js_name) -> void
+
+    attr_reader js_name: String?
+  end
+
+  class SyntaxError < RuntimeError
+  end
+
+  class TypeError < RuntimeError
+  end
+
+  class ReferenceError < RuntimeError
+  end
+
+  class RangeError < RuntimeError
+  end
+
+  class EvalError < RuntimeError
+  end
+
+  class URIError < RuntimeError
+  end
+
+  class AggregateError < RuntimeError
+  end
+
+  class InterruptedError < RuntimeError
+  end
+
+  class NoAwaitError < RuntimeError
+  end
 end


### PR DESCRIPTION
- Define complete type signatures for all public API
- Add rbs gem and rake `rbs:validate` task (included in `default` rake task group).