### PR TITLE
Add POLYFILL_CRYPTO feature

### DIFF
--- a/ext/quickjsrb/extconf.rb
+++ b/ext/quickjsrb/extconf.rb
@@ -17,6 +17,7 @@ $srcs = [
   'polyfill-url.min.c',
   'quickjsrb.c',
   'quickjsrb_file.c',
+  'quickjsrb_crypto.c',
 ]
 
 append_cflags('-I$(srcdir)/quickjs')

--- a/ext/quickjsrb/extconf.rb
+++ b/ext/quickjsrb/extconf.rb
@@ -18,6 +18,7 @@ $srcs = [
   'quickjsrb.c',
   'quickjsrb_file.c',
   'quickjsrb_crypto.c',
+  'quickjsrb_crypto_subtle.c',
 ]
 
 append_cflags('-I$(srcdir)/quickjs')

--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -1,5 +1,6 @@
 #include "quickjsrb.h"
 #include "quickjsrb_file.h"
+#include "quickjsrb_crypto.h"
 
 const char *featureStdId = "feature_std";
 const char *featureOsId = "feature_os";
@@ -8,6 +9,7 @@ const char *featurePolyfillIntlId = "feature_polyfill_intl";
 const char *featurePolyfillFileId = "feature_polyfill_file";
 const char *featurePolyfillEncodingId = "feature_polyfill_encoding";
 const char *featurePolyfillUrlId = "feature_polyfill_url";
+const char *featurePolyfillCryptoId = "feature_polyfill_crypto";
 
 const char *undefinedId = "undefined";
 const char *nanId = "NaN";
@@ -686,6 +688,11 @@ static VALUE vm_m_initialize(int argc, VALUE *argv, VALUE r_self)
     JSValue j_polyfillUrlObject = JS_ReadObject(data->context, &qjsc_polyfill_url_min, qjsc_polyfill_url_min_size, JS_READ_OBJ_BYTECODE);
     JSValue j_polyfillUrlResult = JS_EvalFunction(data->context, j_polyfillUrlObject);
     JS_FreeValue(data->context, j_polyfillUrlResult);
+  }
+
+  if (RTEST(rb_funcall(r_features, rb_intern("include?"), 1, QUICKJSRB_SYM(featurePolyfillCryptoId))))
+  {
+    quickjsrb_init_crypto(data->context, j_global);
   }
 
   JSValue j_console = JS_NewObject(data->context);

--- a/ext/quickjsrb/quickjsrb.h
+++ b/ext/quickjsrb/quickjsrb.h
@@ -28,6 +28,7 @@ extern const char *featurePolyfillIntlId;
 extern const char *featurePolyfillFileId;
 extern const char *featurePolyfillEncodingId;
 extern const char *featurePolyfillUrlId;
+extern const char *featurePolyfillCryptoId;
 
 extern const char *undefinedId;
 extern const char *nanId;
@@ -160,6 +161,7 @@ static void r_define_constants(VALUE r_parent_class)
   rb_define_const(r_parent_class, "POLYFILL_FILE", QUICKJSRB_SYM(featurePolyfillFileId));
   rb_define_const(r_parent_class, "POLYFILL_ENCODING", QUICKJSRB_SYM(featurePolyfillEncodingId));
   rb_define_const(r_parent_class, "POLYFILL_URL", QUICKJSRB_SYM(featurePolyfillUrlId));
+  rb_define_const(r_parent_class, "POLYFILL_CRYPTO", QUICKJSRB_SYM(featurePolyfillCryptoId));
 
   VALUE rb_cQuickjsValue = rb_define_class_under(r_parent_class, "Value", rb_cObject);
   rb_define_const(rb_cQuickjsValue, "UNDEFINED", QUICKJSRB_SYM(undefinedId));

--- a/ext/quickjsrb/quickjsrb_crypto.c
+++ b/ext/quickjsrb/quickjsrb_crypto.c
@@ -1,0 +1,69 @@
+#include "quickjsrb.h"
+#include "quickjsrb_crypto.h"
+
+static VALUE r_secure_random()
+{
+  return rb_const_get(rb_cObject, rb_intern("SecureRandom"));
+}
+
+static JSValue js_crypto_get_random_values(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv)
+{
+  if (argc < 1)
+    return JS_ThrowTypeError(ctx, "Failed to execute 'getRandomValues': 1 argument required, but only 0 present.");
+
+  size_t byte_offset, byte_length, bytes_per_element;
+  JSValue j_buffer = JS_GetTypedArrayBuffer(ctx, argv[0], &byte_offset, &byte_length, &bytes_per_element);
+  if (JS_IsException(j_buffer))
+    return JS_EXCEPTION;
+
+  JSValue j_ctor = JS_GetPropertyStr(ctx, argv[0], "constructor");
+  JSValue j_name = JS_GetPropertyStr(ctx, j_ctor, "name");
+  const char *name = JS_ToCString(ctx, j_name);
+  int is_float = name && (strcmp(name, "Float16Array") == 0 ||
+                          strcmp(name, "Float32Array") == 0 ||
+                          strcmp(name, "Float64Array") == 0);
+  JS_FreeCString(ctx, name);
+  JS_FreeValue(ctx, j_name);
+  JS_FreeValue(ctx, j_ctor);
+
+  if (is_float)
+  {
+    JS_FreeValue(ctx, j_buffer);
+    return JS_ThrowTypeError(ctx, "Failed to execute 'getRandomValues': The provided ArrayBufferView value must not be of floating-point type.");
+  }
+
+  if (byte_length > 65536)
+  {
+    JS_FreeValue(ctx, j_buffer);
+    return JS_ThrowRangeError(ctx, "Failed to execute 'getRandomValues': The ArrayBufferView's byte length exceeds the number of bytes of entropy available via this API (65536).");
+  }
+
+  size_t buf_size;
+  uint8_t *buf = JS_GetArrayBuffer(ctx, &buf_size, j_buffer);
+  JS_FreeValue(ctx, j_buffer);
+
+  if (!buf)
+    return JS_ThrowTypeError(ctx, "Failed to execute 'getRandomValues': Failed to get ArrayBuffer.");
+
+  VALUE r_random_bytes = rb_funcall(r_secure_random(), rb_intern("random_bytes"), 1, SIZET2NUM(byte_length));
+  const uint8_t *random_buf = (const uint8_t *)RSTRING_PTR(r_random_bytes);
+  memcpy(buf + byte_offset, random_buf, byte_length);
+
+  return JS_DupValue(ctx, argv[0]);
+}
+
+static JSValue js_crypto_random_uuid(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv)
+{
+  VALUE r_uuid = rb_funcall(r_secure_random(), rb_intern("uuid"), 0);
+  return JS_NewString(ctx, StringValueCStr(r_uuid));
+}
+
+void quickjsrb_init_crypto(JSContext *ctx, JSValue j_global)
+{
+  JSValue j_crypto = JS_NewObject(ctx);
+  JS_SetPropertyStr(ctx, j_crypto, "getRandomValues",
+                    JS_NewCFunction(ctx, js_crypto_get_random_values, "getRandomValues", 1));
+  JS_SetPropertyStr(ctx, j_crypto, "randomUUID",
+                    JS_NewCFunction(ctx, js_crypto_random_uuid, "randomUUID", 0));
+  JS_SetPropertyStr(ctx, j_global, "crypto", j_crypto);
+}

--- a/ext/quickjsrb/quickjsrb_crypto.c
+++ b/ext/quickjsrb/quickjsrb_crypto.c
@@ -1,5 +1,6 @@
 #include "quickjsrb.h"
 #include "quickjsrb_crypto.h"
+#include "quickjsrb_crypto_subtle.h"
 
 static VALUE r_secure_random()
 {
@@ -65,5 +66,6 @@ void quickjsrb_init_crypto(JSContext *ctx, JSValue j_global)
                     JS_NewCFunction(ctx, js_crypto_get_random_values, "getRandomValues", 1));
   JS_SetPropertyStr(ctx, j_crypto, "randomUUID",
                     JS_NewCFunction(ctx, js_crypto_random_uuid, "randomUUID", 0));
+  quickjsrb_init_crypto_subtle(ctx, j_crypto);
   JS_SetPropertyStr(ctx, j_global, "crypto", j_crypto);
 }

--- a/ext/quickjsrb/quickjsrb_crypto.h
+++ b/ext/quickjsrb/quickjsrb_crypto.h
@@ -1,0 +1,6 @@
+#ifndef QUICKJSRB_CRYPTO_H
+#define QUICKJSRB_CRYPTO_H 1
+
+void quickjsrb_init_crypto(JSContext *ctx, JSValue j_global);
+
+#endif /* QUICKJSRB_CRYPTO_H */

--- a/ext/quickjsrb/quickjsrb_crypto_subtle.c
+++ b/ext/quickjsrb/quickjsrb_crypto_subtle.c
@@ -1,0 +1,105 @@
+#include "quickjsrb.h"
+#include "quickjsrb_crypto_subtle.h"
+
+// Extract algorithm name from a string or { name: "..." } object.
+// Caller must JS_FreeCString the result.
+static const char *js_get_algorithm_name(JSContext *ctx, JSValueConst j_algo)
+{
+  if (JS_IsString(j_algo))
+    return JS_ToCString(ctx, j_algo);
+  JSValue j_name = JS_GetPropertyStr(ctx, j_algo, "name");
+  const char *name = JS_ToCString(ctx, j_name);
+  JS_FreeValue(ctx, j_name);
+  return name;
+}
+
+// Convert a JS ArrayBuffer or TypedArray to a Ruby binary String.
+// Returns Qnil if the value is neither.
+static VALUE js_buffer_to_ruby_str(JSContext *ctx, JSValueConst j_val)
+{
+  size_t byte_offset = 0, byte_length = 0, bytes_per_element = 0;
+  int is_typed_array = 1;
+  JSValue j_buf = JS_GetTypedArrayBuffer(ctx, j_val, &byte_offset, &byte_length, &bytes_per_element);
+  if (JS_IsException(j_buf))
+  {
+    JSValue j_exc = JS_GetException(ctx);
+    JS_FreeValue(ctx, j_exc);
+    is_typed_array = 0;
+    j_buf = JS_DupValue(ctx, j_val);
+  }
+
+  size_t buf_size;
+  uint8_t *buf = JS_GetArrayBuffer(ctx, &buf_size, j_buf);
+  JS_FreeValue(ctx, j_buf);
+
+  if (!buf)
+    return Qnil;
+
+  size_t len = is_typed_array ? byte_length : buf_size;
+  VALUE r_str = rb_str_new((const char *)(buf + byte_offset), len);
+  rb_funcall(r_str, rb_intern("force_encoding"), 1, rb_str_new_cstr("BINARY"));
+  return r_str;
+}
+
+static VALUE r_subtle_digest_call(VALUE r_args)
+{
+  VALUE r_algorithm = rb_ary_entry(r_args, 0);
+  VALUE r_data = rb_ary_entry(r_args, 1);
+  VALUE r_mod = rb_const_get(rb_const_get(rb_cObject, rb_intern("Quickjs")), rb_intern("SubtleCrypto"));
+  return rb_funcall(r_mod, rb_intern("digest"), 2, r_algorithm, r_data);
+}
+
+static JSValue js_subtle_digest(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv)
+{
+  if (argc < 2)
+    return JS_ThrowTypeError(ctx, "Failed to execute 'digest': 2 arguments required.");
+
+  const char *algorithm_name = js_get_algorithm_name(ctx, argv[0]);
+  if (!algorithm_name)
+    return JS_ThrowTypeError(ctx, "Failed to execute 'digest': algorithm name is required.");
+  VALUE r_algorithm = rb_str_new_cstr(algorithm_name);
+  JS_FreeCString(ctx, algorithm_name);
+
+  VALUE r_data = js_buffer_to_ruby_str(ctx, argv[1]);
+  if (NIL_P(r_data))
+    return JS_ThrowTypeError(ctx, "Failed to execute 'digest': data must be an ArrayBuffer or TypedArray.");
+
+  JSValue promise, resolving_funcs[2];
+  promise = JS_NewPromiseCapability(ctx, resolving_funcs);
+  if (JS_IsException(promise))
+    return JS_EXCEPTION;
+
+  VALUE r_args = rb_ary_new3(2, r_algorithm, r_data);
+  int error_state;
+  VALUE r_result = rb_protect(r_subtle_digest_call, r_args, &error_state);
+
+  JSValue j_result, ret;
+  if (error_state)
+  {
+    VALUE r_error = rb_errinfo();
+    VALUE r_message = rb_funcall(r_error, rb_intern("message"), 0);
+    j_result = JS_NewError(ctx);
+    JS_SetPropertyStr(ctx, j_result, "message", JS_NewString(ctx, StringValueCStr(r_message)));
+    ret = JS_Call(ctx, resolving_funcs[1], JS_UNDEFINED, 1, (JSValueConst *)&j_result);
+  }
+  else
+  {
+    j_result = JS_NewArrayBufferCopy(ctx, (const uint8_t *)RSTRING_PTR(r_result), RSTRING_LEN(r_result));
+    ret = JS_Call(ctx, resolving_funcs[0], JS_UNDEFINED, 1, (JSValueConst *)&j_result);
+  }
+
+  JS_FreeValue(ctx, j_result);
+  JS_FreeValue(ctx, ret);
+  JS_FreeValue(ctx, resolving_funcs[0]);
+  JS_FreeValue(ctx, resolving_funcs[1]);
+
+  return promise;
+}
+
+void quickjsrb_init_crypto_subtle(JSContext *ctx, JSValueConst j_crypto)
+{
+  JSValue j_subtle = JS_NewObject(ctx);
+  JS_SetPropertyStr(ctx, j_subtle, "digest",
+                    JS_NewCFunction(ctx, js_subtle_digest, "digest", 2));
+  JS_SetPropertyStr(ctx, j_crypto, "subtle", j_subtle);
+}

--- a/ext/quickjsrb/quickjsrb_crypto_subtle.c
+++ b/ext/quickjsrb/quickjsrb_crypto_subtle.c
@@ -73,6 +73,179 @@ static void js_reject_with_ruby_error(JSContext *ctx, JSValueConst *resolving_fu
   JS_FreeValue(ctx, ret);
 }
 
+// Find Ruby CryptoKey from a JS CryptoKey object via rb_object_id handle.
+static VALUE r_find_alive_crypto_key(JSContext *ctx, JSValueConst j_key)
+{
+  JSValue j_handle = JS_GetPropertyStr(ctx, j_key, "rb_object_id");
+  int64_t handle = 0;
+  JS_ToInt64(ctx, &handle, j_handle);
+  JS_FreeValue(ctx, j_handle);
+  if (handle <= 0)
+    return Qnil;
+  VMData *data = JS_GetContextOpaque(ctx);
+  return rb_hash_aref(data->alive_objects, LONG2NUM(handle));
+}
+
+// Build a comprehensive Ruby Hash (symbol keys) from a JS algorithm object.
+// Extracts all possible properties used across SubtleCrypto operations.
+static VALUE js_algo_to_ruby_hash(JSContext *ctx, JSValueConst j_algo)
+{
+  VALUE r_hash = rb_hash_new();
+
+  const char *name = js_get_algorithm_name(ctx, j_algo);
+  if (name)
+  {
+    rb_hash_aset(r_hash, ID2SYM(rb_intern("name")), rb_str_new_cstr(name));
+    JS_FreeCString(ctx, name);
+  }
+
+  if (JS_IsString(j_algo))
+    return r_hash;
+
+  JSValue j_length = JS_GetPropertyStr(ctx, j_algo, "length");
+  if (!JS_IsUndefined(j_length) && !JS_IsException(j_length))
+  {
+    int32_t length = 0;
+    JS_ToInt32(ctx, &length, j_length);
+    rb_hash_aset(r_hash, ID2SYM(rb_intern("length")), INT2NUM(length));
+  }
+  JS_FreeValue(ctx, j_length);
+
+  JSValue j_named_curve = JS_GetPropertyStr(ctx, j_algo, "namedCurve");
+  if (!JS_IsUndefined(j_named_curve) && !JS_IsException(j_named_curve))
+  {
+    const char *nc = JS_ToCString(ctx, j_named_curve);
+    if (nc)
+    {
+      rb_hash_aset(r_hash, ID2SYM(rb_intern("named_curve")), rb_str_new_cstr(nc));
+      JS_FreeCString(ctx, nc);
+    }
+  }
+  JS_FreeValue(ctx, j_named_curve);
+
+  JSValue j_hash = JS_GetPropertyStr(ctx, j_algo, "hash");
+  if (!JS_IsUndefined(j_hash) && !JS_IsException(j_hash))
+  {
+    const char *hash_name = js_get_algorithm_name(ctx, j_hash);
+    if (hash_name)
+    {
+      rb_hash_aset(r_hash, ID2SYM(rb_intern("hash")), rb_str_new_cstr(hash_name));
+      JS_FreeCString(ctx, hash_name);
+    }
+  }
+  JS_FreeValue(ctx, j_hash);
+
+  JSValue j_modulus_length = JS_GetPropertyStr(ctx, j_algo, "modulusLength");
+  if (!JS_IsUndefined(j_modulus_length) && !JS_IsException(j_modulus_length))
+  {
+    int32_t mod_len = 0;
+    JS_ToInt32(ctx, &mod_len, j_modulus_length);
+    rb_hash_aset(r_hash, ID2SYM(rb_intern("modulus_length")), INT2NUM(mod_len));
+  }
+  JS_FreeValue(ctx, j_modulus_length);
+
+  JSValue j_pub_exp = JS_GetPropertyStr(ctx, j_algo, "publicExponent");
+  if (!JS_IsUndefined(j_pub_exp) && !JS_IsException(j_pub_exp))
+  {
+    VALUE r_pe = js_buffer_to_ruby_str(ctx, j_pub_exp);
+    if (!NIL_P(r_pe))
+      rb_hash_aset(r_hash, ID2SYM(rb_intern("public_exponent")), r_pe);
+  }
+  JS_FreeValue(ctx, j_pub_exp);
+
+  JSValue j_iv = JS_GetPropertyStr(ctx, j_algo, "iv");
+  if (!JS_IsUndefined(j_iv) && !JS_IsException(j_iv))
+  {
+    VALUE r_iv = js_buffer_to_ruby_str(ctx, j_iv);
+    if (!NIL_P(r_iv))
+      rb_hash_aset(r_hash, ID2SYM(rb_intern("iv")), r_iv);
+  }
+  JS_FreeValue(ctx, j_iv);
+
+  JSValue j_tag_length = JS_GetPropertyStr(ctx, j_algo, "tagLength");
+  if (!JS_IsUndefined(j_tag_length) && !JS_IsException(j_tag_length))
+  {
+    int32_t tag_length = 0;
+    JS_ToInt32(ctx, &tag_length, j_tag_length);
+    rb_hash_aset(r_hash, ID2SYM(rb_intern("tag_length")), INT2NUM(tag_length));
+  }
+  JS_FreeValue(ctx, j_tag_length);
+
+  JSValue j_additional_data = JS_GetPropertyStr(ctx, j_algo, "additionalData");
+  if (!JS_IsUndefined(j_additional_data) && !JS_IsException(j_additional_data))
+  {
+    VALUE r_ad = js_buffer_to_ruby_str(ctx, j_additional_data);
+    if (!NIL_P(r_ad))
+      rb_hash_aset(r_hash, ID2SYM(rb_intern("additional_data")), r_ad);
+  }
+  JS_FreeValue(ctx, j_additional_data);
+
+  JSValue j_counter = JS_GetPropertyStr(ctx, j_algo, "counter");
+  if (!JS_IsUndefined(j_counter) && !JS_IsException(j_counter))
+  {
+    VALUE r_counter = js_buffer_to_ruby_str(ctx, j_counter);
+    if (!NIL_P(r_counter))
+      rb_hash_aset(r_hash, ID2SYM(rb_intern("counter")), r_counter);
+  }
+  JS_FreeValue(ctx, j_counter);
+
+  JSValue j_salt = JS_GetPropertyStr(ctx, j_algo, "salt");
+  if (!JS_IsUndefined(j_salt) && !JS_IsException(j_salt))
+  {
+    VALUE r_salt = js_buffer_to_ruby_str(ctx, j_salt);
+    if (!NIL_P(r_salt))
+      rb_hash_aset(r_hash, ID2SYM(rb_intern("salt")), r_salt);
+  }
+  JS_FreeValue(ctx, j_salt);
+
+  JSValue j_iterations = JS_GetPropertyStr(ctx, j_algo, "iterations");
+  if (!JS_IsUndefined(j_iterations) && !JS_IsException(j_iterations))
+  {
+    int32_t iterations = 0;
+    JS_ToInt32(ctx, &iterations, j_iterations);
+    rb_hash_aset(r_hash, ID2SYM(rb_intern("iterations")), INT2NUM(iterations));
+  }
+  JS_FreeValue(ctx, j_iterations);
+
+  JSValue j_info = JS_GetPropertyStr(ctx, j_algo, "info");
+  if (!JS_IsUndefined(j_info) && !JS_IsException(j_info))
+  {
+    VALUE r_info = js_buffer_to_ruby_str(ctx, j_info);
+    if (!NIL_P(r_info))
+      rb_hash_aset(r_hash, ID2SYM(rb_intern("info")), r_info);
+  }
+  JS_FreeValue(ctx, j_info);
+
+  JSValue j_salt_length = JS_GetPropertyStr(ctx, j_algo, "saltLength");
+  if (!JS_IsUndefined(j_salt_length) && !JS_IsException(j_salt_length))
+  {
+    int32_t salt_length = 0;
+    JS_ToInt32(ctx, &salt_length, j_salt_length);
+    rb_hash_aset(r_hash, ID2SYM(rb_intern("salt_length")), INT2NUM(salt_length));
+  }
+  JS_FreeValue(ctx, j_salt_length);
+
+  JSValue j_label = JS_GetPropertyStr(ctx, j_algo, "label");
+  if (!JS_IsUndefined(j_label) && !JS_IsException(j_label))
+  {
+    VALUE r_label = js_buffer_to_ruby_str(ctx, j_label);
+    if (!NIL_P(r_label))
+      rb_hash_aset(r_hash, ID2SYM(rb_intern("label")), r_label);
+  }
+  JS_FreeValue(ctx, j_label);
+
+  JSValue j_public = JS_GetPropertyStr(ctx, j_algo, "public");
+  if (!JS_IsUndefined(j_public) && !JS_IsException(j_public) && JS_IsObject(j_public))
+  {
+    VALUE r_public = r_find_alive_crypto_key(ctx, j_public);
+    if (!NIL_P(r_public))
+      rb_hash_aset(r_hash, ID2SYM(rb_intern("public")), r_public);
+  }
+  JS_FreeValue(ctx, j_public);
+
+  return r_hash;
+}
+
 // Build a JS CryptoKey plain object from a Ruby Quickjs::CryptoKey.
 // Stores the Ruby object in alive_objects; sets rb_object_id as non-enumerable.
 static JSValue js_crypto_key_to_js(JSContext *ctx, VALUE r_key)
@@ -93,11 +266,43 @@ static JSValue js_crypto_key_to_js(JSContext *ctx, VALUE r_key)
   JS_SetPropertyStr(ctx, j_key, "extractable", JS_NewBool(ctx, RTEST(r_extractable)));
 
   JSValue j_algo = JS_NewObject(ctx);
+
   VALUE r_algo_name = rb_hash_aref(r_algorithm, rb_str_new_cstr("name"));
-  VALUE r_algo_length = rb_hash_aref(r_algorithm, rb_str_new_cstr("length"));
   JS_SetPropertyStr(ctx, j_algo, "name", JS_NewString(ctx, StringValueCStr(r_algo_name)));
+
+  VALUE r_algo_length = rb_hash_aref(r_algorithm, rb_str_new_cstr("length"));
   if (!NIL_P(r_algo_length))
     JS_SetPropertyStr(ctx, j_algo, "length", JS_NewInt32(ctx, NUM2INT(r_algo_length)));
+
+  VALUE r_algo_named_curve = rb_hash_aref(r_algorithm, rb_str_new_cstr("namedCurve"));
+  if (!NIL_P(r_algo_named_curve))
+    JS_SetPropertyStr(ctx, j_algo, "namedCurve", JS_NewString(ctx, StringValueCStr(r_algo_named_curve)));
+
+  VALUE r_algo_hash = rb_hash_aref(r_algorithm, rb_str_new_cstr("hash"));
+  if (!NIL_P(r_algo_hash))
+  {
+    JSValue j_hash_obj = JS_NewObject(ctx);
+    JS_SetPropertyStr(ctx, j_hash_obj, "name", JS_NewString(ctx, StringValueCStr(r_algo_hash)));
+    JS_SetPropertyStr(ctx, j_algo, "hash", j_hash_obj);
+  }
+
+  VALUE r_algo_modulus_length = rb_hash_aref(r_algorithm, rb_str_new_cstr("modulusLength"));
+  if (!NIL_P(r_algo_modulus_length))
+    JS_SetPropertyStr(ctx, j_algo, "modulusLength", JS_NewInt32(ctx, NUM2INT(r_algo_modulus_length)));
+
+  VALUE r_algo_pub_exp = rb_hash_aref(r_algorithm, rb_str_new_cstr("publicExponent"));
+  if (!NIL_P(r_algo_pub_exp))
+  {
+    JSValue j_pe_buf = JS_NewArrayBufferCopy(ctx,
+                                             (const uint8_t *)RSTRING_PTR(r_algo_pub_exp),
+                                             RSTRING_LEN(r_algo_pub_exp));
+    JSValue j_uint8 = JS_GetPropertyStr(ctx, JS_GetGlobalObject(ctx), "Uint8Array");
+    JSValue j_pe = JS_CallConstructor(ctx, j_uint8, 1, (JSValueConst *)&j_pe_buf);
+    JS_FreeValue(ctx, j_uint8);
+    JS_FreeValue(ctx, j_pe_buf);
+    JS_SetPropertyStr(ctx, j_algo, "publicExponent", j_pe);
+  }
+
   JS_SetPropertyStr(ctx, j_key, "algorithm", j_algo);
 
   long usages_len = RARRAY_LEN(r_usages);
@@ -114,19 +319,6 @@ static JSValue js_crypto_key_to_js(JSContext *ctx, VALUE r_key)
                             JS_PROP_CONFIGURABLE | JS_PROP_WRITABLE);
 
   return j_key;
-}
-
-// Find Ruby CryptoKey from a JS CryptoKey object via rb_object_id handle.
-static VALUE r_find_alive_crypto_key(JSContext *ctx, JSValueConst j_key)
-{
-  JSValue j_handle = JS_GetPropertyStr(ctx, j_key, "rb_object_id");
-  int64_t handle = 0;
-  JS_ToInt64(ctx, &handle, j_handle);
-  JS_FreeValue(ctx, j_handle);
-  if (handle <= 0)
-    return Qnil;
-  VMData *data = JS_GetContextOpaque(ctx);
-  return rb_hash_aref(data->alive_objects, LONG2NUM(handle));
 }
 
 static VALUE r_subtle_digest_call(VALUE r_args)
@@ -182,11 +374,10 @@ static JSValue js_subtle_digest(JSContext *ctx, JSValueConst this_val, int argc,
 static VALUE r_subtle_generate_key_call(VALUE r_args)
 {
   VALUE r_mod = rb_const_get(rb_const_get(rb_cObject, rb_intern("Quickjs")), rb_intern("SubtleCrypto"));
-  return rb_funcall(r_mod, rb_intern("generate_key"), 4,
+  return rb_funcall(r_mod, rb_intern("generate_key"), 3,
                     rb_ary_entry(r_args, 0),
                     rb_ary_entry(r_args, 1),
-                    rb_ary_entry(r_args, 2),
-                    rb_ary_entry(r_args, 3));
+                    rb_ary_entry(r_args, 2));
 }
 
 static JSValue js_subtle_generate_key(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv)
@@ -194,18 +385,7 @@ static JSValue js_subtle_generate_key(JSContext *ctx, JSValueConst this_val, int
   if (argc < 3)
     return JS_ThrowTypeError(ctx, "Failed to execute 'generateKey': 3 arguments required.");
 
-  const char *algo_name = js_get_algorithm_name(ctx, argv[0]);
-  if (!algo_name)
-    return JS_ThrowTypeError(ctx, "Failed to execute 'generateKey': algorithm name is required.");
-  VALUE r_name = rb_str_new_cstr(algo_name);
-  JS_FreeCString(ctx, algo_name);
-
-  JSValue j_length = JS_GetPropertyStr(ctx, argv[0], "length");
-  int32_t length = 0;
-  if (!JS_IsUndefined(j_length) && !JS_IsException(j_length))
-    JS_ToInt32(ctx, &length, j_length);
-  JS_FreeValue(ctx, j_length);
-
+  VALUE r_algo_hash = js_algo_to_ruby_hash(ctx, argv[0]);
   VALUE r_extractable = JS_ToBool(ctx, argv[1]) ? Qtrue : Qfalse;
   VALUE r_usages = js_usages_to_ruby_array(ctx, argv[2]);
 
@@ -214,13 +394,26 @@ static JSValue js_subtle_generate_key(JSContext *ctx, JSValueConst this_val, int
   if (JS_IsException(promise))
     return JS_EXCEPTION;
 
-  VALUE r_args = rb_ary_new3(4, r_name, INT2NUM(length), r_extractable, r_usages);
+  VALUE r_args = rb_ary_new3(3, r_algo_hash, r_extractable, r_usages);
   int error_state;
   VALUE r_result = rb_protect(r_subtle_generate_key_call, r_args, &error_state);
 
   if (error_state)
   {
     js_reject_with_ruby_error(ctx, resolving_funcs);
+  }
+  else if (RB_TYPE_P(r_result, T_HASH))
+  {
+    VALUE r_priv = rb_hash_aref(r_result, ID2SYM(rb_intern("private_key")));
+    VALUE r_pub = rb_hash_aref(r_result, ID2SYM(rb_intern("public_key")));
+    JSValue j_pair = JS_NewObject(ctx);
+    JSValue j_priv = js_crypto_key_to_js(ctx, r_priv);
+    JSValue j_pub = js_crypto_key_to_js(ctx, r_pub);
+    JS_SetPropertyStr(ctx, j_pair, "privateKey", j_priv);
+    JS_SetPropertyStr(ctx, j_pair, "publicKey", j_pub);
+    JSValue ret = JS_Call(ctx, resolving_funcs[0], JS_UNDEFINED, 1, (JSValueConst *)&j_pair);
+    JS_FreeValue(ctx, j_pair);
+    JS_FreeValue(ctx, ret);
   }
   else
   {
@@ -259,15 +452,8 @@ static JSValue js_subtle_import_key(JSContext *ctx, JSValueConst this_val, int a
   JS_FreeCString(ctx, format_cstr);
 
   VALUE r_key_data = js_buffer_to_ruby_str(ctx, argv[1]);
-  if (NIL_P(r_key_data))
-    return JS_ThrowTypeError(ctx, "Failed to execute 'importKey': keyData must be an ArrayBuffer or TypedArray.");
 
-  const char *algo_name = js_get_algorithm_name(ctx, argv[2]);
-  if (!algo_name)
-    return JS_ThrowTypeError(ctx, "Failed to execute 'importKey': algorithm name is required.");
-  VALUE r_name = rb_str_new_cstr(algo_name);
-  JS_FreeCString(ctx, algo_name);
-
+  VALUE r_algo_hash = js_algo_to_ruby_hash(ctx, argv[2]);
   VALUE r_extractable = JS_ToBool(ctx, argv[3]) ? Qtrue : Qfalse;
   VALUE r_usages = js_usages_to_ruby_array(ctx, argv[4]);
 
@@ -276,7 +462,7 @@ static JSValue js_subtle_import_key(JSContext *ctx, JSValueConst this_val, int a
   if (JS_IsException(promise))
     return JS_EXCEPTION;
 
-  VALUE r_args = rb_ary_new3(5, r_format, r_key_data, r_name, r_extractable, r_usages);
+  VALUE r_args = rb_ary_new3(5, r_format, r_key_data, r_algo_hash, r_extractable, r_usages);
   int error_state;
   VALUE r_result = rb_protect(r_subtle_import_key_call, r_args, &error_state);
 
@@ -368,54 +554,16 @@ static VALUE r_subtle_decrypt_call(VALUE r_args)
                     rb_ary_entry(r_args, 3));
 }
 
-// Build Ruby keyword args Hash from AES-GCM/CBC algorithm params.
-static VALUE js_algo_params_to_ruby_hash(JSContext *ctx, JSValueConst j_algo)
-{
-  VALUE r_params = rb_hash_new();
-
-  JSValue j_iv = JS_GetPropertyStr(ctx, j_algo, "iv");
-  if (!JS_IsUndefined(j_iv) && !JS_IsException(j_iv))
-  {
-    VALUE r_iv = js_buffer_to_ruby_str(ctx, j_iv);
-    if (!NIL_P(r_iv))
-      rb_hash_aset(r_params, ID2SYM(rb_intern("iv")), r_iv);
-  }
-  JS_FreeValue(ctx, j_iv);
-
-  JSValue j_tag_length = JS_GetPropertyStr(ctx, j_algo, "tagLength");
-  if (!JS_IsUndefined(j_tag_length) && !JS_IsException(j_tag_length))
-  {
-    int32_t tag_length = 128;
-    JS_ToInt32(ctx, &tag_length, j_tag_length);
-    rb_hash_aset(r_params, ID2SYM(rb_intern("tag_length")), INT2NUM(tag_length));
-  }
-  JS_FreeValue(ctx, j_tag_length);
-
-  JSValue j_additional_data = JS_GetPropertyStr(ctx, j_algo, "additionalData");
-  if (!JS_IsUndefined(j_additional_data) && !JS_IsException(j_additional_data))
-  {
-    VALUE r_ad = js_buffer_to_ruby_str(ctx, j_additional_data);
-    if (!NIL_P(r_ad))
-      rb_hash_aset(r_params, ID2SYM(rb_intern("additional_data")), r_ad);
-  }
-  JS_FreeValue(ctx, j_additional_data);
-
-  return r_params;
-}
-
-// Shared implementation for encrypt/decrypt.
-// r_call_func: either r_subtle_encrypt_call or r_subtle_decrypt_call
 static JSValue js_subtle_crypt(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv,
                                VALUE (*r_call_func)(VALUE))
 {
   if (argc < 3)
     return JS_ThrowTypeError(ctx, "3 arguments required.");
 
-  const char *algo_name = js_get_algorithm_name(ctx, argv[0]);
-  if (!algo_name)
+  VALUE r_algo_hash = js_algo_to_ruby_hash(ctx, argv[0]);
+  VALUE r_name = rb_hash_aref(r_algo_hash, ID2SYM(rb_intern("name")));
+  if (NIL_P(r_name))
     return JS_ThrowTypeError(ctx, "algorithm name is required.");
-  VALUE r_name = rb_str_new_cstr(algo_name);
-  JS_FreeCString(ctx, algo_name);
 
   VALUE r_key = r_find_alive_crypto_key(ctx, argv[1]);
   if (NIL_P(r_key))
@@ -425,14 +573,7 @@ static JSValue js_subtle_crypt(JSContext *ctx, JSValueConst this_val, int argc, 
   if (NIL_P(r_data))
     return JS_ThrowTypeError(ctx, "data must be an ArrayBuffer or TypedArray.");
 
-  VALUE r_params = js_algo_params_to_ruby_hash(ctx, argv[0]);
-
-  // Merge key and params into a single Ruby object for the call
-  // We pass [name, key_with_params, data] — but encrypt() signature is (name, key, data, **params)
-  // Instead, attach params to key via a wrapper hash: [name, key, data, params]
-  // Actually let's just call encrypt with keyword splat by building a special args array.
-  // Since rb_protect only takes one VALUE, pack everything.
-  VALUE r_args = rb_ary_new3(4, r_name, r_key, r_data, r_params);
+  VALUE r_args = rb_ary_new3(4, r_name, r_key, r_data, r_algo_hash);
 
   JSValue promise, resolving_funcs[2];
   promise = JS_NewPromiseCapability(ctx, resolving_funcs);
@@ -470,6 +611,365 @@ static JSValue js_subtle_decrypt(JSContext *ctx, JSValueConst this_val, int argc
   return js_subtle_crypt(ctx, this_val, argc, argv, r_subtle_decrypt_call);
 }
 
+static VALUE r_subtle_sign_call(VALUE r_args)
+{
+  VALUE r_mod = rb_const_get(rb_const_get(rb_cObject, rb_intern("Quickjs")), rb_intern("SubtleCrypto"));
+  return rb_funcall(r_mod, rb_intern("sign"), 4,
+                    rb_ary_entry(r_args, 0),
+                    rb_ary_entry(r_args, 1),
+                    rb_ary_entry(r_args, 2),
+                    rb_ary_entry(r_args, 3));
+}
+
+static JSValue js_subtle_sign(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv)
+{
+  if (argc < 3)
+    return JS_ThrowTypeError(ctx, "Failed to execute 'sign': 3 arguments required.");
+
+  VALUE r_algo_hash = js_algo_to_ruby_hash(ctx, argv[0]);
+  VALUE r_name = rb_hash_aref(r_algo_hash, ID2SYM(rb_intern("name")));
+  if (NIL_P(r_name))
+    return JS_ThrowTypeError(ctx, "Failed to execute 'sign': algorithm name is required.");
+
+  VALUE r_key = r_find_alive_crypto_key(ctx, argv[1]);
+  if (NIL_P(r_key))
+    return JS_ThrowTypeError(ctx, "Failed to execute 'sign': invalid CryptoKey.");
+
+  VALUE r_data = js_buffer_to_ruby_str(ctx, argv[2]);
+  if (NIL_P(r_data))
+    return JS_ThrowTypeError(ctx, "Failed to execute 'sign': data must be an ArrayBuffer or TypedArray.");
+
+  JSValue promise, resolving_funcs[2];
+  promise = JS_NewPromiseCapability(ctx, resolving_funcs);
+  if (JS_IsException(promise))
+    return JS_EXCEPTION;
+
+  VALUE r_args = rb_ary_new3(4, r_name, r_key, r_data, r_algo_hash);
+  int error_state;
+  VALUE r_result = rb_protect(r_subtle_sign_call, r_args, &error_state);
+
+  if (error_state)
+  {
+    js_reject_with_ruby_error(ctx, resolving_funcs);
+  }
+  else
+  {
+    JSValue j_result = JS_NewArrayBufferCopy(ctx, (const uint8_t *)RSTRING_PTR(r_result), RSTRING_LEN(r_result));
+    JSValue ret = JS_Call(ctx, resolving_funcs[0], JS_UNDEFINED, 1, (JSValueConst *)&j_result);
+    JS_FreeValue(ctx, j_result);
+    JS_FreeValue(ctx, ret);
+  }
+
+  JS_FreeValue(ctx, resolving_funcs[0]);
+  JS_FreeValue(ctx, resolving_funcs[1]);
+
+  return promise;
+}
+
+static VALUE r_subtle_verify_call(VALUE r_args)
+{
+  VALUE r_mod = rb_const_get(rb_const_get(rb_cObject, rb_intern("Quickjs")), rb_intern("SubtleCrypto"));
+  return rb_funcall(r_mod, rb_intern("verify"), 5,
+                    rb_ary_entry(r_args, 0),
+                    rb_ary_entry(r_args, 1),
+                    rb_ary_entry(r_args, 2),
+                    rb_ary_entry(r_args, 3),
+                    rb_ary_entry(r_args, 4));
+}
+
+static JSValue js_subtle_verify(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv)
+{
+  if (argc < 4)
+    return JS_ThrowTypeError(ctx, "Failed to execute 'verify': 4 arguments required.");
+
+  VALUE r_algo_hash = js_algo_to_ruby_hash(ctx, argv[0]);
+  VALUE r_name = rb_hash_aref(r_algo_hash, ID2SYM(rb_intern("name")));
+  if (NIL_P(r_name))
+    return JS_ThrowTypeError(ctx, "Failed to execute 'verify': algorithm name is required.");
+
+  VALUE r_key = r_find_alive_crypto_key(ctx, argv[1]);
+  if (NIL_P(r_key))
+    return JS_ThrowTypeError(ctx, "Failed to execute 'verify': invalid CryptoKey.");
+
+  VALUE r_signature = js_buffer_to_ruby_str(ctx, argv[2]);
+  if (NIL_P(r_signature))
+    return JS_ThrowTypeError(ctx, "Failed to execute 'verify': signature must be an ArrayBuffer or TypedArray.");
+
+  VALUE r_data = js_buffer_to_ruby_str(ctx, argv[3]);
+  if (NIL_P(r_data))
+    return JS_ThrowTypeError(ctx, "Failed to execute 'verify': data must be an ArrayBuffer or TypedArray.");
+
+  JSValue promise, resolving_funcs[2];
+  promise = JS_NewPromiseCapability(ctx, resolving_funcs);
+  if (JS_IsException(promise))
+    return JS_EXCEPTION;
+
+  VALUE r_args = rb_ary_new3(5, r_name, r_key, r_signature, r_data, r_algo_hash);
+  int error_state;
+  VALUE r_result = rb_protect(r_subtle_verify_call, r_args, &error_state);
+
+  if (error_state)
+  {
+    js_reject_with_ruby_error(ctx, resolving_funcs);
+  }
+  else
+  {
+    JSValue j_result = JS_NewBool(ctx, RTEST(r_result));
+    JSValue ret = JS_Call(ctx, resolving_funcs[0], JS_UNDEFINED, 1, (JSValueConst *)&j_result);
+    JS_FreeValue(ctx, ret);
+  }
+
+  JS_FreeValue(ctx, resolving_funcs[0]);
+  JS_FreeValue(ctx, resolving_funcs[1]);
+
+  return promise;
+}
+
+static VALUE r_subtle_derive_bits_call(VALUE r_args)
+{
+  VALUE r_mod = rb_const_get(rb_const_get(rb_cObject, rb_intern("Quickjs")), rb_intern("SubtleCrypto"));
+  return rb_funcall(r_mod, rb_intern("derive_bits"), 4,
+                    rb_ary_entry(r_args, 0),
+                    rb_ary_entry(r_args, 1),
+                    rb_ary_entry(r_args, 2),
+                    rb_ary_entry(r_args, 3));
+}
+
+static JSValue js_subtle_derive_bits(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv)
+{
+  if (argc < 3)
+    return JS_ThrowTypeError(ctx, "Failed to execute 'deriveBits': 3 arguments required.");
+
+  VALUE r_algo_hash = js_algo_to_ruby_hash(ctx, argv[0]);
+  VALUE r_name = rb_hash_aref(r_algo_hash, ID2SYM(rb_intern("name")));
+  if (NIL_P(r_name))
+    return JS_ThrowTypeError(ctx, "Failed to execute 'deriveBits': algorithm name is required.");
+
+  VALUE r_key = r_find_alive_crypto_key(ctx, argv[1]);
+  if (NIL_P(r_key))
+    return JS_ThrowTypeError(ctx, "Failed to execute 'deriveBits': invalid CryptoKey.");
+
+  int32_t length_bits = 0;
+  JS_ToInt32(ctx, &length_bits, argv[2]);
+
+  JSValue promise, resolving_funcs[2];
+  promise = JS_NewPromiseCapability(ctx, resolving_funcs);
+  if (JS_IsException(promise))
+    return JS_EXCEPTION;
+
+  VALUE r_args = rb_ary_new3(4, r_name, r_key, INT2NUM(length_bits), r_algo_hash);
+  int error_state;
+  VALUE r_result = rb_protect(r_subtle_derive_bits_call, r_args, &error_state);
+
+  if (error_state)
+  {
+    js_reject_with_ruby_error(ctx, resolving_funcs);
+  }
+  else
+  {
+    JSValue j_result = JS_NewArrayBufferCopy(ctx, (const uint8_t *)RSTRING_PTR(r_result), RSTRING_LEN(r_result));
+    JSValue ret = JS_Call(ctx, resolving_funcs[0], JS_UNDEFINED, 1, (JSValueConst *)&j_result);
+    JS_FreeValue(ctx, j_result);
+    JS_FreeValue(ctx, ret);
+  }
+
+  JS_FreeValue(ctx, resolving_funcs[0]);
+  JS_FreeValue(ctx, resolving_funcs[1]);
+
+  return promise;
+}
+
+static VALUE r_subtle_derive_key_call(VALUE r_args)
+{
+  VALUE r_mod = rb_const_get(rb_const_get(rb_cObject, rb_intern("Quickjs")), rb_intern("SubtleCrypto"));
+  return rb_funcall(r_mod, rb_intern("derive_key"), 6,
+                    rb_ary_entry(r_args, 0),
+                    rb_ary_entry(r_args, 1),
+                    rb_ary_entry(r_args, 2),
+                    rb_ary_entry(r_args, 3),
+                    rb_ary_entry(r_args, 4),
+                    rb_ary_entry(r_args, 5));
+}
+
+static JSValue js_subtle_derive_key(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv)
+{
+  if (argc < 5)
+    return JS_ThrowTypeError(ctx, "Failed to execute 'deriveKey': 5 arguments required.");
+
+  VALUE r_algo_hash = js_algo_to_ruby_hash(ctx, argv[0]);
+  VALUE r_name = rb_hash_aref(r_algo_hash, ID2SYM(rb_intern("name")));
+  if (NIL_P(r_name))
+    return JS_ThrowTypeError(ctx, "Failed to execute 'deriveKey': algorithm name is required.");
+
+  VALUE r_key = r_find_alive_crypto_key(ctx, argv[1]);
+  if (NIL_P(r_key))
+    return JS_ThrowTypeError(ctx, "Failed to execute 'deriveKey': invalid CryptoKey.");
+
+  VALUE r_derived_algo_hash = js_algo_to_ruby_hash(ctx, argv[2]);
+  VALUE r_extractable = JS_ToBool(ctx, argv[3]) ? Qtrue : Qfalse;
+  VALUE r_usages = js_usages_to_ruby_array(ctx, argv[4]);
+
+  JSValue promise, resolving_funcs[2];
+  promise = JS_NewPromiseCapability(ctx, resolving_funcs);
+  if (JS_IsException(promise))
+    return JS_EXCEPTION;
+
+  VALUE r_args = rb_ary_new3(6, r_name, r_key, r_derived_algo_hash, r_extractable, r_usages, r_algo_hash);
+  int error_state;
+  VALUE r_result = rb_protect(r_subtle_derive_key_call, r_args, &error_state);
+
+  if (error_state)
+  {
+    js_reject_with_ruby_error(ctx, resolving_funcs);
+  }
+  else
+  {
+    JSValue j_result = js_crypto_key_to_js(ctx, r_result);
+    JSValue ret = JS_Call(ctx, resolving_funcs[0], JS_UNDEFINED, 1, (JSValueConst *)&j_result);
+    JS_FreeValue(ctx, j_result);
+    JS_FreeValue(ctx, ret);
+  }
+
+  JS_FreeValue(ctx, resolving_funcs[0]);
+  JS_FreeValue(ctx, resolving_funcs[1]);
+
+  return promise;
+}
+
+static VALUE r_subtle_wrap_key_call(VALUE r_args)
+{
+  VALUE r_mod = rb_const_get(rb_const_get(rb_cObject, rb_intern("Quickjs")), rb_intern("SubtleCrypto"));
+  return rb_funcall(r_mod, rb_intern("wrap_key"), 5,
+                    rb_ary_entry(r_args, 0),
+                    rb_ary_entry(r_args, 1),
+                    rb_ary_entry(r_args, 2),
+                    rb_ary_entry(r_args, 3),
+                    rb_ary_entry(r_args, 4));
+}
+
+static JSValue js_subtle_wrap_key(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv)
+{
+  if (argc < 4)
+    return JS_ThrowTypeError(ctx, "Failed to execute 'wrapKey': 4 arguments required.");
+
+  const char *format_cstr = JS_ToCString(ctx, argv[0]);
+  if (!format_cstr)
+    return JS_ThrowTypeError(ctx, "Failed to execute 'wrapKey': format must be a string.");
+  VALUE r_format = rb_str_new_cstr(format_cstr);
+  JS_FreeCString(ctx, format_cstr);
+
+  VALUE r_key = r_find_alive_crypto_key(ctx, argv[1]);
+  if (NIL_P(r_key))
+    return JS_ThrowTypeError(ctx, "Failed to execute 'wrapKey': invalid CryptoKey.");
+
+  VALUE r_wrapping_key = r_find_alive_crypto_key(ctx, argv[2]);
+  if (NIL_P(r_wrapping_key))
+    return JS_ThrowTypeError(ctx, "Failed to execute 'wrapKey': invalid wrapping CryptoKey.");
+
+  VALUE r_wrap_algo_hash = js_algo_to_ruby_hash(ctx, argv[3]);
+
+  JSValue promise, resolving_funcs[2];
+  promise = JS_NewPromiseCapability(ctx, resolving_funcs);
+  if (JS_IsException(promise))
+    return JS_EXCEPTION;
+
+  VALUE r_args = rb_ary_new3(5, r_format, r_key, r_wrapping_key, r_wrap_algo_hash,
+                             rb_hash_aref(r_wrap_algo_hash, ID2SYM(rb_intern("name"))));
+  int error_state;
+  VALUE r_result = rb_protect(r_subtle_wrap_key_call, r_args, &error_state);
+
+  if (error_state)
+  {
+    js_reject_with_ruby_error(ctx, resolving_funcs);
+  }
+  else
+  {
+    JSValue j_result = JS_NewArrayBufferCopy(ctx, (const uint8_t *)RSTRING_PTR(r_result), RSTRING_LEN(r_result));
+    JSValue ret = JS_Call(ctx, resolving_funcs[0], JS_UNDEFINED, 1, (JSValueConst *)&j_result);
+    JS_FreeValue(ctx, j_result);
+    JS_FreeValue(ctx, ret);
+  }
+
+  JS_FreeValue(ctx, resolving_funcs[0]);
+  JS_FreeValue(ctx, resolving_funcs[1]);
+
+  return promise;
+}
+
+static VALUE r_subtle_unwrap_key_call(VALUE r_args)
+{
+  VALUE r_mod = rb_const_get(rb_const_get(rb_cObject, rb_intern("Quickjs")), rb_intern("SubtleCrypto"));
+  return rb_funcall(r_mod, rb_intern("unwrap_key"), 8,
+                    rb_ary_entry(r_args, 0),
+                    rb_ary_entry(r_args, 1),
+                    rb_ary_entry(r_args, 2),
+                    rb_ary_entry(r_args, 3),
+                    rb_ary_entry(r_args, 4),
+                    rb_ary_entry(r_args, 5),
+                    rb_ary_entry(r_args, 6),
+                    rb_ary_entry(r_args, 7));
+}
+
+static JSValue js_subtle_unwrap_key(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv)
+{
+  if (argc < 7)
+    return JS_ThrowTypeError(ctx, "Failed to execute 'unwrapKey': 7 arguments required.");
+
+  const char *format_cstr = JS_ToCString(ctx, argv[0]);
+  if (!format_cstr)
+    return JS_ThrowTypeError(ctx, "Failed to execute 'unwrapKey': format must be a string.");
+  VALUE r_format = rb_str_new_cstr(format_cstr);
+  JS_FreeCString(ctx, format_cstr);
+
+  VALUE r_wrapped_key = js_buffer_to_ruby_str(ctx, argv[1]);
+  if (NIL_P(r_wrapped_key))
+    return JS_ThrowTypeError(ctx, "Failed to execute 'unwrapKey': wrapped key data must be an ArrayBuffer or TypedArray.");
+
+  VALUE r_unwrapping_key = r_find_alive_crypto_key(ctx, argv[2]);
+  if (NIL_P(r_unwrapping_key))
+    return JS_ThrowTypeError(ctx, "Failed to execute 'unwrapKey': invalid unwrapping CryptoKey.");
+
+  VALUE r_unwrap_algo_hash = js_algo_to_ruby_hash(ctx, argv[3]);
+  VALUE r_unwrapped_algo_hash = js_algo_to_ruby_hash(ctx, argv[4]);
+  VALUE r_extractable = JS_ToBool(ctx, argv[5]) ? Qtrue : Qfalse;
+  VALUE r_usages = js_usages_to_ruby_array(ctx, argv[6]);
+
+  JSValue promise, resolving_funcs[2];
+  promise = JS_NewPromiseCapability(ctx, resolving_funcs);
+  if (JS_IsException(promise))
+    return JS_EXCEPTION;
+
+  VALUE r_args = rb_ary_new();
+  rb_ary_push(r_args, r_format);
+  rb_ary_push(r_args, r_wrapped_key);
+  rb_ary_push(r_args, r_unwrapping_key);
+  rb_ary_push(r_args, r_unwrap_algo_hash);
+  rb_ary_push(r_args, r_unwrapped_algo_hash);
+  rb_ary_push(r_args, r_extractable);
+  rb_ary_push(r_args, r_usages);
+  rb_ary_push(r_args, rb_hash_aref(r_unwrap_algo_hash, ID2SYM(rb_intern("name"))));
+
+  int error_state;
+  VALUE r_result = rb_protect(r_subtle_unwrap_key_call, r_args, &error_state);
+
+  if (error_state)
+  {
+    js_reject_with_ruby_error(ctx, resolving_funcs);
+  }
+  else
+  {
+    JSValue j_result = js_crypto_key_to_js(ctx, r_result);
+    JSValue ret = JS_Call(ctx, resolving_funcs[0], JS_UNDEFINED, 1, (JSValueConst *)&j_result);
+    JS_FreeValue(ctx, j_result);
+    JS_FreeValue(ctx, ret);
+  }
+
+  JS_FreeValue(ctx, resolving_funcs[0]);
+  JS_FreeValue(ctx, resolving_funcs[1]);
+
+  return promise;
+}
+
 void quickjsrb_init_crypto_subtle(JSContext *ctx, JSValueConst j_crypto)
 {
   JSValue j_subtle = JS_NewObject(ctx);
@@ -485,5 +985,17 @@ void quickjsrb_init_crypto_subtle(JSContext *ctx, JSValueConst j_crypto)
                     JS_NewCFunction(ctx, js_subtle_encrypt, "encrypt", 3));
   JS_SetPropertyStr(ctx, j_subtle, "decrypt",
                     JS_NewCFunction(ctx, js_subtle_decrypt, "decrypt", 3));
+  JS_SetPropertyStr(ctx, j_subtle, "sign",
+                    JS_NewCFunction(ctx, js_subtle_sign, "sign", 3));
+  JS_SetPropertyStr(ctx, j_subtle, "verify",
+                    JS_NewCFunction(ctx, js_subtle_verify, "verify", 4));
+  JS_SetPropertyStr(ctx, j_subtle, "deriveBits",
+                    JS_NewCFunction(ctx, js_subtle_derive_bits, "deriveBits", 3));
+  JS_SetPropertyStr(ctx, j_subtle, "deriveKey",
+                    JS_NewCFunction(ctx, js_subtle_derive_key, "deriveKey", 5));
+  JS_SetPropertyStr(ctx, j_subtle, "wrapKey",
+                    JS_NewCFunction(ctx, js_subtle_wrap_key, "wrapKey", 4));
+  JS_SetPropertyStr(ctx, j_subtle, "unwrapKey",
+                    JS_NewCFunction(ctx, js_subtle_unwrap_key, "unwrapKey", 7));
   JS_SetPropertyStr(ctx, j_crypto, "subtle", j_subtle);
 }

--- a/ext/quickjsrb/quickjsrb_crypto_subtle.c
+++ b/ext/quickjsrb/quickjsrb_crypto_subtle.c
@@ -41,6 +41,94 @@ static VALUE js_buffer_to_ruby_str(JSContext *ctx, JSValueConst j_val)
   return r_str;
 }
 
+// Build a Ruby Array of strings from a JS array value.
+static VALUE js_usages_to_ruby_array(JSContext *ctx, JSValueConst j_usages)
+{
+  VALUE r_usages = rb_ary_new();
+  JSValue j_len = JS_GetPropertyStr(ctx, j_usages, "length");
+  int32_t count = 0;
+  JS_ToInt32(ctx, &count, j_len);
+  JS_FreeValue(ctx, j_len);
+  for (int32_t i = 0; i < count; i++)
+  {
+    JSValue j_u = JS_GetPropertyUint32(ctx, j_usages, (uint32_t)i);
+    const char *u_str = JS_ToCString(ctx, j_u);
+    if (u_str)
+      rb_ary_push(r_usages, rb_str_new_cstr(u_str));
+    JS_FreeCString(ctx, u_str);
+    JS_FreeValue(ctx, j_u);
+  }
+  return r_usages;
+}
+
+// Reject a promise with a plain JS Error built from Ruby exception info.
+static void js_reject_with_ruby_error(JSContext *ctx, JSValueConst *resolving_funcs)
+{
+  VALUE r_error = rb_errinfo();
+  VALUE r_message = rb_funcall(r_error, rb_intern("message"), 0);
+  JSValue j_err = JS_NewError(ctx);
+  JS_SetPropertyStr(ctx, j_err, "message", JS_NewString(ctx, StringValueCStr(r_message)));
+  JSValue ret = JS_Call(ctx, resolving_funcs[1], JS_UNDEFINED, 1, (JSValueConst *)&j_err);
+  JS_FreeValue(ctx, j_err);
+  JS_FreeValue(ctx, ret);
+}
+
+// Build a JS CryptoKey plain object from a Ruby Quickjs::CryptoKey.
+// Stores the Ruby object in alive_objects; sets rb_object_id as non-enumerable.
+static JSValue js_crypto_key_to_js(JSContext *ctx, VALUE r_key)
+{
+  VMData *data = JS_GetContextOpaque(ctx);
+  VALUE r_object_id = rb_funcall(r_key, rb_intern("object_id"), 0);
+  rb_hash_aset(data->alive_objects, r_object_id, r_key);
+  int64_t handle = NUM2LONG(r_object_id);
+
+  VALUE r_type = rb_funcall(r_key, rb_intern("type"), 0);
+  VALUE r_extractable = rb_funcall(r_key, rb_intern("extractable"), 0);
+  VALUE r_algorithm = rb_funcall(r_key, rb_intern("algorithm"), 0);
+  VALUE r_usages = rb_funcall(r_key, rb_intern("usages"), 0);
+
+  JSValue j_key = JS_NewObject(ctx);
+
+  JS_SetPropertyStr(ctx, j_key, "type", JS_NewString(ctx, StringValueCStr(r_type)));
+  JS_SetPropertyStr(ctx, j_key, "extractable", JS_NewBool(ctx, RTEST(r_extractable)));
+
+  JSValue j_algo = JS_NewObject(ctx);
+  VALUE r_algo_name = rb_hash_aref(r_algorithm, rb_str_new_cstr("name"));
+  VALUE r_algo_length = rb_hash_aref(r_algorithm, rb_str_new_cstr("length"));
+  JS_SetPropertyStr(ctx, j_algo, "name", JS_NewString(ctx, StringValueCStr(r_algo_name)));
+  if (!NIL_P(r_algo_length))
+    JS_SetPropertyStr(ctx, j_algo, "length", JS_NewInt32(ctx, NUM2INT(r_algo_length)));
+  JS_SetPropertyStr(ctx, j_key, "algorithm", j_algo);
+
+  long usages_len = RARRAY_LEN(r_usages);
+  JSValue j_usages = JS_NewArray(ctx);
+  for (long i = 0; i < usages_len; i++)
+  {
+    VALUE r_usage = rb_ary_entry(r_usages, i);
+    JS_SetPropertyUint32(ctx, j_usages, (uint32_t)i, JS_NewString(ctx, StringValueCStr(r_usage)));
+  }
+  JS_SetPropertyStr(ctx, j_key, "usages", j_usages);
+
+  JS_DefinePropertyValueStr(ctx, j_key, "rb_object_id",
+                            JS_NewInt64(ctx, handle),
+                            JS_PROP_CONFIGURABLE | JS_PROP_WRITABLE);
+
+  return j_key;
+}
+
+// Find Ruby CryptoKey from a JS CryptoKey object via rb_object_id handle.
+static VALUE r_find_alive_crypto_key(JSContext *ctx, JSValueConst j_key)
+{
+  JSValue j_handle = JS_GetPropertyStr(ctx, j_key, "rb_object_id");
+  int64_t handle = 0;
+  JS_ToInt64(ctx, &handle, j_handle);
+  JS_FreeValue(ctx, j_handle);
+  if (handle <= 0)
+    return Qnil;
+  VMData *data = JS_GetContextOpaque(ctx);
+  return rb_hash_aref(data->alive_objects, LONG2NUM(handle));
+}
+
 static VALUE r_subtle_digest_call(VALUE r_args)
 {
   VALUE r_algorithm = rb_ary_entry(r_args, 0);
@@ -73,27 +161,313 @@ static JSValue js_subtle_digest(JSContext *ctx, JSValueConst this_val, int argc,
   int error_state;
   VALUE r_result = rb_protect(r_subtle_digest_call, r_args, &error_state);
 
-  JSValue j_result, ret;
   if (error_state)
   {
-    VALUE r_error = rb_errinfo();
-    VALUE r_message = rb_funcall(r_error, rb_intern("message"), 0);
-    j_result = JS_NewError(ctx);
-    JS_SetPropertyStr(ctx, j_result, "message", JS_NewString(ctx, StringValueCStr(r_message)));
-    ret = JS_Call(ctx, resolving_funcs[1], JS_UNDEFINED, 1, (JSValueConst *)&j_result);
+    js_reject_with_ruby_error(ctx, resolving_funcs);
   }
   else
   {
-    j_result = JS_NewArrayBufferCopy(ctx, (const uint8_t *)RSTRING_PTR(r_result), RSTRING_LEN(r_result));
-    ret = JS_Call(ctx, resolving_funcs[0], JS_UNDEFINED, 1, (JSValueConst *)&j_result);
+    JSValue j_result = JS_NewArrayBufferCopy(ctx, (const uint8_t *)RSTRING_PTR(r_result), RSTRING_LEN(r_result));
+    JSValue ret = JS_Call(ctx, resolving_funcs[0], JS_UNDEFINED, 1, (JSValueConst *)&j_result);
+    JS_FreeValue(ctx, j_result);
+    JS_FreeValue(ctx, ret);
   }
 
-  JS_FreeValue(ctx, j_result);
-  JS_FreeValue(ctx, ret);
   JS_FreeValue(ctx, resolving_funcs[0]);
   JS_FreeValue(ctx, resolving_funcs[1]);
 
   return promise;
+}
+
+static VALUE r_subtle_generate_key_call(VALUE r_args)
+{
+  VALUE r_mod = rb_const_get(rb_const_get(rb_cObject, rb_intern("Quickjs")), rb_intern("SubtleCrypto"));
+  return rb_funcall(r_mod, rb_intern("generate_key"), 4,
+                    rb_ary_entry(r_args, 0),
+                    rb_ary_entry(r_args, 1),
+                    rb_ary_entry(r_args, 2),
+                    rb_ary_entry(r_args, 3));
+}
+
+static JSValue js_subtle_generate_key(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv)
+{
+  if (argc < 3)
+    return JS_ThrowTypeError(ctx, "Failed to execute 'generateKey': 3 arguments required.");
+
+  const char *algo_name = js_get_algorithm_name(ctx, argv[0]);
+  if (!algo_name)
+    return JS_ThrowTypeError(ctx, "Failed to execute 'generateKey': algorithm name is required.");
+  VALUE r_name = rb_str_new_cstr(algo_name);
+  JS_FreeCString(ctx, algo_name);
+
+  JSValue j_length = JS_GetPropertyStr(ctx, argv[0], "length");
+  int32_t length = 0;
+  if (!JS_IsUndefined(j_length) && !JS_IsException(j_length))
+    JS_ToInt32(ctx, &length, j_length);
+  JS_FreeValue(ctx, j_length);
+
+  VALUE r_extractable = JS_ToBool(ctx, argv[1]) ? Qtrue : Qfalse;
+  VALUE r_usages = js_usages_to_ruby_array(ctx, argv[2]);
+
+  JSValue promise, resolving_funcs[2];
+  promise = JS_NewPromiseCapability(ctx, resolving_funcs);
+  if (JS_IsException(promise))
+    return JS_EXCEPTION;
+
+  VALUE r_args = rb_ary_new3(4, r_name, INT2NUM(length), r_extractable, r_usages);
+  int error_state;
+  VALUE r_result = rb_protect(r_subtle_generate_key_call, r_args, &error_state);
+
+  if (error_state)
+  {
+    js_reject_with_ruby_error(ctx, resolving_funcs);
+  }
+  else
+  {
+    JSValue j_result = js_crypto_key_to_js(ctx, r_result);
+    JSValue ret = JS_Call(ctx, resolving_funcs[0], JS_UNDEFINED, 1, (JSValueConst *)&j_result);
+    JS_FreeValue(ctx, j_result);
+    JS_FreeValue(ctx, ret);
+  }
+
+  JS_FreeValue(ctx, resolving_funcs[0]);
+  JS_FreeValue(ctx, resolving_funcs[1]);
+
+  return promise;
+}
+
+static VALUE r_subtle_import_key_call(VALUE r_args)
+{
+  VALUE r_mod = rb_const_get(rb_const_get(rb_cObject, rb_intern("Quickjs")), rb_intern("SubtleCrypto"));
+  return rb_funcall(r_mod, rb_intern("import_key"), 5,
+                    rb_ary_entry(r_args, 0),
+                    rb_ary_entry(r_args, 1),
+                    rb_ary_entry(r_args, 2),
+                    rb_ary_entry(r_args, 3),
+                    rb_ary_entry(r_args, 4));
+}
+
+static JSValue js_subtle_import_key(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv)
+{
+  if (argc < 5)
+    return JS_ThrowTypeError(ctx, "Failed to execute 'importKey': 5 arguments required.");
+
+  const char *format_cstr = JS_ToCString(ctx, argv[0]);
+  if (!format_cstr)
+    return JS_ThrowTypeError(ctx, "Failed to execute 'importKey': format must be a string.");
+  VALUE r_format = rb_str_new_cstr(format_cstr);
+  JS_FreeCString(ctx, format_cstr);
+
+  VALUE r_key_data = js_buffer_to_ruby_str(ctx, argv[1]);
+  if (NIL_P(r_key_data))
+    return JS_ThrowTypeError(ctx, "Failed to execute 'importKey': keyData must be an ArrayBuffer or TypedArray.");
+
+  const char *algo_name = js_get_algorithm_name(ctx, argv[2]);
+  if (!algo_name)
+    return JS_ThrowTypeError(ctx, "Failed to execute 'importKey': algorithm name is required.");
+  VALUE r_name = rb_str_new_cstr(algo_name);
+  JS_FreeCString(ctx, algo_name);
+
+  VALUE r_extractable = JS_ToBool(ctx, argv[3]) ? Qtrue : Qfalse;
+  VALUE r_usages = js_usages_to_ruby_array(ctx, argv[4]);
+
+  JSValue promise, resolving_funcs[2];
+  promise = JS_NewPromiseCapability(ctx, resolving_funcs);
+  if (JS_IsException(promise))
+    return JS_EXCEPTION;
+
+  VALUE r_args = rb_ary_new3(5, r_format, r_key_data, r_name, r_extractable, r_usages);
+  int error_state;
+  VALUE r_result = rb_protect(r_subtle_import_key_call, r_args, &error_state);
+
+  if (error_state)
+  {
+    js_reject_with_ruby_error(ctx, resolving_funcs);
+  }
+  else
+  {
+    JSValue j_result = js_crypto_key_to_js(ctx, r_result);
+    JSValue ret = JS_Call(ctx, resolving_funcs[0], JS_UNDEFINED, 1, (JSValueConst *)&j_result);
+    JS_FreeValue(ctx, j_result);
+    JS_FreeValue(ctx, ret);
+  }
+
+  JS_FreeValue(ctx, resolving_funcs[0]);
+  JS_FreeValue(ctx, resolving_funcs[1]);
+
+  return promise;
+}
+
+static VALUE r_subtle_export_key_call(VALUE r_args)
+{
+  VALUE r_mod = rb_const_get(rb_const_get(rb_cObject, rb_intern("Quickjs")), rb_intern("SubtleCrypto"));
+  return rb_funcall(r_mod, rb_intern("export_key"), 2,
+                    rb_ary_entry(r_args, 0),
+                    rb_ary_entry(r_args, 1));
+}
+
+static JSValue js_subtle_export_key(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv)
+{
+  if (argc < 2)
+    return JS_ThrowTypeError(ctx, "Failed to execute 'exportKey': 2 arguments required.");
+
+  const char *format_cstr = JS_ToCString(ctx, argv[0]);
+  if (!format_cstr)
+    return JS_ThrowTypeError(ctx, "Failed to execute 'exportKey': format must be a string.");
+  VALUE r_format = rb_str_new_cstr(format_cstr);
+  JS_FreeCString(ctx, format_cstr);
+
+  VALUE r_key = r_find_alive_crypto_key(ctx, argv[1]);
+  if (NIL_P(r_key))
+    return JS_ThrowTypeError(ctx, "Failed to execute 'exportKey': invalid CryptoKey.");
+
+  JSValue promise, resolving_funcs[2];
+  promise = JS_NewPromiseCapability(ctx, resolving_funcs);
+  if (JS_IsException(promise))
+    return JS_EXCEPTION;
+
+  VALUE r_args = rb_ary_new3(2, r_format, r_key);
+  int error_state;
+  VALUE r_result = rb_protect(r_subtle_export_key_call, r_args, &error_state);
+
+  if (error_state)
+  {
+    js_reject_with_ruby_error(ctx, resolving_funcs);
+  }
+  else
+  {
+    JSValue j_result = JS_NewArrayBufferCopy(ctx, (const uint8_t *)RSTRING_PTR(r_result), RSTRING_LEN(r_result));
+    JSValue ret = JS_Call(ctx, resolving_funcs[0], JS_UNDEFINED, 1, (JSValueConst *)&j_result);
+    JS_FreeValue(ctx, j_result);
+    JS_FreeValue(ctx, ret);
+  }
+
+  JS_FreeValue(ctx, resolving_funcs[0]);
+  JS_FreeValue(ctx, resolving_funcs[1]);
+
+  return promise;
+}
+
+static VALUE r_subtle_encrypt_call(VALUE r_args)
+{
+  VALUE r_mod = rb_const_get(rb_const_get(rb_cObject, rb_intern("Quickjs")), rb_intern("SubtleCrypto"));
+  return rb_funcall(r_mod, rb_intern("encrypt"), 4,
+                    rb_ary_entry(r_args, 0),
+                    rb_ary_entry(r_args, 1),
+                    rb_ary_entry(r_args, 2),
+                    rb_ary_entry(r_args, 3));
+}
+
+static VALUE r_subtle_decrypt_call(VALUE r_args)
+{
+  VALUE r_mod = rb_const_get(rb_const_get(rb_cObject, rb_intern("Quickjs")), rb_intern("SubtleCrypto"));
+  return rb_funcall(r_mod, rb_intern("decrypt"), 4,
+                    rb_ary_entry(r_args, 0),
+                    rb_ary_entry(r_args, 1),
+                    rb_ary_entry(r_args, 2),
+                    rb_ary_entry(r_args, 3));
+}
+
+// Build Ruby keyword args Hash from AES-GCM/CBC algorithm params.
+static VALUE js_algo_params_to_ruby_hash(JSContext *ctx, JSValueConst j_algo)
+{
+  VALUE r_params = rb_hash_new();
+
+  JSValue j_iv = JS_GetPropertyStr(ctx, j_algo, "iv");
+  if (!JS_IsUndefined(j_iv) && !JS_IsException(j_iv))
+  {
+    VALUE r_iv = js_buffer_to_ruby_str(ctx, j_iv);
+    if (!NIL_P(r_iv))
+      rb_hash_aset(r_params, ID2SYM(rb_intern("iv")), r_iv);
+  }
+  JS_FreeValue(ctx, j_iv);
+
+  JSValue j_tag_length = JS_GetPropertyStr(ctx, j_algo, "tagLength");
+  if (!JS_IsUndefined(j_tag_length) && !JS_IsException(j_tag_length))
+  {
+    int32_t tag_length = 128;
+    JS_ToInt32(ctx, &tag_length, j_tag_length);
+    rb_hash_aset(r_params, ID2SYM(rb_intern("tag_length")), INT2NUM(tag_length));
+  }
+  JS_FreeValue(ctx, j_tag_length);
+
+  JSValue j_additional_data = JS_GetPropertyStr(ctx, j_algo, "additionalData");
+  if (!JS_IsUndefined(j_additional_data) && !JS_IsException(j_additional_data))
+  {
+    VALUE r_ad = js_buffer_to_ruby_str(ctx, j_additional_data);
+    if (!NIL_P(r_ad))
+      rb_hash_aset(r_params, ID2SYM(rb_intern("additional_data")), r_ad);
+  }
+  JS_FreeValue(ctx, j_additional_data);
+
+  return r_params;
+}
+
+// Shared implementation for encrypt/decrypt.
+// r_call_func: either r_subtle_encrypt_call or r_subtle_decrypt_call
+static JSValue js_subtle_crypt(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv,
+                               VALUE (*r_call_func)(VALUE))
+{
+  if (argc < 3)
+    return JS_ThrowTypeError(ctx, "3 arguments required.");
+
+  const char *algo_name = js_get_algorithm_name(ctx, argv[0]);
+  if (!algo_name)
+    return JS_ThrowTypeError(ctx, "algorithm name is required.");
+  VALUE r_name = rb_str_new_cstr(algo_name);
+  JS_FreeCString(ctx, algo_name);
+
+  VALUE r_key = r_find_alive_crypto_key(ctx, argv[1]);
+  if (NIL_P(r_key))
+    return JS_ThrowTypeError(ctx, "invalid CryptoKey.");
+
+  VALUE r_data = js_buffer_to_ruby_str(ctx, argv[2]);
+  if (NIL_P(r_data))
+    return JS_ThrowTypeError(ctx, "data must be an ArrayBuffer or TypedArray.");
+
+  VALUE r_params = js_algo_params_to_ruby_hash(ctx, argv[0]);
+
+  // Merge key and params into a single Ruby object for the call
+  // We pass [name, key_with_params, data] — but encrypt() signature is (name, key, data, **params)
+  // Instead, attach params to key via a wrapper hash: [name, key, data, params]
+  // Actually let's just call encrypt with keyword splat by building a special args array.
+  // Since rb_protect only takes one VALUE, pack everything.
+  VALUE r_args = rb_ary_new3(4, r_name, r_key, r_data, r_params);
+
+  JSValue promise, resolving_funcs[2];
+  promise = JS_NewPromiseCapability(ctx, resolving_funcs);
+  if (JS_IsException(promise))
+    return JS_EXCEPTION;
+
+  int error_state;
+  VALUE r_result = rb_protect(r_call_func, r_args, &error_state);
+
+  if (error_state)
+  {
+    js_reject_with_ruby_error(ctx, resolving_funcs);
+  }
+  else
+  {
+    JSValue j_result = JS_NewArrayBufferCopy(ctx, (const uint8_t *)RSTRING_PTR(r_result), RSTRING_LEN(r_result));
+    JSValue ret = JS_Call(ctx, resolving_funcs[0], JS_UNDEFINED, 1, (JSValueConst *)&j_result);
+    JS_FreeValue(ctx, j_result);
+    JS_FreeValue(ctx, ret);
+  }
+
+  JS_FreeValue(ctx, resolving_funcs[0]);
+  JS_FreeValue(ctx, resolving_funcs[1]);
+
+  return promise;
+}
+
+static JSValue js_subtle_encrypt(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv)
+{
+  return js_subtle_crypt(ctx, this_val, argc, argv, r_subtle_encrypt_call);
+}
+
+static JSValue js_subtle_decrypt(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv)
+{
+  return js_subtle_crypt(ctx, this_val, argc, argv, r_subtle_decrypt_call);
 }
 
 void quickjsrb_init_crypto_subtle(JSContext *ctx, JSValueConst j_crypto)
@@ -101,5 +475,15 @@ void quickjsrb_init_crypto_subtle(JSContext *ctx, JSValueConst j_crypto)
   JSValue j_subtle = JS_NewObject(ctx);
   JS_SetPropertyStr(ctx, j_subtle, "digest",
                     JS_NewCFunction(ctx, js_subtle_digest, "digest", 2));
+  JS_SetPropertyStr(ctx, j_subtle, "generateKey",
+                    JS_NewCFunction(ctx, js_subtle_generate_key, "generateKey", 3));
+  JS_SetPropertyStr(ctx, j_subtle, "importKey",
+                    JS_NewCFunction(ctx, js_subtle_import_key, "importKey", 5));
+  JS_SetPropertyStr(ctx, j_subtle, "exportKey",
+                    JS_NewCFunction(ctx, js_subtle_export_key, "exportKey", 2));
+  JS_SetPropertyStr(ctx, j_subtle, "encrypt",
+                    JS_NewCFunction(ctx, js_subtle_encrypt, "encrypt", 3));
+  JS_SetPropertyStr(ctx, j_subtle, "decrypt",
+                    JS_NewCFunction(ctx, js_subtle_decrypt, "decrypt", 3));
   JS_SetPropertyStr(ctx, j_crypto, "subtle", j_subtle);
 }

--- a/ext/quickjsrb/quickjsrb_crypto_subtle.h
+++ b/ext/quickjsrb/quickjsrb_crypto_subtle.h
@@ -1,0 +1,6 @@
+#ifndef QUICKJSRB_CRYPTO_SUBTLE_H
+#define QUICKJSRB_CRYPTO_SUBTLE_H 1
+
+void quickjsrb_init_crypto_subtle(JSContext *ctx, JSValueConst j_crypto);
+
+#endif /* QUICKJSRB_CRYPTO_SUBTLE_H */

--- a/lib/quickjs.rb
+++ b/lib/quickjs.rb
@@ -3,6 +3,7 @@
 require "securerandom"
 require "timeout"
 require_relative "quickjs/version"
+require_relative "quickjs/subtle_crypto"
 require_relative "quickjs/quickjsrb"
 
 module Quickjs

--- a/lib/quickjs.rb
+++ b/lib/quickjs.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "securerandom"
 require "timeout"
 require_relative "quickjs/version"
 require_relative "quickjs/quickjsrb"

--- a/lib/quickjs.rb
+++ b/lib/quickjs.rb
@@ -4,6 +4,7 @@ require "securerandom"
 require "timeout"
 require_relative "quickjs/version"
 require_relative "quickjs/subtle_crypto"
+require_relative "quickjs/crypto_key"
 require_relative "quickjs/quickjsrb"
 
 module Quickjs

--- a/lib/quickjs/crypto_key.rb
+++ b/lib/quickjs/crypto_key.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Quickjs
+  class CryptoKey
+    attr_reader :type, :extractable, :algorithm, :usages, :key_data
+
+    def initialize(type, extractable, algorithm, usages, key_data)
+      @type = type
+      @extractable = extractable
+      @algorithm = algorithm
+      @usages = usages
+      @key_data = key_data
+    end
+  end
+end

--- a/lib/quickjs/subtle_crypto.rb
+++ b/lib/quickjs/subtle_crypto.rb
@@ -180,7 +180,13 @@ module Quickjs
           key.key_data.public_to_der.then { |spki_der| ec_spki_to_raw(spki_der) }
         when "Ed25519", "X25519"
           raise ArgumentError, "SubtleCrypto: raw export only for public OKP keys" unless key.type == "public"
-          key.key_data.raw_public_key
+          if key.key_data.respond_to?(:raw_public_key)
+            key.key_data.raw_public_key
+          else
+            # raw_public_key added in openssl gem 3.2.0 (Ruby 3.3): https://github.com/ruby/openssl/blob/master/History.md
+            # Ed25519/X25519 SPKI DER is 44 bytes with the 32-byte key at the end
+            key.key_data.public_to_der[-32..]
+          end
         else
           raise ArgumentError, "SubtleCrypto: raw export not supported for '#{name}'"
         end

--- a/lib/quickjs/subtle_crypto.rb
+++ b/lib/quickjs/subtle_crypto.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "openssl"
+
+module Quickjs
+  module SubtleCrypto
+    DIGEST_ALGORITHMS = {
+      "SHA-1"   => "SHA1",
+      "SHA-256" => "SHA256",
+      "SHA-384" => "SHA384",
+      "SHA-512" => "SHA512",
+    }.freeze
+
+    def self.digest(algorithm_name, data)
+      ossl_name = DIGEST_ALGORITHMS[algorithm_name] or
+        raise ArgumentError, "SubtleCrypto: unsupported digest algorithm '#{algorithm_name}'"
+      OpenSSL::Digest.digest(ossl_name, data)
+    end
+  end
+end

--- a/lib/quickjs/subtle_crypto.rb
+++ b/lib/quickjs/subtle_crypto.rb
@@ -11,10 +11,111 @@ module Quickjs
       "SHA-512" => "SHA512",
     }.freeze
 
+    AES_ALGORITHMS = %w[AES-GCM AES-CBC AES-CTR].freeze
+    AES_VALID_LENGTHS = [128, 192, 256].freeze
+
     def self.digest(algorithm_name, data)
       ossl_name = DIGEST_ALGORITHMS[algorithm_name] or
         raise ArgumentError, "SubtleCrypto: unsupported digest algorithm '#{algorithm_name}'"
       OpenSSL::Digest.digest(ossl_name, data)
     end
+
+    def self.generate_key(name, length, extractable, usages)
+      raise ArgumentError, "SubtleCrypto: unsupported generateKey algorithm '#{name}'" unless AES_ALGORITHMS.include?(name)
+      raise ArgumentError, "SubtleCrypto: invalid AES key length #{length}" unless AES_VALID_LENGTHS.include?(length)
+
+      key_data = OpenSSL::Random.random_bytes(length / 8)
+      Quickjs::CryptoKey.new("secret", extractable, { "name" => name, "length" => length }, usages, key_data)
+    end
+
+    def self.import_key(format, key_data, name, extractable, usages)
+      case format
+      when "raw"
+        raise ArgumentError, "SubtleCrypto: unsupported importKey algorithm '#{name}'" unless AES_ALGORITHMS.include?(name)
+        length = key_data.bytesize * 8
+        raise ArgumentError, "SubtleCrypto: invalid AES key length #{length}" unless AES_VALID_LENGTHS.include?(length)
+        Quickjs::CryptoKey.new("secret", extractable, { "name" => name, "length" => length }, usages, key_data)
+      else
+        raise ArgumentError, "SubtleCrypto: unsupported importKey format '#{format}'"
+      end
+    end
+
+    def self.export_key(format, key)
+      case format
+      when "raw"
+        raise ArgumentError, "SubtleCrypto: key is not extractable" unless key.extractable
+        key.key_data
+      else
+        raise ArgumentError, "SubtleCrypto: unsupported exportKey format '#{format}'"
+      end
+    end
+
+    def self.encrypt(name, key, data, params = {})
+      case name
+      when "AES-GCM"
+        aes_gcm_encrypt(key, data, params)
+      when "AES-CBC"
+        aes_cbc_crypt(key, data, params, :encrypt)
+      else
+        raise ArgumentError, "SubtleCrypto: unsupported encrypt algorithm '#{name}'"
+      end
+    end
+
+    def self.decrypt(name, key, data, params = {})
+      case name
+      when "AES-GCM"
+        aes_gcm_decrypt(key, data, params)
+      when "AES-CBC"
+        aes_cbc_crypt(key, data, params, :decrypt)
+      else
+        raise ArgumentError, "SubtleCrypto: unsupported decrypt algorithm '#{name}'"
+      end
+    end
+
+    def self.aes_gcm_encrypt(key, data, params)
+      iv = params.fetch(:iv)
+      tag_length = params.fetch(:tag_length, 128)
+      additional_data = params[:additional_data]
+
+      cipher = OpenSSL::Cipher.new("aes-#{key.algorithm["length"]}-gcm")
+      cipher.encrypt
+      cipher.key = key.key_data
+      cipher.iv = iv
+      cipher.auth_data = additional_data || ""
+      ciphertext = cipher.update(data) + cipher.final
+      tag = cipher.auth_tag(tag_length / 8)
+      ciphertext + tag
+    end
+    private_class_method :aes_gcm_encrypt
+
+    def self.aes_gcm_decrypt(key, data, params)
+      iv = params.fetch(:iv)
+      tag_length = params.fetch(:tag_length, 128)
+      additional_data = params[:additional_data]
+
+      tag_bytes = tag_length / 8
+      ciphertext = data[0, data.bytesize - tag_bytes]
+      tag = data[-tag_bytes, tag_bytes]
+
+      decipher = OpenSSL::Cipher.new("aes-#{key.algorithm["length"]}-gcm")
+      decipher.decrypt
+      decipher.key = key.key_data
+      decipher.iv = iv
+      decipher.auth_tag = tag
+      decipher.auth_data = additional_data || ""
+      decipher.update(ciphertext) + decipher.final
+    end
+    private_class_method :aes_gcm_decrypt
+
+    def self.aes_cbc_crypt(key, data, params, direction)
+      iv = params.fetch(:iv)
+
+      cipher = OpenSSL::Cipher.new("aes-#{key.algorithm["length"]}-cbc")
+      direction == :encrypt ? cipher.encrypt : cipher.decrypt
+      cipher.key = key.key_data
+      cipher.iv = iv
+      cipher.update(data) + cipher.final
+    end
+    private_class_method :aes_cbc_crypt
   end
 end

--- a/lib/quickjs/subtle_crypto.rb
+++ b/lib/quickjs/subtle_crypto.rb
@@ -11,8 +11,27 @@ module Quickjs
       "SHA-512" => "SHA512",
     }.freeze
 
-    AES_ALGORITHMS = %w[AES-GCM AES-CBC AES-CTR].freeze
+    AES_ALGORITHMS = %w[AES-GCM AES-CBC AES-CTR AES-KW].freeze
     AES_VALID_LENGTHS = [128, 192, 256].freeze
+
+    HMAC_HASH_OUTPUT_LENGTHS = {
+      "SHA-1" => 160, "SHA-256" => 256, "SHA-384" => 384, "SHA-512" => 512,
+    }.freeze
+
+    EC_CURVE_MAP = {
+      "P-256" => "prime256v1",
+      "P-384" => "secp384r1",
+      "P-521" => "secp521r1",
+    }.freeze
+
+    EC_COORD_SIZES = {
+      "P-256" => 32, "P-384" => 48, "P-521" => 66,
+    }.freeze
+
+    RSA_ALGORITHMS = %w[RSASSA-PKCS1-v1_5 RSA-PSS RSA-OAEP].freeze
+    ECDSA_ALGORITHMS = %w[ECDSA].freeze
+    ECDH_ALGORITHMS = %w[ECDH X25519].freeze
+    KDF_ALGORITHMS = %w[PBKDF2 HKDF].freeze
 
     def self.digest(algorithm_name, data)
       ossl_name = DIGEST_ALGORITHMS[algorithm_name] or
@@ -20,31 +39,159 @@ module Quickjs
       OpenSSL::Digest.digest(ossl_name, data)
     end
 
-    def self.generate_key(name, length, extractable, usages)
-      raise ArgumentError, "SubtleCrypto: unsupported generateKey algorithm '#{name}'" unless AES_ALGORITHMS.include?(name)
-      raise ArgumentError, "SubtleCrypto: invalid AES key length #{length}" unless AES_VALID_LENGTHS.include?(length)
-
-      key_data = OpenSSL::Random.random_bytes(length / 8)
-      Quickjs::CryptoKey.new("secret", extractable, { "name" => name, "length" => length }, usages, key_data)
+    def self.generate_key(algo, extractable, usages)
+      name = algo[:name] or raise ArgumentError, "SubtleCrypto: algorithm name is required"
+      case name
+      when *AES_ALGORITHMS
+        length = algo[:length] or raise ArgumentError, "SubtleCrypto: AES key requires length"
+        raise ArgumentError, "SubtleCrypto: invalid AES key length #{length}" unless AES_VALID_LENGTHS.include?(length)
+        key_data = OpenSSL::Random.random_bytes(length / 8)
+        Quickjs::CryptoKey.new("secret", extractable, { "name" => name, "length" => length }, usages, key_data)
+      when "HMAC"
+        hash = algo[:hash] or raise ArgumentError, "SubtleCrypto: HMAC requires hash"
+        length = algo[:length] || HMAC_HASH_OUTPUT_LENGTHS[hash] or
+          raise ArgumentError, "SubtleCrypto: unsupported HMAC hash '#{hash}'"
+        key_data = OpenSSL::Random.random_bytes(length / 8)
+        Quickjs::CryptoKey.new("secret", extractable, { "name" => "HMAC", "hash" => hash, "length" => length }, usages, key_data)
+      when *RSA_ALGORITHMS
+        modulus_length = algo[:modulus_length] or raise ArgumentError, "SubtleCrypto: RSA key requires modulusLength"
+        public_exponent_bytes = algo[:public_exponent] or raise ArgumentError, "SubtleCrypto: RSA key requires publicExponent"
+        hash = algo[:hash] or raise ArgumentError, "SubtleCrypto: RSA key requires hash"
+        exponent = public_exponent_bytes.bytes.reduce(0) { |acc, b| (acc << 8) | b }
+        pkey = OpenSSL::PKey::RSA.generate(modulus_length, exponent)
+        algo_hash = { "name" => name, "modulusLength" => modulus_length, "publicExponent" => public_exponent_bytes, "hash" => hash }
+        {
+          private_key: Quickjs::CryptoKey.new("private", extractable, algo_hash, usages.select { |u| %w[sign decrypt unwrapKey].include?(u) }, pkey),
+          public_key: Quickjs::CryptoKey.new("public", true, algo_hash, usages.select { |u| %w[verify encrypt wrapKey].include?(u) }, pkey),
+        }
+      when "ECDSA", "ECDH"
+        named_curve = algo[:named_curve] or raise ArgumentError, "SubtleCrypto: EC key requires namedCurve"
+        ossl_curve = EC_CURVE_MAP[named_curve] or raise ArgumentError, "SubtleCrypto: unsupported curve '#{named_curve}'"
+        pkey = OpenSSL::PKey::EC.generate(ossl_curve)
+        algo_hash = { "name" => name, "namedCurve" => named_curve }
+        private_usages = name == "ECDSA" ? %w[sign] : %w[deriveKey deriveBits]
+        public_usages = name == "ECDSA" ? %w[verify] : []
+        {
+          private_key: Quickjs::CryptoKey.new("private", extractable, algo_hash, usages.select { |u| private_usages.include?(u) }, pkey),
+          public_key: Quickjs::CryptoKey.new("public", true, algo_hash, usages.select { |u| public_usages.include?(u) }, pkey),
+        }
+      when "Ed25519"
+        pkey = OpenSSL::PKey.generate_key("ED25519")
+        algo_hash = { "name" => "Ed25519" }
+        {
+          private_key: Quickjs::CryptoKey.new("private", extractable, algo_hash, usages.select { |u| u == "sign" }, pkey),
+          public_key: Quickjs::CryptoKey.new("public", true, algo_hash, usages.select { |u| u == "verify" }, pkey),
+        }
+      when "X25519"
+        pkey = OpenSSL::PKey.generate_key("X25519")
+        algo_hash = { "name" => "X25519" }
+        {
+          private_key: Quickjs::CryptoKey.new("private", extractable, algo_hash, usages.select { |u| %w[deriveKey deriveBits].include?(u) }, pkey),
+          public_key: Quickjs::CryptoKey.new("public", true, algo_hash, [], pkey),
+        }
+      else
+        raise ArgumentError, "SubtleCrypto: unsupported generateKey algorithm '#{name}'"
+      end
     end
 
-    def self.import_key(format, key_data, name, extractable, usages)
+    def self.import_key(format, key_data, algo, extractable, usages)
+      name = algo[:name] or raise ArgumentError, "SubtleCrypto: algorithm name is required"
       case format
       when "raw"
-        raise ArgumentError, "SubtleCrypto: unsupported importKey algorithm '#{name}'" unless AES_ALGORITHMS.include?(name)
-        length = key_data.bytesize * 8
-        raise ArgumentError, "SubtleCrypto: invalid AES key length #{length}" unless AES_VALID_LENGTHS.include?(length)
-        Quickjs::CryptoKey.new("secret", extractable, { "name" => name, "length" => length }, usages, key_data)
+        case name
+        when *AES_ALGORITHMS
+          length = key_data.bytesize * 8
+          raise ArgumentError, "SubtleCrypto: invalid AES key length #{length}" unless AES_VALID_LENGTHS.include?(length)
+          Quickjs::CryptoKey.new("secret", extractable, { "name" => name, "length" => length }, usages, key_data)
+        when "HMAC"
+          hash = algo[:hash] or raise ArgumentError, "SubtleCrypto: HMAC requires hash"
+          length = key_data.bytesize * 8
+          Quickjs::CryptoKey.new("secret", extractable, { "name" => "HMAC", "hash" => hash, "length" => length }, usages, key_data)
+        when "PBKDF2"
+          Quickjs::CryptoKey.new("secret", false, { "name" => "PBKDF2" }, usages, key_data)
+        when "HKDF"
+          Quickjs::CryptoKey.new("secret", false, { "name" => "HKDF" }, usages, key_data)
+        when "ECDSA", "ECDH"
+          named_curve = algo[:named_curve] or raise ArgumentError, "SubtleCrypto: EC import requires namedCurve"
+          pkey = import_raw_ec_public(key_data, named_curve)
+          Quickjs::CryptoKey.new("public", extractable, { "name" => name, "namedCurve" => named_curve }, usages, pkey)
+        when "Ed25519"
+          pkey = import_raw_okp_public(key_data, "ED25519")
+          Quickjs::CryptoKey.new("public", extractable, { "name" => "Ed25519" }, usages, pkey)
+        when "X25519"
+          pkey = import_raw_okp_public(key_data, "X25519")
+          Quickjs::CryptoKey.new("public", extractable, { "name" => "X25519" }, usages, pkey)
+        else
+          raise ArgumentError, "SubtleCrypto: unsupported raw importKey algorithm '#{name}'"
+        end
+      when "spki"
+        pkey = OpenSSL::PKey.read(key_data)
+        case name
+        when *RSA_ALGORITHMS
+          rsa = pkey.is_a?(OpenSSL::PKey::RSA) ? pkey : raise(ArgumentError, "SubtleCrypto: key is not RSA")
+          hash = algo[:hash] or raise ArgumentError, "SubtleCrypto: RSA import requires hash"
+          pub_exp_bytes = [rsa.e.to_s(16)].pack("H*")
+          algo_hash = { "name" => name, "modulusLength" => rsa.n.num_bits, "publicExponent" => pub_exp_bytes, "hash" => hash }
+          Quickjs::CryptoKey.new("public", extractable, algo_hash, usages, pkey)
+        when "ECDSA", "ECDH"
+          named_curve = algo[:named_curve] or raise ArgumentError, "SubtleCrypto: EC import requires namedCurve"
+          Quickjs::CryptoKey.new("public", extractable, { "name" => name, "namedCurve" => named_curve }, usages, pkey)
+        when "Ed25519"
+          Quickjs::CryptoKey.new("public", extractable, { "name" => "Ed25519" }, usages, pkey)
+        when "X25519"
+          Quickjs::CryptoKey.new("public", extractable, { "name" => "X25519" }, usages, pkey)
+        else
+          raise ArgumentError, "SubtleCrypto: unsupported spki importKey algorithm '#{name}'"
+        end
+      when "pkcs8"
+        pkey = OpenSSL::PKey.read(key_data)
+        case name
+        when *RSA_ALGORITHMS
+          hash = algo[:hash] or raise ArgumentError, "SubtleCrypto: RSA import requires hash"
+          rsa = pkey.is_a?(OpenSSL::PKey::RSA) ? pkey : raise(ArgumentError, "SubtleCrypto: key is not RSA")
+          pub_exp_bytes = [rsa.e.to_s(16)].pack("H*")
+          algo_hash = { "name" => name, "modulusLength" => rsa.n.num_bits, "publicExponent" => pub_exp_bytes, "hash" => hash }
+          Quickjs::CryptoKey.new("private", extractable, algo_hash, usages, pkey)
+        when "ECDSA", "ECDH"
+          named_curve = algo[:named_curve] or raise ArgumentError, "SubtleCrypto: EC import requires namedCurve"
+          Quickjs::CryptoKey.new("private", extractable, { "name" => name, "namedCurve" => named_curve }, usages, pkey)
+        when "Ed25519"
+          Quickjs::CryptoKey.new("private", extractable, { "name" => "Ed25519" }, usages, pkey)
+        when "X25519"
+          Quickjs::CryptoKey.new("private", extractable, { "name" => "X25519" }, usages, pkey)
+        else
+          raise ArgumentError, "SubtleCrypto: unsupported pkcs8 importKey algorithm '#{name}'"
+        end
       else
         raise ArgumentError, "SubtleCrypto: unsupported importKey format '#{format}'"
       end
     end
 
     def self.export_key(format, key)
+      name = key.algorithm["name"]
       case format
       when "raw"
         raise ArgumentError, "SubtleCrypto: key is not extractable" unless key.extractable
-        key.key_data
+        case name
+        when *AES_ALGORITHMS, "HMAC"
+          key.key_data
+        when "ECDSA", "ECDH"
+          raise ArgumentError, "SubtleCrypto: raw export only for public EC keys" unless key.type == "public"
+          key.key_data.public_to_der.then { |spki_der| ec_spki_to_raw(spki_der) }
+        when "Ed25519", "X25519"
+          raise ArgumentError, "SubtleCrypto: raw export only for public OKP keys" unless key.type == "public"
+          key.key_data.raw_public_key
+        else
+          raise ArgumentError, "SubtleCrypto: raw export not supported for '#{name}'"
+        end
+      when "spki"
+        raise ArgumentError, "SubtleCrypto: key is not extractable" unless key.extractable
+        raise ArgumentError, "SubtleCrypto: spki export requires public key" unless key.type == "public"
+        key.key_data.public_to_der
+      when "pkcs8"
+        raise ArgumentError, "SubtleCrypto: key is not extractable" unless key.extractable
+        raise ArgumentError, "SubtleCrypto: pkcs8 export requires private key" unless key.type == "private"
+        key.key_data.private_to_der
       else
         raise ArgumentError, "SubtleCrypto: unsupported exportKey format '#{format}'"
       end
@@ -56,6 +203,12 @@ module Quickjs
         aes_gcm_encrypt(key, data, params)
       when "AES-CBC"
         aes_cbc_crypt(key, data, params, :encrypt)
+      when "AES-CTR"
+        aes_ctr_crypt(key, data, params, :encrypt)
+      when "AES-KW"
+        aes_kw_crypt(key, data, :encrypt)
+      when "RSA-OAEP"
+        rsa_oaep_crypt(key, data, params, :encrypt)
       else
         raise ArgumentError, "SubtleCrypto: unsupported encrypt algorithm '#{name}'"
       end
@@ -67,9 +220,121 @@ module Quickjs
         aes_gcm_decrypt(key, data, params)
       when "AES-CBC"
         aes_cbc_crypt(key, data, params, :decrypt)
+      when "AES-CTR"
+        aes_ctr_crypt(key, data, params, :decrypt)
+      when "AES-KW"
+        aes_kw_crypt(key, data, :decrypt)
+      when "RSA-OAEP"
+        rsa_oaep_crypt(key, data, params, :decrypt)
       else
         raise ArgumentError, "SubtleCrypto: unsupported decrypt algorithm '#{name}'"
       end
+    end
+
+    def self.sign(name, key, data, params = {})
+      case name
+      when "HMAC"
+        hash_name = ossl_digest_name(key.algorithm["hash"])
+        OpenSSL::HMAC.digest(hash_name, key.key_data, data)
+      when "RSASSA-PKCS1-v1_5"
+        hash_name = ossl_digest_name(key.algorithm["hash"])
+        key.key_data.sign(hash_name, data)
+      when "RSA-PSS"
+        hash_name = ossl_digest_name(key.algorithm["hash"])
+        salt_length = params[:salt_length] || :digest
+        key.key_data.sign_pss(hash_name, data, salt_length: salt_length, mgf1_hash: hash_name)
+      when "ECDSA"
+        hash_name = ossl_digest_name(params[:hash] || key.algorithm["hash"])
+        named_curve = key.algorithm["namedCurve"]
+        coord_size = EC_COORD_SIZES[named_curve] or raise ArgumentError, "SubtleCrypto: unsupported curve '#{named_curve}'"
+        der_sig = key.key_data.sign(hash_name, data)
+        der_to_p1363(der_sig, coord_size)
+      when "Ed25519"
+        key.key_data.sign(nil, data)
+      else
+        raise ArgumentError, "SubtleCrypto: unsupported sign algorithm '#{name}'"
+      end
+    end
+
+    def self.verify(name, key, signature, data, params = {})
+      case name
+      when "HMAC"
+        hash_name = ossl_digest_name(key.algorithm["hash"])
+        expected = OpenSSL::HMAC.digest(hash_name, key.key_data, data)
+        OpenSSL::HMAC.hexdigest(hash_name, key.key_data, data) == OpenSSL::HMAC.hexdigest(hash_name, key.key_data, data) &&
+          secure_compare(expected, signature)
+      when "RSASSA-PKCS1-v1_5"
+        hash_name = ossl_digest_name(key.algorithm["hash"])
+        key.key_data.verify(hash_name, signature, data)
+      when "RSA-PSS"
+        hash_name = ossl_digest_name(key.algorithm["hash"])
+        salt_length = params[:salt_length] || :digest
+        key.key_data.verify_pss(hash_name, signature, data, salt_length: salt_length, mgf1_hash: hash_name)
+      when "ECDSA"
+        hash_name = ossl_digest_name(params[:hash] || key.algorithm["hash"])
+        named_curve = key.algorithm["namedCurve"]
+        coord_size = EC_COORD_SIZES[named_curve] or raise ArgumentError, "SubtleCrypto: unsupported curve '#{named_curve}'"
+        begin
+          der_sig = p1363_to_der(signature, coord_size)
+          key.key_data.verify(hash_name, der_sig, data)
+        rescue OpenSSL::PKey::PKeyError
+          false
+        end
+      when "Ed25519"
+        begin
+          key.key_data.verify(nil, signature, data)
+        rescue OpenSSL::PKey::PKeyError
+          false
+        end
+      else
+        raise ArgumentError, "SubtleCrypto: unsupported verify algorithm '#{name}'"
+      end
+    end
+
+    def self.derive_bits(name, key, length_bits, params = {})
+      case name
+      when "PBKDF2"
+        hash_name = ossl_digest_name(params[:hash]) or raise ArgumentError, "SubtleCrypto: PBKDF2 requires hash"
+        salt = params[:salt] or raise ArgumentError, "SubtleCrypto: PBKDF2 requires salt"
+        iterations = params[:iterations] or raise ArgumentError, "SubtleCrypto: PBKDF2 requires iterations"
+        OpenSSL::KDF.pbkdf2_hmac(key.key_data, salt: salt, iterations: iterations, length: length_bits / 8, hash: hash_name)
+      when "HKDF"
+        hash_name = ossl_digest_name(params[:hash]) or raise ArgumentError, "SubtleCrypto: HKDF requires hash"
+        salt = params[:salt] || ""
+        info = params[:info] || ""
+        OpenSSL::KDF.hkdf(key.key_data, salt: salt, info: info, length: length_bits / 8, hash: hash_name)
+      when "ECDH"
+        peer_key = params[:public] or raise ArgumentError, "SubtleCrypto: ECDH requires public key"
+        shared = key.key_data.dh_compute_key(peer_key.key_data.public_key)
+        shared.byteslice(0, length_bits / 8)
+      when "X25519"
+        peer_key = params[:public] or raise ArgumentError, "SubtleCrypto: X25519 requires public key"
+        shared = key.key_data.derive(peer_key.key_data)
+        shared.byteslice(0, length_bits / 8)
+      else
+        raise ArgumentError, "SubtleCrypto: unsupported deriveBits algorithm '#{name}'"
+      end
+    end
+
+    def self.derive_key(name, key, derived_algo, extractable, usages, params = {})
+      derived_name = derived_algo[:name] or raise ArgumentError, "SubtleCrypto: derived key algorithm name is required"
+      derived_length = case derived_name
+                       when *AES_ALGORITHMS then derived_algo[:length] or raise ArgumentError, "SubtleCrypto: derived AES key requires length"
+                       when "HMAC" then derived_algo[:length] || HMAC_HASH_OUTPUT_LENGTHS[derived_algo[:hash]]
+                       else raise ArgumentError, "SubtleCrypto: unsupported derived key algorithm '#{derived_name}'"
+                       end
+      key_bytes = derive_bits(name, key, derived_length, params)
+      import_key("raw", key_bytes, derived_algo, extractable, usages)
+    end
+
+    def self.wrap_key(format, key, wrapping_key, wrap_algo_hash, wrap_name)
+      key_data = export_key(format, key)
+      encrypt(wrap_name, wrapping_key, key_data, wrap_algo_hash)
+    end
+
+    def self.unwrap_key(format, wrapped, unwrapping_key, unwrap_algo_hash, unwrapped_algo_hash, extractable, usages, unwrap_name)
+      key_data = decrypt(unwrap_name, unwrapping_key, wrapped, unwrap_algo_hash)
+      import_key(format, key_data, unwrapped_algo_hash, extractable, usages)
     end
 
     def self.aes_gcm_encrypt(key, data, params)
@@ -104,6 +369,8 @@ module Quickjs
       decipher.auth_tag = tag
       decipher.auth_data = additional_data || ""
       decipher.update(ciphertext) + decipher.final
+    rescue OpenSSL::Cipher::CipherError => e
+      raise RuntimeError, "SubtleCrypto: AES-GCM decryption failed: #{e.message}"
     end
     private_class_method :aes_gcm_decrypt
 
@@ -115,7 +382,106 @@ module Quickjs
       cipher.key = key.key_data
       cipher.iv = iv
       cipher.update(data) + cipher.final
+    rescue OpenSSL::Cipher::CipherError => e
+      raise RuntimeError, "SubtleCrypto: AES-CBC failed: #{e.message}"
     end
     private_class_method :aes_cbc_crypt
+
+    def self.aes_kw_crypt(key, data, direction)
+      bits = key.algorithm["length"]
+      cipher = OpenSSL::Cipher.new("aes-#{bits}-wrap")
+      direction == :encrypt ? cipher.encrypt : cipher.decrypt
+      cipher.key = key.key_data
+      cipher.update(data) + cipher.final
+    rescue OpenSSL::Cipher::CipherError => e
+      raise RuntimeError, "SubtleCrypto: AES-KW failed: #{e.message}"
+    end
+    private_class_method :aes_kw_crypt
+
+    def self.aes_ctr_crypt(key, data, params, direction)
+      counter = params.fetch(:counter)
+      length = params[:length] || 64
+
+      cipher = OpenSSL::Cipher.new("aes-#{key.algorithm["length"]}-ctr")
+      direction == :encrypt ? cipher.encrypt : cipher.decrypt
+      cipher.key = key.key_data
+      cipher.iv = counter
+      cipher.update(data) + cipher.final
+    end
+    private_class_method :aes_ctr_crypt
+
+    def self.rsa_oaep_crypt(key, data, params, direction)
+      hash_name = ossl_digest_name(key.algorithm["hash"])
+      opts = { rsa_padding_mode: "oaep", rsa_oaep_md: hash_name, rsa_mgf1_md: hash_name }
+      if direction == :encrypt
+        key.key_data.encrypt(data, opts)
+      else
+        key.key_data.decrypt(data, opts)
+      end
+    rescue OpenSSL::PKey::PKeyError => e
+      raise RuntimeError, "SubtleCrypto: RSA-OAEP failed: #{e.message}"
+    end
+    private_class_method :rsa_oaep_crypt
+
+    def self.ossl_digest_name(hash_name)
+      DIGEST_ALGORITHMS[hash_name] or raise ArgumentError, "SubtleCrypto: unsupported hash '#{hash_name}'"
+    end
+    private_class_method :ossl_digest_name
+
+    def self.secure_compare(a, b)
+      return false unless a.bytesize == b.bytesize
+      OpenSSL.fixed_length_secure_compare(a, b)
+    end
+    private_class_method :secure_compare
+
+    def self.der_to_p1363(der_sig, coord_size)
+      asn = OpenSSL::ASN1.decode(der_sig)
+      r_bn = asn.value[0].value
+      s_bn = asn.value[1].value
+      r_bytes = r_bn.to_s(2)
+      s_bytes = s_bn.to_s(2)
+      pad = "\x00" * coord_size
+      r_padded = (pad + r_bytes).byteslice(-coord_size, coord_size)
+      s_padded = (pad + s_bytes).byteslice(-coord_size, coord_size)
+      r_padded + s_padded
+    end
+    private_class_method :der_to_p1363
+
+    def self.p1363_to_der(p1363_sig, coord_size)
+      r_bytes = p1363_sig.byteslice(0, coord_size)
+      s_bytes = p1363_sig.byteslice(coord_size, coord_size)
+      r_bn = OpenSSL::BN.new(r_bytes, 2)
+      s_bn = OpenSSL::BN.new(s_bytes, 2)
+      OpenSSL::ASN1::Sequence([
+        OpenSSL::ASN1::Integer(r_bn),
+        OpenSSL::ASN1::Integer(s_bn),
+      ]).to_der
+    end
+    private_class_method :p1363_to_der
+
+    def self.import_raw_ec_public(raw_bytes, named_curve)
+      ossl_curve = EC_CURVE_MAP[named_curve] or
+        raise ArgumentError, "SubtleCrypto: unsupported EC curve '#{named_curve}'"
+      ec_oid = OpenSSL::ASN1::ObjectId("id-ecPublicKey")
+      curve_oid = OpenSSL::ASN1::ObjectId(ossl_curve)
+      algo_seq = OpenSSL::ASN1::Sequence([ec_oid, curve_oid])
+      spki = OpenSSL::ASN1::Sequence([algo_seq, OpenSSL::ASN1::BitString(raw_bytes)])
+      OpenSSL::PKey.read(spki.to_der)
+    end
+    private_class_method :import_raw_ec_public
+
+    def self.import_raw_okp_public(raw_bytes, ossl_algo)
+      oid = OpenSSL::ASN1::ObjectId(ossl_algo)
+      algo_seq = OpenSSL::ASN1::Sequence([oid])
+      spki = OpenSSL::ASN1::Sequence([algo_seq, OpenSSL::ASN1::BitString(raw_bytes)])
+      OpenSSL::PKey.read(spki.to_der)
+    end
+    private_class_method :import_raw_okp_public
+
+    def self.ec_spki_to_raw(spki_der)
+      asn = OpenSSL::ASN1.decode(spki_der)
+      asn.value[1].value
+    end
+    private_class_method :ec_spki_to_raw
   end
 end

--- a/quickjs.gemspec
+++ b/quickjs.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description = 'A native wrapper to run QuickJS in Ruby'
   spec.homepage = 'https://github.com/hmsk/quickjs.rb'
   spec.license = 'MIT'
-  spec.required_ruby_version = '>= 3.0.0'
+  spec.required_ruby_version = '>= 3.1.0'
 
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = spec.homepage

--- a/test/quickjs_crypto_subtle_aes_cbc_test.rb
+++ b/test/quickjs_crypto_subtle_aes_cbc_test.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+describe "crypto.subtle AES-CBC encrypt/decrypt" do
+  before do
+    @options = { features: [::Quickjs::POLYFILL_CRYPTO] }
+  end
+
+  it "encrypts and decrypts round-trip" do
+    code = <<~JS
+      const rawKey = new Uint8Array(32);
+      const iv = new Uint8Array(16);
+      const key = await crypto.subtle.importKey("raw", rawKey, {name: "AES-CBC"}, false, ["encrypt", "decrypt"]);
+      const pt = new Uint8Array([1, 2, 3, 4, 5]);
+      const ct = await crypto.subtle.encrypt({name: "AES-CBC", iv}, key, pt);
+      const dt = await crypto.subtle.decrypt({name: "AES-CBC", iv}, key, ct);
+      new Uint8Array(dt).join(',')
+    JS
+    _(::Quickjs.eval_code(code, @options)).must_equal "1,2,3,4,5"
+  end
+
+  it "ciphertext is padded to a multiple of 16 bytes" do
+    code = <<~JS
+      const rawKey = new Uint8Array(16);
+      const iv = new Uint8Array(16);
+      const key = await crypto.subtle.importKey("raw", rawKey, {name: "AES-CBC"}, false, ["encrypt"]);
+      const ct = await crypto.subtle.encrypt({name: "AES-CBC", iv}, key, new Uint8Array(5));
+      ct.byteLength
+    JS
+    _(::Quickjs.eval_code(code, @options)).must_equal 16
+  end
+
+  it "produces deterministic ciphertext for same key+iv" do
+    code = <<~JS
+      const rawKey = new Uint8Array(16).fill(7);
+      const iv = new Uint8Array(16).fill(3);
+      const key = await crypto.subtle.importKey("raw", rawKey, {name: "AES-CBC"}, false, ["encrypt"]);
+      const pt = new Uint8Array([10, 20, 30]);
+      const ct1 = await crypto.subtle.encrypt({name: "AES-CBC", iv}, key, pt);
+      const ct2 = await crypto.subtle.encrypt({name: "AES-CBC", iv}, key, pt);
+      const a = new Uint8Array(ct1);
+      const b = new Uint8Array(ct2);
+      a.length === b.length && a.every((v, i) => v === b[i])
+    JS
+    _(::Quickjs.eval_code(code, @options)).must_equal true
+  end
+
+  it "fails to decrypt with wrong key" do
+    code = <<~JS
+      const iv = new Uint8Array(16);
+      const key1 = await crypto.subtle.importKey("raw", new Uint8Array(32).fill(1), {name: "AES-CBC"}, false, ["encrypt", "decrypt"]);
+      const key2 = await crypto.subtle.importKey("raw", new Uint8Array(32).fill(2), {name: "AES-CBC"}, false, ["encrypt", "decrypt"]);
+      const ct = await crypto.subtle.encrypt({name: "AES-CBC", iv}, key1, new Uint8Array([1, 2, 3]));
+      await crypto.subtle.decrypt({name: "AES-CBC", iv}, key2, ct)
+    JS
+    _ { ::Quickjs.eval_code(code, @options) }.must_raise Quickjs::RuntimeError
+  end
+end

--- a/test/quickjs_crypto_subtle_aes_ctr_test.rb
+++ b/test/quickjs_crypto_subtle_aes_ctr_test.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+describe "crypto.subtle AES-CTR encrypt/decrypt" do
+  before do
+    @options = { features: [::Quickjs::POLYFILL_CRYPTO] }
+  end
+
+  it "encrypts and decrypts round-trip" do
+    code = <<~JS
+      const key = await crypto.subtle.generateKey({name: "AES-CTR", length: 256}, false, ["encrypt", "decrypt"]);
+      const counter = new Uint8Array(16);
+      const pt = new Uint8Array([1, 2, 3, 4, 5]);
+      const ct = await crypto.subtle.encrypt({name: "AES-CTR", counter, length: 64}, key, pt);
+      const dt = await crypto.subtle.decrypt({name: "AES-CTR", counter, length: 64}, key, ct);
+      new Uint8Array(dt).join(',')
+    JS
+    _(::Quickjs.eval_code(code, @options)).must_equal "1,2,3,4,5"
+  end
+
+  it "ciphertext is same length as plaintext (stream cipher)" do
+    code = <<~JS
+      const key = await crypto.subtle.generateKey({name: "AES-CTR", length: 128}, false, ["encrypt"]);
+      const counter = new Uint8Array(16);
+      const ct = await crypto.subtle.encrypt({name: "AES-CTR", counter, length: 64}, key, new Uint8Array(13));
+      ct.byteLength
+    JS
+    _(::Quickjs.eval_code(code, @options)).must_equal 13
+  end
+
+  it "produces deterministic ciphertext for same key+counter" do
+    code = <<~JS
+      const rawKey = new Uint8Array(16).fill(5);
+      const counter = new Uint8Array(16).fill(3);
+      const key = await crypto.subtle.importKey("raw", rawKey, {name: "AES-CTR"}, false, ["encrypt"]);
+      const pt = new Uint8Array([10, 20, 30]);
+      const ct1 = new Uint8Array(await crypto.subtle.encrypt({name: "AES-CTR", counter, length: 64}, key, pt));
+      const ct2 = new Uint8Array(await crypto.subtle.encrypt({name: "AES-CTR", counter, length: 64}, key, pt));
+      ct1.every((v, i) => v === ct2[i])
+    JS
+    _(::Quickjs.eval_code(code, @options)).must_equal true
+  end
+end

--- a/test/quickjs_crypto_subtle_aes_gcm_test.rb
+++ b/test/quickjs_crypto_subtle_aes_gcm_test.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+describe "crypto.subtle AES-GCM encrypt/decrypt" do
+  before do
+    @options = { features: [::Quickjs::POLYFILL_CRYPTO] }
+  end
+
+  it "encrypts and decrypts round-trip" do
+    code = <<~JS
+      const key = await crypto.subtle.generateKey({name: "AES-GCM", length: 256}, false, ["encrypt", "decrypt"]);
+      const iv = crypto.getRandomValues(new Uint8Array(12));
+      const plaintext = new TextEncoder().encode("hello world");
+      const ciphertext = await crypto.subtle.encrypt({name: "AES-GCM", iv}, key, plaintext);
+      const decrypted = await crypto.subtle.decrypt({name: "AES-GCM", iv}, key, ciphertext);
+      new TextDecoder().decode(decrypted)
+    JS
+    _(::Quickjs.eval_code(code, { features: [::Quickjs::POLYFILL_CRYPTO, ::Quickjs::POLYFILL_ENCODING] })).must_equal "hello world"
+  end
+
+  it "produces deterministic ciphertext for same key+iv" do
+    code = <<~JS
+      const rawKey = new Uint8Array(32).fill(1);
+      const iv = new Uint8Array(12).fill(2);
+      const key = await crypto.subtle.importKey("raw", rawKey, {name: "AES-GCM"}, false, ["encrypt"]);
+      const ct1 = await crypto.subtle.encrypt({name: "AES-GCM", iv}, key, new Uint8Array([104, 101, 108, 108, 111]));
+      const ct2 = await crypto.subtle.encrypt({name: "AES-GCM", iv}, key, new Uint8Array([104, 101, 108, 108, 111]));
+      const a = new Uint8Array(ct1);
+      const b = new Uint8Array(ct2);
+      a.length === b.length && a.every((v, i) => v === b[i])
+    JS
+    _(::Quickjs.eval_code(code, @options)).must_equal true
+  end
+
+  it "returns ciphertext with tag appended (byteLength = plaintext + 16)" do
+    code = <<~JS
+      const rawKey = new Uint8Array(32);
+      const iv = new Uint8Array(12);
+      const key = await crypto.subtle.importKey("raw", rawKey, {name: "AES-GCM"}, false, ["encrypt"]);
+      const ct = await crypto.subtle.encrypt({name: "AES-GCM", iv}, key, new Uint8Array(10));
+      ct.byteLength
+    JS
+    _(::Quickjs.eval_code(code, @options)).must_equal 26
+  end
+
+  it "supports custom tagLength (e.g. 96 bits = 12 bytes tag)" do
+    code = <<~JS
+      const rawKey = new Uint8Array(16);
+      const iv = new Uint8Array(12);
+      const key = await crypto.subtle.importKey("raw", rawKey, {name: "AES-GCM"}, false, ["encrypt", "decrypt"]);
+      const pt = new Uint8Array(5);
+      const ct = await crypto.subtle.encrypt({name: "AES-GCM", iv, tagLength: 96}, key, pt);
+      const dt = await crypto.subtle.decrypt({name: "AES-GCM", iv, tagLength: 96}, key, ct);
+      ct.byteLength === 17 && dt.byteLength === 5
+    JS
+    _(::Quickjs.eval_code(code, @options)).must_equal true
+  end
+
+  it "supports additionalData (AEAD)" do
+    code = <<~JS
+      const rawKey = new Uint8Array(32);
+      const iv = new Uint8Array(12);
+      const ad = new Uint8Array([1, 2, 3]);
+      const key = await crypto.subtle.importKey("raw", rawKey, {name: "AES-GCM"}, false, ["encrypt", "decrypt"]);
+      const pt = new Uint8Array([10, 20, 30]);
+      const ct = await crypto.subtle.encrypt({name: "AES-GCM", iv, additionalData: ad}, key, pt);
+      const dt = await crypto.subtle.decrypt({name: "AES-GCM", iv, additionalData: ad}, key, ct);
+      new Uint8Array(dt).join(',')
+    JS
+    _(::Quickjs.eval_code(code, @options)).must_equal "10,20,30"
+  end
+
+  it "fails to decrypt with wrong iv" do
+    code = <<~JS
+      const rawKey = new Uint8Array(32);
+      const iv1 = new Uint8Array(12).fill(1);
+      const iv2 = new Uint8Array(12).fill(2);
+      const key = await crypto.subtle.importKey("raw", rawKey, {name: "AES-GCM"}, false, ["encrypt", "decrypt"]);
+      const ct = await crypto.subtle.encrypt({name: "AES-GCM", iv: iv1}, key, new Uint8Array([1,2,3]));
+      await crypto.subtle.decrypt({name: "AES-GCM", iv: iv2}, key, ct)
+    JS
+    _ { ::Quickjs.eval_code(code, @options) }.must_raise Quickjs::RuntimeError
+  end
+
+  it "rejects unsupported algorithm" do
+    code = <<~JS
+      const rawKey = new Uint8Array(32);
+      const key = await crypto.subtle.importKey("raw", rawKey, {name: "AES-GCM"}, false, ["encrypt"]);
+      await crypto.subtle.encrypt({name: "AES-XYZ"}, key, new Uint8Array([1]))
+    JS
+    _ { ::Quickjs.eval_code(code, @options) }.must_raise Quickjs::RuntimeError
+  end
+end

--- a/test/quickjs_crypto_subtle_aes_kw_test.rb
+++ b/test/quickjs_crypto_subtle_aes_kw_test.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+describe "crypto.subtle AES-KW wrapKey/unwrapKey" do
+  before do
+    @options = { features: [::Quickjs::POLYFILL_CRYPTO] }
+  end
+
+  it "wraps and unwraps an AES-GCM key round-trip" do
+    code = <<~JS
+      const wrappingKey = await crypto.subtle.generateKey({name: "AES-KW", length: 256}, false, ["wrapKey", "unwrapKey"]);
+      const keyToWrap = await crypto.subtle.generateKey({name: "AES-GCM", length: 256}, true, ["encrypt"]);
+      const wrapped = await crypto.subtle.wrapKey("raw", keyToWrap, wrappingKey, {name: "AES-KW"});
+      const unwrapped = await crypto.subtle.unwrapKey(
+        "raw", wrapped, wrappingKey, {name: "AES-KW"},
+        {name: "AES-GCM", length: 256}, true, ["encrypt"]
+      );
+      unwrapped.algorithm.name
+    JS
+    _(::Quickjs.eval_code(code, @options)).must_equal "AES-GCM"
+  end
+
+  it "wrapped key is 8 bytes longer than the raw key (AES-KW overhead)" do
+    code = <<~JS
+      const wrappingKey = await crypto.subtle.generateKey({name: "AES-KW", length: 128}, false, ["wrapKey"]);
+      const keyToWrap = await crypto.subtle.generateKey({name: "AES-GCM", length: 256}, true, ["encrypt"]);
+      const wrapped = await crypto.subtle.wrapKey("raw", keyToWrap, wrappingKey, {name: "AES-KW"});
+      wrapped.byteLength
+    JS
+    _(::Quickjs.eval_code(code, @options)).must_equal 40
+  end
+
+  it "unwrapped key data matches original" do
+    code = <<~JS
+      const rawKey = new Uint8Array(16).fill(42);
+      const wrappingKey = await crypto.subtle.generateKey({name: "AES-KW", length: 256}, false, ["wrapKey", "unwrapKey"]);
+      const keyToWrap = await crypto.subtle.importKey("raw", rawKey, {name: "AES-GCM"}, true, ["encrypt"]);
+      const wrapped = await crypto.subtle.wrapKey("raw", keyToWrap, wrappingKey, {name: "AES-KW"});
+      const unwrapped = await crypto.subtle.unwrapKey(
+        "raw", wrapped, wrappingKey, {name: "AES-KW"},
+        {name: "AES-GCM", length: 128}, true, ["encrypt"]
+      );
+      const exported = await crypto.subtle.exportKey("raw", unwrapped);
+      new Uint8Array(exported).every((v, i) => v === rawKey[i])
+    JS
+    _(::Quickjs.eval_code(code, @options)).must_equal true
+  end
+end

--- a/test/quickjs_crypto_subtle_ec_test.rb
+++ b/test/quickjs_crypto_subtle_ec_test.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+describe "crypto.subtle EC (ECDSA / ECDH)" do
+  before do
+    @options = { features: [::Quickjs::POLYFILL_CRYPTO] }
+  end
+
+  describe "ECDSA generateKey" do
+    it "returns a key pair with correct properties for P-256" do
+      code = <<~JS
+        const pair = await crypto.subtle.generateKey({name: "ECDSA", namedCurve: "P-256"}, true, ["sign", "verify"]);
+        ({
+          privateType: pair.privateKey.type,
+          publicType: pair.publicKey.type,
+          name: pair.privateKey.algorithm.name,
+          namedCurve: pair.privateKey.algorithm.namedCurve
+        })
+      JS
+      result = ::Quickjs.eval_code(code, @options)
+      _(result["privateType"]).must_equal "private"
+      _(result["publicType"]).must_equal "public"
+      _(result["name"]).must_equal "ECDSA"
+      _(result["namedCurve"]).must_equal "P-256"
+    end
+
+    it "supports P-384 and P-521" do
+      %w[P-384 P-521].each do |curve|
+        code = <<~JS
+          const pair = await crypto.subtle.generateKey({name: "ECDSA", namedCurve: "#{curve}"}, false, ["sign"]);
+          pair.privateKey.algorithm.namedCurve
+        JS
+        _(::Quickjs.eval_code(code, @options)).must_equal curve
+      end
+    end
+  end
+
+  describe "ECDSA exportKey / importKey" do
+    it "exports public key as spki and re-imports it" do
+      code = <<~JS
+        const pair = await crypto.subtle.generateKey({name: "ECDSA", namedCurve: "P-256"}, true, ["sign", "verify"]);
+        const spki = await crypto.subtle.exportKey("spki", pair.publicKey);
+        const imported = await crypto.subtle.importKey("spki", spki, {name: "ECDSA", namedCurve: "P-256"}, true, ["verify"]);
+        imported.type
+      JS
+      _(::Quickjs.eval_code(code, @options)).must_equal "public"
+    end
+
+    it "exports public key as raw and re-imports it" do
+      code = <<~JS
+        const pair = await crypto.subtle.generateKey({name: "ECDSA", namedCurve: "P-256"}, true, ["sign", "verify"]);
+        const raw = await crypto.subtle.exportKey("raw", pair.publicKey);
+        raw.byteLength
+      JS
+      _(::Quickjs.eval_code(code, @options)).must_equal 65
+    end
+
+    it "exports private key as pkcs8 and re-imports it" do
+      code = <<~JS
+        const pair = await crypto.subtle.generateKey({name: "ECDSA", namedCurve: "P-256"}, true, ["sign"]);
+        const pkcs8 = await crypto.subtle.exportKey("pkcs8", pair.privateKey);
+        const imported = await crypto.subtle.importKey("pkcs8", pkcs8, {name: "ECDSA", namedCurve: "P-256"}, true, ["sign"]);
+        imported.type
+      JS
+      _(::Quickjs.eval_code(code, @options)).must_equal "private"
+    end
+  end
+
+  describe "ECDSA sign / verify" do
+    it "sign and verify round-trip with P-256 + SHA-256" do
+      code = <<~JS
+        const pair = await crypto.subtle.generateKey({name: "ECDSA", namedCurve: "P-256"}, false, ["sign", "verify"]);
+        const data = new Uint8Array([1, 2, 3, 4, 5]);
+        const sig = await crypto.subtle.sign({name: "ECDSA", hash: "SHA-256"}, pair.privateKey, data);
+        await crypto.subtle.verify({name: "ECDSA", hash: "SHA-256"}, pair.publicKey, sig, data)
+      JS
+      _(::Quickjs.eval_code(code, @options)).must_equal true
+    end
+
+    it "produces DER-length signature (not P1363)" do
+      code = <<~JS
+        const pair = await crypto.subtle.generateKey({name: "ECDSA", namedCurve: "P-256"}, false, ["sign"]);
+        const sig = await crypto.subtle.sign({name: "ECDSA", hash: "SHA-256"}, pair.privateKey, new Uint8Array(10));
+        sig.byteLength
+      JS
+      sig_len = ::Quickjs.eval_code(code, @options)
+      _(sig_len).must_equal 64
+    end
+
+    it "verify returns false for tampered data" do
+      code = <<~JS
+        const pair = await crypto.subtle.generateKey({name: "ECDSA", namedCurve: "P-256"}, false, ["sign", "verify"]);
+        const data = new Uint8Array([1, 2, 3]);
+        const sig = await crypto.subtle.sign({name: "ECDSA", hash: "SHA-256"}, pair.privateKey, data);
+        await crypto.subtle.verify({name: "ECDSA", hash: "SHA-256"}, pair.publicKey, sig, new Uint8Array([1, 2, 4]))
+      JS
+      _(::Quickjs.eval_code(code, @options)).must_equal false
+    end
+  end
+
+  describe "ECDH key derivation" do
+    it "derives bits from two parties" do
+      code = <<~JS
+        const alice = await crypto.subtle.generateKey({name: "ECDH", namedCurve: "P-256"}, false, ["deriveBits"]);
+        const bob = await crypto.subtle.generateKey({name: "ECDH", namedCurve: "P-256"}, false, ["deriveBits"]);
+        const aliceBits = await crypto.subtle.deriveBits({name: "ECDH", public: bob.publicKey}, alice.privateKey, 128);
+        const bobBits = await crypto.subtle.deriveBits({name: "ECDH", public: alice.publicKey}, bob.privateKey, 128);
+        const a = new Uint8Array(aliceBits);
+        const b = new Uint8Array(bobBits);
+        a.length === b.length && a.every((v, i) => v === b[i])
+      JS
+      _(::Quickjs.eval_code(code, @options)).must_equal true
+    end
+
+    it "derives a key via deriveKey" do
+      code = <<~JS
+        const alice = await crypto.subtle.generateKey({name: "ECDH", namedCurve: "P-256"}, false, ["deriveKey"]);
+        const bob = await crypto.subtle.generateKey({name: "ECDH", namedCurve: "P-256"}, false, ["deriveKey"]);
+        const key = await crypto.subtle.deriveKey(
+          {name: "ECDH", public: bob.publicKey}, alice.privateKey,
+          {name: "AES-GCM", length: 128}, false, ["encrypt"]
+        );
+        key.algorithm.name
+      JS
+      _(::Quickjs.eval_code(code, @options)).must_equal "AES-GCM"
+    end
+  end
+end

--- a/test/quickjs_crypto_subtle_ed25519_test.rb
+++ b/test/quickjs_crypto_subtle_ed25519_test.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+describe "crypto.subtle Ed25519 / X25519" do
+  before do
+    @options = { features: [::Quickjs::POLYFILL_CRYPTO] }
+  end
+
+  describe "Ed25519" do
+    it "generates a key pair with correct properties" do
+      code = <<~JS
+        const pair = await crypto.subtle.generateKey({name: "Ed25519"}, true, ["sign", "verify"]);
+        ({ privateType: pair.privateKey.type, publicType: pair.publicKey.type, name: pair.privateKey.algorithm.name })
+      JS
+      result = ::Quickjs.eval_code(code, @options)
+      _(result["privateType"]).must_equal "private"
+      _(result["publicType"]).must_equal "public"
+      _(result["name"]).must_equal "Ed25519"
+    end
+
+    it "sign and verify round-trip" do
+      code = <<~JS
+        const pair = await crypto.subtle.generateKey({name: "Ed25519"}, false, ["sign", "verify"]);
+        const data = new Uint8Array([1, 2, 3, 4, 5]);
+        const sig = await crypto.subtle.sign("Ed25519", pair.privateKey, data);
+        await crypto.subtle.verify("Ed25519", pair.publicKey, sig, data)
+      JS
+      _(::Quickjs.eval_code(code, @options)).must_equal true
+    end
+
+    it "signature is 64 bytes" do
+      code = <<~JS
+        const pair = await crypto.subtle.generateKey({name: "Ed25519"}, false, ["sign"]);
+        const sig = await crypto.subtle.sign("Ed25519", pair.privateKey, new Uint8Array(10));
+        sig.byteLength
+      JS
+      _(::Quickjs.eval_code(code, @options)).must_equal 64
+    end
+
+    it "verify returns false for tampered data" do
+      code = <<~JS
+        const pair = await crypto.subtle.generateKey({name: "Ed25519"}, false, ["sign", "verify"]);
+        const data = new Uint8Array([1, 2, 3]);
+        const sig = await crypto.subtle.sign("Ed25519", pair.privateKey, data);
+        await crypto.subtle.verify("Ed25519", pair.publicKey, sig, new Uint8Array([1, 2, 4]))
+      JS
+      _(::Quickjs.eval_code(code, @options)).must_equal false
+    end
+
+    it "exports and imports public key (spki)" do
+      code = <<~JS
+        const pair = await crypto.subtle.generateKey({name: "Ed25519"}, true, ["sign", "verify"]);
+        const spki = await crypto.subtle.exportKey("spki", pair.publicKey);
+        const imported = await crypto.subtle.importKey("spki", spki, {name: "Ed25519"}, true, ["verify"]);
+        imported.type
+      JS
+      _(::Quickjs.eval_code(code, @options)).must_equal "public"
+    end
+
+    it "exports public key as raw (32 bytes)" do
+      code = <<~JS
+        const pair = await crypto.subtle.generateKey({name: "Ed25519"}, true, ["sign"]);
+        const raw = await crypto.subtle.exportKey("raw", pair.publicKey);
+        raw.byteLength
+      JS
+      _(::Quickjs.eval_code(code, @options)).must_equal 32
+    end
+
+    it "sign with exported-then-imported key pair" do
+      code = <<~JS
+        const pair = await crypto.subtle.generateKey({name: "Ed25519"}, true, ["sign", "verify"]);
+        const spki = await crypto.subtle.exportKey("spki", pair.publicKey);
+        const pkcs8 = await crypto.subtle.exportKey("pkcs8", pair.privateKey);
+        const pubKey = await crypto.subtle.importKey("spki", spki, {name: "Ed25519"}, true, ["verify"]);
+        const privKey = await crypto.subtle.importKey("pkcs8", pkcs8, {name: "Ed25519"}, true, ["sign"]);
+        const data = new Uint8Array([10, 20, 30]);
+        const sig = await crypto.subtle.sign("Ed25519", privKey, data);
+        await crypto.subtle.verify("Ed25519", pubKey, sig, data)
+      JS
+      _(::Quickjs.eval_code(code, @options)).must_equal true
+    end
+  end
+
+  describe "X25519" do
+    it "generates a key pair with correct properties" do
+      code = <<~JS
+        const pair = await crypto.subtle.generateKey({name: "X25519"}, true, ["deriveKey", "deriveBits"]);
+        ({ privateType: pair.privateKey.type, publicType: pair.publicKey.type, name: pair.privateKey.algorithm.name })
+      JS
+      result = ::Quickjs.eval_code(code, @options)
+      _(result["privateType"]).must_equal "private"
+      _(result["name"]).must_equal "X25519"
+    end
+
+    it "derives same bits for both parties" do
+      code = <<~JS
+        const alice = await crypto.subtle.generateKey({name: "X25519"}, true, ["deriveBits"]);
+        const bob = await crypto.subtle.generateKey({name: "X25519"}, true, ["deriveBits"]);
+        const aliceBits = await crypto.subtle.deriveBits({name: "X25519", public: bob.publicKey}, alice.privateKey, 256);
+        const bobBits = await crypto.subtle.deriveBits({name: "X25519", public: alice.publicKey}, bob.privateKey, 256);
+        const a = new Uint8Array(aliceBits);
+        const b = new Uint8Array(bobBits);
+        a.length === 32 && b.length === 32 && a.every((v, i) => v === b[i])
+      JS
+      _(::Quickjs.eval_code(code, @options)).must_equal true
+    end
+  end
+end

--- a/test/quickjs_crypto_subtle_hmac_test.rb
+++ b/test/quickjs_crypto_subtle_hmac_test.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+describe "crypto.subtle HMAC" do
+  before do
+    @options = { features: [::Quickjs::POLYFILL_CRYPTO] }
+  end
+
+  describe "generateKey" do
+    it "returns a CryptoKey with correct properties" do
+      code = <<~JS
+        const key = await crypto.subtle.generateKey({name: "HMAC", hash: "SHA-256"}, true, ["sign", "verify"]);
+        ({ type: key.type, name: key.algorithm.name, hash: key.algorithm.hash.name, length: key.algorithm.length })
+      JS
+      result = ::Quickjs.eval_code(code, @options)
+      _(result["type"]).must_equal "secret"
+      _(result["name"]).must_equal "HMAC"
+      _(result["hash"]).must_equal "SHA-256"
+      _(result["length"]).must_equal 256
+    end
+
+    it "uses hash output length as default key length" do
+      code = <<~JS
+        const key = await crypto.subtle.generateKey({name: "HMAC", hash: "SHA-512"}, true, ["sign"]);
+        key.algorithm.length
+      JS
+      _(::Quickjs.eval_code(code, @options)).must_equal 512
+    end
+
+    it "respects explicit length" do
+      code = <<~JS
+        const key = await crypto.subtle.generateKey({name: "HMAC", hash: "SHA-256", length: 128}, true, ["sign"]);
+        key.algorithm.length
+      JS
+      _(::Quickjs.eval_code(code, @options)).must_equal 128
+    end
+  end
+
+  describe "importKey / exportKey" do
+    it "imports raw HMAC key and exports it back" do
+      code = <<~JS
+        const raw = new Uint8Array(32).fill(7);
+        const key = await crypto.subtle.importKey("raw", raw, {name: "HMAC", hash: "SHA-256"}, true, ["sign"]);
+        const exported = await crypto.subtle.exportKey("raw", key);
+        new Uint8Array(exported).every((v, i) => v === raw[i]) && exported.byteLength === 32
+      JS
+      _(::Quickjs.eval_code(code, @options)).must_equal true
+    end
+  end
+
+  describe "sign / verify" do
+    it "sign produces a 32-byte MAC for SHA-256" do
+      code = <<~JS
+        const key = await crypto.subtle.importKey("raw", new Uint8Array(32), {name: "HMAC", hash: "SHA-256"}, false, ["sign"]);
+        const sig = await crypto.subtle.sign("HMAC", key, new Uint8Array([1, 2, 3]));
+        sig.byteLength
+      JS
+      _(::Quickjs.eval_code(code, @options)).must_equal 32
+    end
+
+    it "verify returns true for correct signature" do
+      code = <<~JS
+        const key = await crypto.subtle.generateKey({name: "HMAC", hash: "SHA-256"}, false, ["sign", "verify"]);
+        const data = new Uint8Array([10, 20, 30]);
+        const sig = await crypto.subtle.sign("HMAC", key, data);
+        await crypto.subtle.verify("HMAC", key, sig, data)
+      JS
+      _(::Quickjs.eval_code(code, @options)).must_equal true
+    end
+
+    it "verify returns false for wrong signature" do
+      code = <<~JS
+        const key = await crypto.subtle.generateKey({name: "HMAC", hash: "SHA-256"}, false, ["sign", "verify"]);
+        const data = new Uint8Array([10, 20, 30]);
+        const wrongSig = new Uint8Array(32);
+        await crypto.subtle.verify("HMAC", key, wrongSig, data)
+      JS
+      _(::Quickjs.eval_code(code, @options)).must_equal false
+    end
+
+    it "verify returns false for tampered data" do
+      code = <<~JS
+        const key = await crypto.subtle.generateKey({name: "HMAC", hash: "SHA-256"}, false, ["sign", "verify"]);
+        const data = new Uint8Array([10, 20, 30]);
+        const sig = await crypto.subtle.sign("HMAC", key, data);
+        await crypto.subtle.verify("HMAC", key, sig, new Uint8Array([10, 20, 31]))
+      JS
+      _(::Quickjs.eval_code(code, @options)).must_equal false
+    end
+
+    it "sign produces deterministic MAC" do
+      code = <<~JS
+        const key = await crypto.subtle.importKey("raw", new Uint8Array(32).fill(1), {name: "HMAC", hash: "SHA-256"}, false, ["sign"]);
+        const data = new Uint8Array([1, 2, 3]);
+        const s1 = new Uint8Array(await crypto.subtle.sign("HMAC", key, data));
+        const s2 = new Uint8Array(await crypto.subtle.sign("HMAC", key, data));
+        s1.every((v, i) => v === s2[i])
+      JS
+      _(::Quickjs.eval_code(code, @options)).must_equal true
+    end
+  end
+end

--- a/test/quickjs_crypto_subtle_kdf_test.rb
+++ b/test/quickjs_crypto_subtle_kdf_test.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+describe "crypto.subtle KDF (PBKDF2 / HKDF)" do
+  before do
+    @options = { features: [::Quickjs::POLYFILL_CRYPTO] }
+  end
+
+  describe "PBKDF2" do
+    it "importKey accepts raw password" do
+      code = <<~JS
+        const pw = new TextEncoder().encode("password");
+        const key = await crypto.subtle.importKey("raw", pw, "PBKDF2", false, ["deriveBits"]);
+        key.algorithm.name
+      JS
+      _(::Quickjs.eval_code(code, { features: [::Quickjs::POLYFILL_CRYPTO, ::Quickjs::POLYFILL_ENCODING] })).must_equal "PBKDF2"
+    end
+
+    it "deriveBits produces correct length" do
+      code = <<~JS
+        const pw = new Uint8Array([1, 2, 3]);
+        const salt = new Uint8Array(16);
+        const key = await crypto.subtle.importKey("raw", pw, "PBKDF2", false, ["deriveBits"]);
+        const bits = await crypto.subtle.deriveBits(
+          {name: "PBKDF2", salt, iterations: 1000, hash: "SHA-256"}, key, 256
+        );
+        bits.byteLength
+      JS
+      _(::Quickjs.eval_code(code, @options)).must_equal 32
+    end
+
+    it "deriveBits is deterministic" do
+      code = <<~JS
+        const pw = new Uint8Array([42]);
+        const salt = new Uint8Array([1, 2, 3, 4]);
+        const key = await crypto.subtle.importKey("raw", pw, "PBKDF2", false, ["deriveBits"]);
+        const params = {name: "PBKDF2", salt, iterations: 100, hash: "SHA-256"};
+        const b1 = new Uint8Array(await crypto.subtle.deriveBits(params, key, 128));
+        const b2 = new Uint8Array(await crypto.subtle.deriveBits(params, key, 128));
+        b1.every((v, i) => v === b2[i])
+      JS
+      _(::Quickjs.eval_code(code, @options)).must_equal true
+    end
+
+    it "deriveKey produces an AES key" do
+      code = <<~JS
+        const pw = new Uint8Array([1, 2, 3]);
+        const salt = new Uint8Array(16);
+        const key = await crypto.subtle.importKey("raw", pw, "PBKDF2", false, ["deriveKey"]);
+        const derived = await crypto.subtle.deriveKey(
+          {name: "PBKDF2", salt, iterations: 1000, hash: "SHA-256"},
+          key, {name: "AES-GCM", length: 256}, false, ["encrypt"]
+        );
+        derived.algorithm.name
+      JS
+      _(::Quickjs.eval_code(code, @options)).must_equal "AES-GCM"
+    end
+  end
+
+  describe "HKDF" do
+    it "importKey accepts raw key material" do
+      code = <<~JS
+        const ikm = new Uint8Array(32);
+        const key = await crypto.subtle.importKey("raw", ikm, "HKDF", false, ["deriveBits"]);
+        key.algorithm.name
+      JS
+      _(::Quickjs.eval_code(code, @options)).must_equal "HKDF"
+    end
+
+    it "deriveBits produces correct length" do
+      code = <<~JS
+        const ikm = new Uint8Array(32);
+        const key = await crypto.subtle.importKey("raw", ikm, "HKDF", false, ["deriveBits"]);
+        const bits = await crypto.subtle.deriveBits(
+          {name: "HKDF", salt: new Uint8Array(32), info: new Uint8Array(0), hash: "SHA-256"},
+          key, 256
+        );
+        bits.byteLength
+      JS
+      _(::Quickjs.eval_code(code, @options)).must_equal 32
+    end
+
+    it "deriveBits is deterministic" do
+      code = <<~JS
+        const ikm = new Uint8Array([1, 2, 3]);
+        const salt = new Uint8Array([4, 5, 6]);
+        const info = new Uint8Array([7, 8]);
+        const key = await crypto.subtle.importKey("raw", ikm, "HKDF", false, ["deriveBits"]);
+        const params = {name: "HKDF", salt, info, hash: "SHA-256"};
+        const b1 = new Uint8Array(await crypto.subtle.deriveBits(params, key, 128));
+        const b2 = new Uint8Array(await crypto.subtle.deriveBits(params, key, 128));
+        b1.every((v, i) => v === b2[i])
+      JS
+      _(::Quickjs.eval_code(code, @options)).must_equal true
+    end
+
+    it "deriveKey produces an HMAC key" do
+      code = <<~JS
+        const ikm = new Uint8Array(32);
+        const key = await crypto.subtle.importKey("raw", ikm, "HKDF", false, ["deriveKey"]);
+        const derived = await crypto.subtle.deriveKey(
+          {name: "HKDF", salt: new Uint8Array(16), info: new Uint8Array(0), hash: "SHA-256"},
+          key, {name: "HMAC", hash: "SHA-256"}, false, ["sign"]
+        );
+        derived.algorithm.name
+      JS
+      _(::Quickjs.eval_code(code, @options)).must_equal "HMAC"
+    end
+  end
+end

--- a/test/quickjs_crypto_subtle_key_test.rb
+++ b/test/quickjs_crypto_subtle_key_test.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+describe "crypto.subtle key management" do
+  before do
+    @options = { features: [::Quickjs::POLYFILL_CRYPTO] }
+  end
+
+  describe "generateKey" do
+    it "returns a CryptoKey with correct properties for AES-GCM 256" do
+      code = <<~JS
+        const key = await crypto.subtle.generateKey({name: "AES-GCM", length: 256}, true, ["encrypt", "decrypt"]);
+        ({ type: key.type, extractable: key.extractable, name: key.algorithm.name, length: key.algorithm.length, usages: key.usages })
+      JS
+      result = ::Quickjs.eval_code(code, @options)
+      _(result["type"]).must_equal "secret"
+      _(result["extractable"]).must_equal true
+      _(result["name"]).must_equal "AES-GCM"
+      _(result["length"]).must_equal 256
+      _(result["usages"]).must_equal ["encrypt", "decrypt"]
+    end
+
+    it "supports AES-CBC and AES-CTR" do
+      %w[AES-CBC AES-CTR].each do |name|
+        code = "const key = await crypto.subtle.generateKey({name: '#{name}', length: 128}, false, ['encrypt']); key.algorithm.name"
+        _(::Quickjs.eval_code(code, @options)).must_equal name
+      end
+    end
+
+    it "supports 128 and 192 bit key lengths" do
+      [128, 192].each do |len|
+        code = "const key = await crypto.subtle.generateKey({name: 'AES-GCM', length: #{len}}, true, ['encrypt']); key.algorithm.length"
+        _(::Quickjs.eval_code(code, @options)).must_equal len
+      end
+    end
+
+    it "rejects unsupported algorithm" do
+      code = "await crypto.subtle.generateKey({name: 'RSA-PSS', length: 2048}, true, ['sign'])"
+      _ { ::Quickjs.eval_code(code, @options) }.must_raise Quickjs::RuntimeError
+    end
+
+    it "rejects invalid key length" do
+      code = "await crypto.subtle.generateKey({name: 'AES-GCM', length: 512}, true, ['encrypt'])"
+      _ { ::Quickjs.eval_code(code, @options) }.must_raise Quickjs::RuntimeError
+    end
+
+    it "rb_object_id is not enumerable (not included in JSON.stringify)" do
+      code = "const key = await crypto.subtle.generateKey({name: 'AES-GCM', length: 256}, true, ['encrypt']); Object.keys(key).includes('rb_object_id')"
+      _(::Quickjs.eval_code(code, @options)).must_equal false
+    end
+  end
+
+  describe "exportKey" do
+    it "exports a raw AES-GCM key with correct byte length" do
+      code = <<~JS
+        const key = await crypto.subtle.generateKey({name: "AES-GCM", length: 256}, true, ["encrypt", "decrypt"]);
+        const raw = await crypto.subtle.exportKey("raw", key);
+        raw.byteLength
+      JS
+      _(::Quickjs.eval_code(code, @options)).must_equal 32
+    end
+
+    it "exports 128-bit key as 16 bytes" do
+      code = <<~JS
+        const key = await crypto.subtle.generateKey({name: "AES-GCM", length: 128}, true, ["encrypt"]);
+        const raw = await crypto.subtle.exportKey("raw", key);
+        raw.byteLength
+      JS
+      _(::Quickjs.eval_code(code, @options)).must_equal 16
+    end
+
+    it "rejects export of non-extractable key" do
+      code = <<~JS
+        const key = await crypto.subtle.generateKey({name: "AES-GCM", length: 256}, false, ["encrypt"]);
+        await crypto.subtle.exportKey("raw", key)
+      JS
+      _ { ::Quickjs.eval_code(code, @options) }.must_raise Quickjs::RuntimeError
+    end
+  end
+
+  describe "importKey" do
+    it "imports a raw key and returns correct properties" do
+      code = <<~JS
+        const raw = new Uint8Array(32);
+        const key = await crypto.subtle.importKey("raw", raw, {name: "AES-GCM"}, true, ["encrypt", "decrypt"]);
+        ({ type: key.type, name: key.algorithm.name, length: key.algorithm.length })
+      JS
+      result = ::Quickjs.eval_code(code, @options)
+      _(result["type"]).must_equal "secret"
+      _(result["name"]).must_equal "AES-GCM"
+      _(result["length"]).must_equal 256
+    end
+
+    it "round-trips key data through exportKey → importKey → exportKey" do
+      code = <<~JS
+        const key1 = await crypto.subtle.generateKey({name: "AES-GCM", length: 256}, true, ["encrypt"]);
+        const raw1 = await crypto.subtle.exportKey("raw", key1);
+        const key2 = await crypto.subtle.importKey("raw", raw1, {name: "AES-GCM"}, true, ["encrypt"]);
+        const raw2 = await crypto.subtle.exportKey("raw", key2);
+        const a = new Uint8Array(raw1);
+        const b = new Uint8Array(raw2);
+        a.every((v, i) => v === b[i])
+      JS
+      _(::Quickjs.eval_code(code, @options)).must_equal true
+    end
+
+    it "rejects unsupported format" do
+      code = <<~JS
+        const raw = new Uint8Array(32);
+        await crypto.subtle.importKey("jwk", raw, {name: "AES-GCM"}, true, ["encrypt"])
+      JS
+      _ { ::Quickjs.eval_code(code, @options) }.must_raise Quickjs::RuntimeError
+    end
+
+    it "rejects invalid key length" do
+      code = <<~JS
+        const raw = new Uint8Array(10);
+        await crypto.subtle.importKey("raw", raw, {name: "AES-GCM"}, true, ["encrypt"])
+      JS
+      _ { ::Quickjs.eval_code(code, @options) }.must_raise Quickjs::RuntimeError
+    end
+  end
+end

--- a/test/quickjs_crypto_subtle_rsa_oaep_test.rb
+++ b/test/quickjs_crypto_subtle_rsa_oaep_test.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+describe "crypto.subtle RSA-OAEP encrypt/decrypt" do
+  before do
+    @options = { features: [::Quickjs::POLYFILL_CRYPTO] }
+    @algo = "{name: 'RSA-OAEP', modulusLength: 1024, publicExponent: new Uint8Array([1, 0, 1]), hash: 'SHA-256'}"
+  end
+
+  it "encrypts and decrypts round-trip" do
+    code = <<~JS
+      const pair = await crypto.subtle.generateKey(#{@algo}, false, ["encrypt", "decrypt"]);
+      const pt = new Uint8Array([1, 2, 3, 4, 5]);
+      const ct = await crypto.subtle.encrypt({name: "RSA-OAEP"}, pair.publicKey, pt);
+      const dt = await crypto.subtle.decrypt({name: "RSA-OAEP"}, pair.privateKey, ct);
+      new Uint8Array(dt).join(',')
+    JS
+    _(::Quickjs.eval_code(code, @options)).must_equal "1,2,3,4,5"
+  end
+
+  it "ciphertext size equals key modulus size (1024 bit = 128 bytes)" do
+    code = <<~JS
+      const pair = await crypto.subtle.generateKey(#{@algo}, false, ["encrypt"]);
+      const ct = await crypto.subtle.encrypt({name: "RSA-OAEP"}, pair.publicKey, new Uint8Array(5));
+      ct.byteLength
+    JS
+    _(::Quickjs.eval_code(code, @options)).must_equal 128
+  end
+
+  it "fails to decrypt with wrong key" do
+    code = <<~JS
+      const pair1 = await crypto.subtle.generateKey(#{@algo}, false, ["encrypt", "decrypt"]);
+      const pair2 = await crypto.subtle.generateKey(#{@algo}, false, ["encrypt", "decrypt"]);
+      const ct = await crypto.subtle.encrypt({name: "RSA-OAEP"}, pair1.publicKey, new Uint8Array([1, 2, 3]));
+      await crypto.subtle.decrypt({name: "RSA-OAEP"}, pair2.privateKey, ct)
+    JS
+    _ { ::Quickjs.eval_code(code, @options) }.must_raise Quickjs::RuntimeError
+  end
+end

--- a/test/quickjs_crypto_subtle_rsa_test.rb
+++ b/test/quickjs_crypto_subtle_rsa_test.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+describe "crypto.subtle RSA" do
+  before do
+    @options = { features: [::Quickjs::POLYFILL_CRYPTO] }
+    @rsa_algo = "{name: 'RSASSA-PKCS1-v1_5', modulusLength: 1024, publicExponent: new Uint8Array([1, 0, 1]), hash: 'SHA-256'}"
+    @pss_algo = "{name: 'RSA-PSS', modulusLength: 1024, publicExponent: new Uint8Array([1, 0, 1]), hash: 'SHA-256'}"
+  end
+
+  describe "generateKey" do
+    it "returns a key pair with correct properties for RSASSA-PKCS1-v1_5" do
+      code = <<~JS
+        const pair = await crypto.subtle.generateKey(#{@rsa_algo}, true, ["sign", "verify"]);
+        ({
+          privateType: pair.privateKey.type,
+          publicType: pair.publicKey.type,
+          name: pair.privateKey.algorithm.name,
+          hash: pair.privateKey.algorithm.hash.name,
+          modulusLength: pair.privateKey.algorithm.modulusLength
+        })
+      JS
+      result = ::Quickjs.eval_code(code, @options)
+      _(result["privateType"]).must_equal "private"
+      _(result["publicType"]).must_equal "public"
+      _(result["name"]).must_equal "RSASSA-PKCS1-v1_5"
+      _(result["hash"]).must_equal "SHA-256"
+      _(result["modulusLength"]).must_equal 1024
+    end
+
+    it "generates RSA-PSS key pair" do
+      code = "const pair = await crypto.subtle.generateKey(#{@pss_algo}, false, ['sign', 'verify']); pair.privateKey.algorithm.name"
+      _(::Quickjs.eval_code(code, @options)).must_equal "RSA-PSS"
+    end
+  end
+
+  describe "exportKey / importKey" do
+    it "exports public key as spki and re-imports it" do
+      code = <<~JS
+        const pair = await crypto.subtle.generateKey(#{@rsa_algo}, true, ["sign", "verify"]);
+        const spki = await crypto.subtle.exportKey("spki", pair.publicKey);
+        const imported = await crypto.subtle.importKey("spki", spki, {name: "RSASSA-PKCS1-v1_5", hash: "SHA-256"}, true, ["verify"]);
+        imported.type
+      JS
+      _(::Quickjs.eval_code(code, @options)).must_equal "public"
+    end
+
+    it "exports private key as pkcs8 and re-imports it" do
+      code = <<~JS
+        const pair = await crypto.subtle.generateKey(#{@rsa_algo}, true, ["sign", "verify"]);
+        const pkcs8 = await crypto.subtle.exportKey("pkcs8", pair.privateKey);
+        const imported = await crypto.subtle.importKey("pkcs8", pkcs8, {name: "RSASSA-PKCS1-v1_5", hash: "SHA-256"}, true, ["sign"]);
+        imported.type
+      JS
+      _(::Quickjs.eval_code(code, @options)).must_equal "private"
+    end
+  end
+
+  describe "sign / verify with RSASSA-PKCS1-v1_5" do
+    it "sign and verify round-trip" do
+      code = <<~JS
+        const pair = await crypto.subtle.generateKey(#{@rsa_algo}, false, ["sign", "verify"]);
+        const data = new Uint8Array([1, 2, 3, 4, 5]);
+        const sig = await crypto.subtle.sign("RSASSA-PKCS1-v1_5", pair.privateKey, data);
+        await crypto.subtle.verify("RSASSA-PKCS1-v1_5", pair.publicKey, sig, data)
+      JS
+      _(::Quickjs.eval_code(code, @options)).must_equal true
+    end
+
+    it "verify returns false for wrong data" do
+      code = <<~JS
+        const pair = await crypto.subtle.generateKey(#{@rsa_algo}, false, ["sign", "verify"]);
+        const data = new Uint8Array([1, 2, 3]);
+        const sig = await crypto.subtle.sign("RSASSA-PKCS1-v1_5", pair.privateKey, data);
+        await crypto.subtle.verify("RSASSA-PKCS1-v1_5", pair.publicKey, sig, new Uint8Array([1, 2, 4]))
+      JS
+      _(::Quickjs.eval_code(code, @options)).must_equal false
+    end
+  end
+
+  describe "sign / verify with RSA-PSS" do
+    it "sign and verify round-trip" do
+      code = <<~JS
+        const pair = await crypto.subtle.generateKey(#{@pss_algo}, false, ["sign", "verify"]);
+        const data = new Uint8Array([10, 20, 30]);
+        const sig = await crypto.subtle.sign({name: "RSA-PSS", saltLength: 32}, pair.privateKey, data);
+        await crypto.subtle.verify({name: "RSA-PSS", saltLength: 32}, pair.publicKey, sig, data)
+      JS
+      _(::Quickjs.eval_code(code, @options)).must_equal true
+    end
+  end
+end

--- a/test/quickjs_crypto_subtle_test.rb
+++ b/test/quickjs_crypto_subtle_test.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+describe "crypto.subtle" do
+  before do
+    @options = { features: [::Quickjs::POLYFILL_CRYPTO] }
+  end
+
+  it "is not available without the polyfill" do
+    _ { ::Quickjs.eval_code("crypto.subtle.digest('SHA-256', new Uint8Array([1,2,3]))") }.must_raise Quickjs::ReferenceError
+  end
+
+  describe "digest" do
+    it "returns an ArrayBuffer" do
+      code = "const buf = await crypto.subtle.digest('SHA-256', new Uint8Array([1,2,3])); buf.byteLength"
+      _(::Quickjs.eval_code(code, @options)).must_equal 32
+    end
+
+    it "produces correct SHA-256 digest" do
+      code = <<~JS
+        const buf = await crypto.subtle.digest('SHA-256', new Uint8Array([104, 101, 108, 108, 111]));
+        Array.from(new Uint8Array(buf)).map(b => b.toString(16).padStart(2, '0')).join('')
+      JS
+      result = ::Quickjs.eval_code(code, @options)
+      _(result).must_equal "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+    end
+
+    it "produces correct SHA-1 digest" do
+      code = <<~JS
+        const buf = await crypto.subtle.digest('SHA-1', new Uint8Array([104, 101, 108, 108, 111]));
+        buf.byteLength
+      JS
+      _(::Quickjs.eval_code(code, @options)).must_equal 20
+    end
+
+    it "produces correct SHA-384 digest" do
+      code = "const buf = await crypto.subtle.digest('SHA-384', new Uint8Array([1])); buf.byteLength"
+      _(::Quickjs.eval_code(code, @options)).must_equal 48
+    end
+
+    it "produces correct SHA-512 digest" do
+      code = "const buf = await crypto.subtle.digest('SHA-512', new Uint8Array([1])); buf.byteLength"
+      _(::Quickjs.eval_code(code, @options)).must_equal 64
+    end
+
+    it "accepts algorithm as an object with name property" do
+      code = "const buf = await crypto.subtle.digest({ name: 'SHA-256' }, new Uint8Array([1,2,3])); buf.byteLength"
+      _(::Quickjs.eval_code(code, @options)).must_equal 32
+    end
+
+    it "accepts ArrayBuffer as data" do
+      code = <<~JS
+        const buf = new ArrayBuffer(3);
+        new Uint8Array(buf).set([1, 2, 3]);
+        const result = await crypto.subtle.digest('SHA-256', buf);
+        result.byteLength
+      JS
+      _(::Quickjs.eval_code(code, @options)).must_equal 32
+    end
+
+    it "rejects unsupported algorithm" do
+      code = "await crypto.subtle.digest('MD5', new Uint8Array([1,2,3]))"
+      _ { ::Quickjs.eval_code(code, @options) }.must_raise Quickjs::RuntimeError
+    end
+  end
+end

--- a/test/quickjs_polyfill_test.rb
+++ b/test/quickjs_polyfill_test.rb
@@ -668,3 +668,80 @@ describe "JS Blob to Ruby" do
     _(result.size).must_equal 0
   end
 end
+
+describe "PolyfillCrypto" do
+  before do
+    @options = { features: [::Quickjs::POLYFILL_CRYPTO] }
+  end
+
+  it "is not available without the polyfill" do
+    _ { ::Quickjs.eval_code("crypto.getRandomValues(new Uint8Array(8))") }.must_raise Quickjs::ReferenceError
+  end
+
+  describe "getRandomValues" do
+    it "fills a Uint8Array with random bytes" do
+      code = "const a = new Uint8Array(16); crypto.getRandomValues(a); a.length"
+      _(::Quickjs.eval_code(code, @options)).must_equal 16
+    end
+
+    it "returns the same typed array" do
+      code = <<~JS
+        const a = new Uint8Array(8);
+        const b = crypto.getRandomValues(a);
+        a === b
+      JS
+      _(::Quickjs.eval_code(code, @options)).must_equal true
+    end
+
+    it "actually fills bytes (not all zero)" do
+      code = "Array.from(crypto.getRandomValues(new Uint8Array(32))).some(b => b !== 0)"
+      _(::Quickjs.eval_code(code, @options)).must_equal true
+    end
+
+    it "works with Uint32Array" do
+      code = "crypto.getRandomValues(new Uint32Array(4)).length"
+      _(::Quickjs.eval_code(code, @options)).must_equal 4
+    end
+
+    it "works with Int8Array" do
+      code = "crypto.getRandomValues(new Int8Array(8)).length"
+      _(::Quickjs.eval_code(code, @options)).must_equal 8
+    end
+
+    it "throws TypeError for Float32Array" do
+      code = "crypto.getRandomValues(new Float32Array(4))"
+      _ { ::Quickjs.eval_code(code, @options) }.must_raise Quickjs::TypeError
+    end
+
+    it "throws TypeError for Float64Array" do
+      code = "crypto.getRandomValues(new Float64Array(4))"
+      _ { ::Quickjs.eval_code(code, @options) }.must_raise Quickjs::TypeError
+    end
+
+    it "throws RangeError when byte length exceeds 65536" do
+      code = "crypto.getRandomValues(new Uint8Array(65537))"
+      _ { ::Quickjs.eval_code(code, @options) }.must_raise Quickjs::RangeError
+    end
+
+    it "throws TypeError for non-TypedArray argument" do
+      code = "crypto.getRandomValues({})"
+      _ { ::Quickjs.eval_code(code, @options) }.must_raise Quickjs::TypeError
+    end
+  end
+
+  describe "randomUUID" do
+    it "returns a string" do
+      _(::Quickjs.eval_code("typeof crypto.randomUUID()", @options)).must_equal "string"
+    end
+
+    it "matches UUID v4 format" do
+      uuid = ::Quickjs.eval_code("crypto.randomUUID()", @options)
+      _(uuid).must_match(/\A[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\z/)
+    end
+
+    it "returns different values on each call" do
+      code = "crypto.randomUUID() === crypto.randomUUID()"
+      _(::Quickjs.eval_code(code, @options)).must_equal false
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `Quickjs::POLYFILL_CRYPTO` feature flag that exposes the Web Crypto API to JS
- `crypto.getRandomValues` and `crypto.randomUUID` via C extension
- `crypto.subtle` fully implemented in Ruby backed by OpenSSL:
  - `digest` (SHA-1/256/384/512)
  - `generateKey`, `importKey`, `exportKey` for AES, RSA, EC, Ed25519, X25519, HMAC
  - `encrypt` / `decrypt` for AES-GCM, AES-CBC, AES-CTR, RSA-OAEP
  - `sign` / `verify` for RSASSA-PKCS1-v1_5, RSA-PSS, ECDSA, Ed25519, HMAC
  - `deriveBits` / `deriveKey` for ECDH, X25519, HKDF, PBKDF2
  - `wrapKey` / `unwrapKey`
- Bumps `required_ruby_version` to `>= 3.1.0` (`OpenSSL::PKey.generate_key` required for Ed25519/X25519)

## Test plan

- [ ] CI passes on Ruby 3.2/3.3/4.0 × Ubuntu/macOS
- [ ] `Quickjs.eval_code("crypto.randomUUID()", features: [Quickjs::POLYFILL_CRYPTO])` returns a UUID string
- [ ] `crypto.subtle` operations round-trip (generate → export → import → sign → verify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)