### PR TITLE
Provide Quickjs::VM#on_log to listen to that console(log|debug|info|warn|error) is called

### DIFF
--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -767,6 +767,8 @@ static VALUE vm_m_import(int argc, VALUE *argv, VALUE r_self)
 
 static VALUE vm_m_logs(VALUE r_self)
 {
+  rb_category_warn(RB_WARN_CATEGORY_DEPRECATED, "Quickjs::VM#logs is deprecated; use Quickjs::VM#on_log instead");
+
   VMData *data;
   TypedData_Get_Struct(r_self, VMData, &vm_type, data);
 

--- a/ext/quickjsrb/quickjsrb.h
+++ b/ext/quickjsrb/quickjsrb.h
@@ -52,6 +52,7 @@ typedef struct VMData
   VALUE defined_functions;
   struct EvalTime *eval_time;
   VALUE logs;
+  VALUE log_listener;
   VALUE alive_errors;
 } VMData;
 
@@ -79,6 +80,7 @@ static void vm_mark(void *ptr)
   VMData *data = (VMData *)ptr;
   rb_gc_mark_movable(data->defined_functions);
   rb_gc_mark_movable(data->logs);
+  rb_gc_mark_movable(data->log_listener);
   rb_gc_mark_movable(data->alive_errors);
 }
 
@@ -87,6 +89,7 @@ static void vm_compact(void *ptr)
   VMData *data = (VMData *)ptr;
   data->defined_functions = rb_gc_location(data->defined_functions);
   data->logs = rb_gc_location(data->logs);
+  data->log_listener = rb_gc_location(data->log_listener);
   data->alive_errors = rb_gc_location(data->alive_errors);
 }
 
@@ -107,6 +110,7 @@ static VALUE vm_alloc(VALUE r_self)
   VALUE obj = TypedData_Make_Struct(r_self, VMData, &vm_type, data);
   data->defined_functions = rb_hash_new();
   data->logs = rb_ary_new();
+  data->log_listener = Qnil;
   data->alive_errors = rb_hash_new();
 
   EvalTime *eval_time = malloc(sizeof(EvalTime));


### PR DESCRIPTION
with showing a deprecation message for `Quickjs::VM#logs`.

```rb
vm = Quickjs::VM.new
vm.on_log do |log|
  # log.severity => :info | :verbose | :warning | :error
  # log.to_s => stringified log inputs like browser console shows
  # log.raw => an array of the real data (converted forthe  Ruby world) that is passed to console.(log|info|warn|error)
end
```