### PR TITLE
Add Quickjs::VM#call to invoke a JS function with Ruby args

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,29 @@ vm.eval_code('a.b = "d";')
 vm.eval_code('a.b;') #=> "d"
 ```
 
+#### `Quickjs::VM#call`: ⚡ Call a JS function directly with Ruby arguments
+
+```rb
+vm = Quickjs::VM.new
+vm.eval_code('function add(a, b) { return a + b; }')
+
+vm.call('add', 1, 2)           #=> 3
+vm.call(:add, 1, 2)            #=> 3  (Symbol also works)
+
+# Nested functions — preserves `this` binding
+vm.eval_code('const counter = { n: 0, inc() { return ++this.n; } }')
+vm.call('counter.inc')         #=> 1
+vm.call('counter.inc')         #=> 2
+
+# Keys with special characters via bracket notation
+vm.eval_code("const obj = {}; obj['my-fn'] = x => x * 2;")
+vm.call('obj["my-fn"]', 21)    #=> 42
+
+# Async functions are automatically awaited
+vm.eval_code('async function fetchVal() { return 42; }')
+vm.call('fetchVal')            #=> 42
+```
+
 #### `Quickjs::VM#import`: 🔌 Import ESM from a source code
 
 ```rb

--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -722,6 +722,20 @@ static int interrupt_handler(JSRuntime *runtime, void *opaque)
   return elapsed_ms >= eval_time->limit_ms ? 1 : 0;
 }
 
+static VALUE to_rb_return_value(JSContext *ctx, JSValue j_val)
+{
+  if (JS_VALUE_GET_NORM_TAG(j_val) == JS_TAG_OBJECT && JS_PromiseState(ctx, j_val) != -1)
+  {
+    JS_FreeValue(ctx, j_val);
+    VALUE r_error_message = rb_str_new2("An unawaited Promise was returned to the top-level");
+    rb_exc_raise(rb_funcall(QUICKJSRB_ERROR_FOR(QUICKJSRB_NO_AWAIT_ERROR), rb_intern("new"), 2, r_error_message, Qnil));
+    return Qnil;
+  }
+  VALUE result = to_rb_value(ctx, j_val);
+  JS_FreeValue(ctx, j_val);
+  return result;
+}
+
 static VALUE vm_m_evalCode(VALUE r_self, VALUE r_code)
 {
   VMData *data;
@@ -799,6 +813,148 @@ static VALUE vm_m_defineGlobalFunction(int argc, VALUE *argv, VALUE r_self)
   return r_name_sym;
 }
 
+static VALUE vm_m_callGlobalFunction(int argc, VALUE *argv, VALUE r_self)
+{
+  if (argc < 1)
+    rb_raise(rb_eArgError, "wrong number of arguments (given 0, expected 1+)");
+
+  VALUE r_name = argv[0];
+
+  VMData *data;
+  TypedData_Get_Struct(r_self, VMData, &vm_type, data);
+
+  JSValue j_this = JS_UNDEFINED;
+  JSValue j_func;
+
+  VALUE r_path;
+  if (rb_obj_is_kind_of(r_name, rb_cArray))
+  {
+    if (RARRAY_LEN(r_name) == 0)
+      rb_raise(rb_eArgError, "function path must not be empty");
+    r_path = r_name;
+  }
+  else if (SYMBOL_P(r_name) || RB_TYPE_P(r_name, T_STRING))
+  {
+    VALUE r_name_str = rb_funcall(r_name, rb_intern("to_s"), 0);
+    const char *name_str = StringValueCStr(r_name_str);
+    size_t name_len = strlen(name_str);
+    const char *last_bracket = strrchr(name_str, '[');
+    const char *last_dot = strrchr(name_str, '.');
+
+    if (last_bracket != NULL && last_bracket != name_str && name_str[name_len - 1] == ']')
+    {
+      // Bracket notation: 'a["key"]' or 'a.b["key"]' or 'a[0]'
+      // Split into parent expression and the bracketed key
+      VALUE r_parent = rb_str_new(name_str, last_bracket - name_str);
+      const char *key_start = last_bracket + 1;
+      size_t key_len = name_len - (key_start - name_str) - 1; // exclude ']'
+      // Strip surrounding quotes for string keys: 'a["b"]' → key = b
+      if (key_len >= 2 &&
+          ((key_start[0] == '\'' && key_start[key_len - 1] == '\'') ||
+           (key_start[0] == '"' && key_start[key_len - 1] == '"')))
+      {
+        key_start++;
+        key_len -= 2;
+      }
+      VALUE r_key = rb_str_new(key_start, key_len);
+      r_path = rb_ary_new3(2, r_parent, r_key);
+    }
+    else if (last_dot != NULL && last_dot != name_str)
+    {
+      // Dot notation: 'a.b.c' → ['a.b', 'c'] so the parent becomes `this`
+      VALUE r_parent = rb_str_new(name_str, last_dot - name_str);
+      VALUE r_key = rb_str_new2(last_dot + 1);
+      r_path = rb_ary_new3(2, r_parent, r_key);
+    }
+    else
+    {
+      r_path = rb_ary_new3(1, r_name_str);
+    }
+  }
+  else
+  {
+    rb_raise(rb_eTypeError, "function's name should be a Symbol, a String, or an Array of them");
+  }
+
+  {
+    long path_len = RARRAY_LEN(r_path);
+
+    VALUE r_first = RARRAY_AREF(r_path, 0);
+    if (!(SYMBOL_P(r_first) || RB_TYPE_P(r_first, T_STRING)))
+      rb_raise(rb_eTypeError, "function path elements should be Symbols or Strings");
+
+    VALUE r_first_str = rb_funcall(r_first, rb_intern("to_s"), 0);
+    const char *first_seg = StringValueCStr(r_first_str);
+
+    // JS_Eval accesses both global object properties and lexical (const/let) bindings
+    JSValue j_cur = JS_Eval(data->context, first_seg, strlen(first_seg), "<vm>", JS_EVAL_TYPE_GLOBAL);
+    if (JS_IsException(j_cur))
+      return to_rb_value(data->context, j_cur); // raises
+
+    for (long i = 1; i < path_len; i++)
+    {
+      VALUE r_seg = RARRAY_AREF(r_path, i);
+      if (!(SYMBOL_P(r_seg) || RB_TYPE_P(r_seg, T_STRING)))
+      {
+        JS_FreeValue(data->context, j_cur);
+        JS_FreeValue(data->context, j_this);
+        rb_raise(rb_eTypeError, "function path elements should be Symbols or Strings");
+      }
+      VALUE r_seg_str = rb_funcall(r_seg, rb_intern("to_s"), 0);
+      const char *seg = StringValueCStr(r_seg_str);
+
+      JSValue j_next = JS_GetPropertyStr(data->context, j_cur, seg);
+      if (JS_IsException(j_next))
+      {
+        JS_FreeValue(data->context, j_cur);
+        JS_FreeValue(data->context, j_this);
+        return to_rb_value(data->context, j_next); // raises
+      }
+
+      JS_FreeValue(data->context, j_this);
+      j_this = j_cur;
+      j_cur = j_next;
+    }
+
+    j_func = j_cur;
+  }
+
+  if (!JS_IsFunction(data->context, j_func))
+  {
+    JS_FreeValue(data->context, j_func);
+    JS_FreeValue(data->context, j_this);
+    VALUE r_error_message = rb_str_new2("given path is not a function");
+    rb_exc_raise(rb_funcall(QUICKJSRB_ERROR_FOR(QUICKJSRB_ROOT_RUNTIME_ERROR), rb_intern("new"), 2, r_error_message, Qnil));
+    return Qnil;
+  }
+
+  int nargs = argc - 1;
+  JSValue *j_args = NULL;
+  if (nargs > 0)
+  {
+    j_args = (JSValue *)malloc(sizeof(JSValue) * nargs);
+    for (int i = 0; i < nargs; i++)
+      j_args[i] = to_js_value(data->context, argv[i + 1]);
+  }
+
+  clock_gettime(CLOCK_MONOTONIC, &data->eval_time->started_at);
+  JS_SetInterruptHandler(JS_GetRuntime(data->context), interrupt_handler, data->eval_time);
+
+  JSValue j_result = JS_Call(data->context, j_func, j_this, nargs, (JSValueConst *)j_args);
+
+  JS_FreeValue(data->context, j_func);
+  JS_FreeValue(data->context, j_this);
+  if (j_args)
+  {
+    for (int i = 0; i < nargs; i++)
+      JS_FreeValue(data->context, j_args[i]);
+    free(j_args);
+  }
+
+  // js_std_await handles both async (promise) and sync results; frees j_result
+  return to_rb_return_value(data->context, js_std_await(data->context, j_result));
+}
+
 static VALUE vm_m_import(int argc, VALUE *argv, VALUE r_self)
 {
   VALUE r_import_string, r_opts;
@@ -872,6 +1028,7 @@ RUBY_FUNC_EXPORTED void Init_quickjsrb(void)
   rb_define_alloc_func(r_class_vm, vm_alloc);
   rb_define_method(r_class_vm, "initialize", vm_m_initialize, -1);
   rb_define_method(r_class_vm, "eval_code", vm_m_evalCode, 1);
+  rb_define_method(r_class_vm, "call", vm_m_callGlobalFunction, -1);
   rb_define_method(r_class_vm, "define_function", vm_m_defineGlobalFunction, -1);
   rb_define_method(r_class_vm, "import", vm_m_import, -1);
   rb_define_method(r_class_vm, "on_log", vm_m_on_log, 0);

--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -753,26 +753,11 @@ static VALUE vm_m_evalCode(VALUE r_self, VALUE r_code)
   char *code = StringValueCStr(r_code);
   JSValue j_codeResult = JS_Eval(data->context, code, strlen(code), "<code>", JS_EVAL_TYPE_GLOBAL | JS_EVAL_FLAG_ASYNC);
   JSValue j_awaitedResult = js_std_await(data->context, j_codeResult); // This frees j_codeResult
+  // JS_EVAL_FLAG_ASYNC wraps the result in {value, done} — extract the actual value
+  // Free j_awaitedResult before to_rb_return_value because it may raise (longjmp), which would skip cleanup
   JSValue j_returnedValue = JS_GetPropertyStr(data->context, j_awaitedResult, "value");
-  // Do this by rescuing to_rb_value
-  if (JS_VALUE_GET_NORM_TAG(j_returnedValue) == JS_TAG_OBJECT && JS_PromiseState(data->context, j_returnedValue) != -1)
-  {
-    JS_FreeValue(data->context, j_returnedValue);
-    JS_FreeValue(data->context, j_awaitedResult);
-    VALUE r_error_message = rb_str_new2("An unawaited Promise was returned to the top-level");
-    rb_exc_raise(rb_funcall(QUICKJSRB_ERROR_FOR(QUICKJSRB_NO_AWAIT_ERROR), rb_intern("new"), 2, r_error_message, Qnil));
-    return Qnil;
-  }
-  else
-  {
-    // Free j_awaitedResult before to_rb_value because to_rb_value may
-    // raise (longjmp) for JS exceptions, which would skip any cleanup
-    // after it and leak JS GC objects.
-    JS_FreeValue(data->context, j_awaitedResult);
-    VALUE result = to_rb_value(data->context, j_returnedValue);
-    JS_FreeValue(data->context, j_returnedValue);
-    return result;
-  }
+  JS_FreeValue(data->context, j_awaitedResult);
+  return to_rb_return_value(data->context, j_returnedValue);
 }
 
 static VALUE vm_m_defineGlobalFunction(int argc, VALUE *argv, VALUE r_self)

--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -812,13 +812,7 @@ static VALUE vm_m_callGlobalFunction(int argc, VALUE *argv, VALUE r_self)
   JSValue j_func;
 
   VALUE r_path;
-  if (rb_obj_is_kind_of(r_name, rb_cArray))
-  {
-    if (RARRAY_LEN(r_name) == 0)
-      rb_raise(rb_eArgError, "function path must not be empty");
-    r_path = r_name;
-  }
-  else if (SYMBOL_P(r_name) || RB_TYPE_P(r_name, T_STRING))
+  if (SYMBOL_P(r_name) || RB_TYPE_P(r_name, T_STRING))
   {
     VALUE r_name_str = rb_funcall(r_name, rb_intern("to_s"), 0);
     const char *name_str = StringValueCStr(r_name_str);
@@ -858,7 +852,7 @@ static VALUE vm_m_callGlobalFunction(int argc, VALUE *argv, VALUE r_self)
   }
   else
   {
-    rb_raise(rb_eTypeError, "function's name should be a Symbol, a String, or an Array of them");
+    rb_raise(rb_eTypeError, "function's name should be a Symbol or a String");
   }
 
   {

--- a/sig/quickjs.rbs
+++ b/sig/quickjs.rbs
@@ -7,6 +7,9 @@ module Quickjs
   POLYFILL_INTL: Symbol
   POLYFILL_FILE: Symbol
   POLYFILL_HTML_BASE64: Symbol
+  POLYFILL_ENCODING: Symbol
+  POLYFILL_URL: Symbol
+  POLYFILL_CRYPTO: Symbol
 
   def self.eval_code: (String code, ?Hash[Symbol, untyped] overwrite_opts) -> untyped
 
@@ -19,6 +22,8 @@ module Quickjs
     def initialize: (?features: Array[Symbol], ?memory_limit: Integer, ?max_stack_size: Integer, ?timeout_msec: Integer) -> void
 
     def eval_code: (String code) -> untyped
+
+    def call: (String | Symbol name, *untyped args) -> untyped
 
     def define_function: (String | Symbol name, *Symbol flags) { (*untyped) -> untyped } -> Symbol
 

--- a/sig/quickjs.rbs
+++ b/sig/quickjs.rbs
@@ -29,7 +29,7 @@ module Quickjs
 
     def import: (String | Array[String] | Hash[Symbol, String] imported, from: String, ?code_to_expose: String?) -> true
 
-    def logs: () -> Array[Log]
+    def on_log: () { (Log) -> void } -> nil
 
     class Log
       attr_reader severity: Symbol

--- a/test/quickjs_rbs_test.rb
+++ b/test/quickjs_rbs_test.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "rbs"
+require "pathname"
+
+describe "RBS completeness" do
+  before do
+    env = RBS::Environment.new
+    loader = RBS::EnvironmentLoader.new
+    loader.add(path: Pathname(File.expand_path("../sig", __dir__)))
+    loader.load(env: env)
+    @env = env.resolve_type_names
+    @builder = RBS::DefinitionBuilder.new(env: @env)
+  end
+
+  it "declares all public Quickjs::VM instance methods" do
+    type_name = RBS::TypeName.parse("::Quickjs::VM")
+    rbs_methods = @env.class_decls[type_name].decls
+      .flat_map { |d| d.decl.members.grep(RBS::AST::Members::MethodDefinition) }
+      .reject { |m| m.kind == :singleton || m.name.to_s == "initialize" }
+      .map { |m| m.name.to_s }
+      .to_set
+
+    actual = Quickjs::VM.public_instance_methods(false).map(&:to_s).to_set
+    missing = actual - rbs_methods
+    assert missing.empty?, "VM methods missing from RBS: #{missing.sort.join(", ")}"
+    stale = rbs_methods - actual
+    assert stale.empty?, "RBS declares non-existent VM methods: #{stale.sort.join(", ")}"
+  end
+
+  it "declares all Quickjs Symbol constants" do
+    rbs_constants = @env.constant_decls.keys
+      .select { |name| name.namespace.absolute? && name.namespace.path == [:Quickjs] }
+      .map { |name| name.name.to_s }
+      .to_set
+
+    actual = Quickjs.constants
+      .select { |c| Quickjs.const_get(c).is_a?(Symbol) }
+      .map(&:to_s)
+      .to_set
+
+    missing = actual - rbs_constants
+    assert missing.empty?, "Quickjs constants missing from RBS: #{missing.sort.join(", ")}"
+  end
+end

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -484,50 +484,11 @@ describe Quickjs::VM do
       _(@vm.call('obj["🎉"]', 'party')).must_equal 'party!'
     end
 
-    it "supports Array path with emoji key" do
-      @vm.eval_code("const obj = {}; obj['🎉'] = function() { return 'tada'; };")
-      _(@vm.call(['obj', '🎉'])).must_equal 'tada'
-    end
-
     it "supports mixed dot and bracket notation" do
       @vm.eval_code("const a = { b: {} }; a.b['c-d'] = function() { return 'mixed'; };")
       _(@vm.call('a.b["c-d"]')).must_equal 'mixed'
     end
 
-    it "calls a nested function via Array path" do
-      @vm.eval_code("const obj = { greet: function(name) { return 'hello ' + name; } };")
-      _(@vm.call(['obj', 'greet'], 'Alice')).must_equal 'hello Alice'
-    end
-
-    it "preserves this binding for nested method calls" do
-      @vm.eval_code("const counter = { count: 0, increment: function() { this.count++; return this.count; } };")
-      _(@vm.call(['counter', 'increment'])).must_equal 1
-      _(@vm.call(['counter', 'increment'])).must_equal 2
-    end
-
-    it "supports deeply nested paths" do
-      @vm.eval_code("const a = { b: { c: function() { return 42; } } };")
-      _(@vm.call(['a', 'b', 'c'])).must_equal 42
-    end
-
-    it "raises TypeError when path contains a non-String/Symbol" do
-      _ { @vm.call([42]) }.must_raise TypeError
-    end
-
-    it "raises ArgumentError for empty path array" do
-      _ { @vm.call([]) }.must_raise ArgumentError
-    end
-
-    it "raises RuntimeError when path does not lead to a function" do
-      @vm.eval_code("const obj = { x: 1 };")
-      err = _ { @vm.call(['obj', 'x']) }.must_raise Quickjs::RuntimeError
-      _(err.message).must_equal 'given path is not a function'
-    end
-
-    it "raises a JS TypeError when traversing through a non-object" do
-      @vm.eval_code("const obj = { x: null };")
-      _ { @vm.call(['obj', 'x', 'method']) }.must_raise Quickjs::TypeError
-    end
   end
 
   describe "Import" do

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -389,6 +389,147 @@ describe Quickjs::VM do
     end
   end
 
+  describe "Call" do
+    before do
+      @vm = Quickjs::VM.new
+    end
+
+    it "calls a global function with no args" do
+      @vm.eval_code("function greet() { return 'hello'; }")
+      _(@vm.call('greet')).must_equal 'hello'
+    end
+
+    it "accepts a Symbol as function name" do
+      @vm.eval_code("function greet() { return 'hello'; }")
+      _(@vm.call(:greet)).must_equal 'hello'
+    end
+
+    it "passes primitive args" do
+      @vm.eval_code("function add(a, b) { return a + b; }")
+      _(@vm.call('add', 1, 2)).must_equal 3
+    end
+
+    it "passes hash as object" do
+      @vm.eval_code("function getName(obj) { return obj.name; }")
+      _(@vm.call('getName', { name: 'Alice' })).must_equal 'Alice'
+    end
+
+    it "passes array arg" do
+      @vm.eval_code("function sum(arr) { return arr.reduce((a, b) => a + b, 0); }")
+      _(@vm.call('sum', [1, 2, 3])).must_equal 6
+    end
+
+    it "passes mixed args" do
+      @vm.eval_code("function format(tmpl, data) { return tmpl.replace('{name}', data.name); }")
+      _(@vm.call('format', 'Hello, {name}!', { name: 'Bob' })).must_equal 'Hello, Bob!'
+    end
+
+    it "passes nil as null" do
+      @vm.eval_code("function isNull(v) { return v === null; }")
+      _(@vm.call('isNull', nil)).must_equal true
+    end
+
+    it "automatically awaits async functions" do
+      @vm.eval_code("async function asyncGreet() { return 'async hello'; }")
+      _(@vm.call('asyncGreet')).must_equal 'async hello'
+    end
+
+    it "raises ReferenceError when the name is not defined" do
+      _ { @vm.call('nonExistent') }.must_raise Quickjs::ReferenceError
+    end
+
+    it "raises RuntimeError when the path resolves to a non-function" do
+      err = _ { @vm.call('console') }.must_raise Quickjs::RuntimeError
+      _(err.message).must_equal 'given path is not a function'
+    end
+
+    it "raises TypeError when function name is not a String or Symbol" do
+      _ { @vm.call(42) }.must_raise TypeError
+    end
+
+    it "raises an error raised within the function" do
+      @vm.eval_code("function boom() { throw new TypeError('bang'); }")
+      err = _ { @vm.call('boom') }.must_raise Quickjs::TypeError
+      _(err.message).must_equal 'bang'
+    end
+
+    it "calls a nested function via dot-notation string" do
+      @vm.eval_code("const obj = { greet: function(name) { return 'hello ' + name; } };")
+      _(@vm.call('obj.greet', 'Alice')).must_equal 'hello Alice'
+    end
+
+    it "preserves this binding with dot-notation string" do
+      @vm.eval_code("const counter = { count: 0, increment: function() { this.count++; return this.count; } };")
+      _(@vm.call('counter.increment')).must_equal 1
+      _(@vm.call('counter.increment')).must_equal 2
+    end
+
+    it "supports deeply nested dot-notation string" do
+      @vm.eval_code("const a = { b: { c: function() { return 42; } } };")
+      _(@vm.call('a.b.c')).must_equal 42
+    end
+
+    it "calls a nested function via bracket-notation string" do
+      @vm.eval_code("const obj = { greet: function(name) { return 'hello ' + name; } };")
+      _(@vm.call('obj["greet"]', 'Alice')).must_equal 'hello Alice'
+    end
+
+    it "supports bracket notation for keys with special characters" do
+      @vm.eval_code("const obj = {}; obj['my-func'] = function(x) { return x * 2; };")
+      _(@vm.call('obj["my-func"]', 21)).must_equal 42
+    end
+
+    it "supports bracket notation for emoji keys" do
+      @vm.eval_code("const obj = {}; obj['🎉'] = function(x) { return x + '!'; };")
+      _(@vm.call('obj["🎉"]', 'party')).must_equal 'party!'
+    end
+
+    it "supports Array path with emoji key" do
+      @vm.eval_code("const obj = {}; obj['🎉'] = function() { return 'tada'; };")
+      _(@vm.call(['obj', '🎉'])).must_equal 'tada'
+    end
+
+    it "supports mixed dot and bracket notation" do
+      @vm.eval_code("const a = { b: {} }; a.b['c-d'] = function() { return 'mixed'; };")
+      _(@vm.call('a.b["c-d"]')).must_equal 'mixed'
+    end
+
+    it "calls a nested function via Array path" do
+      @vm.eval_code("const obj = { greet: function(name) { return 'hello ' + name; } };")
+      _(@vm.call(['obj', 'greet'], 'Alice')).must_equal 'hello Alice'
+    end
+
+    it "preserves this binding for nested method calls" do
+      @vm.eval_code("const counter = { count: 0, increment: function() { this.count++; return this.count; } };")
+      _(@vm.call(['counter', 'increment'])).must_equal 1
+      _(@vm.call(['counter', 'increment'])).must_equal 2
+    end
+
+    it "supports deeply nested paths" do
+      @vm.eval_code("const a = { b: { c: function() { return 42; } } };")
+      _(@vm.call(['a', 'b', 'c'])).must_equal 42
+    end
+
+    it "raises TypeError when path contains a non-String/Symbol" do
+      _ { @vm.call([42]) }.must_raise TypeError
+    end
+
+    it "raises ArgumentError for empty path array" do
+      _ { @vm.call([]) }.must_raise ArgumentError
+    end
+
+    it "raises RuntimeError when path does not lead to a function" do
+      @vm.eval_code("const obj = { x: 1 };")
+      err = _ { @vm.call(['obj', 'x']) }.must_raise Quickjs::RuntimeError
+      _(err.message).must_equal 'given path is not a function'
+    end
+
+    it "raises a JS TypeError when traversing through a non-object" do
+      @vm.eval_code("const obj = { x: null };")
+      _ { @vm.call(['obj', 'x', 'method']) }.must_raise Quickjs::TypeError
+    end
+  end
+
   describe "Import" do
     before do
       @vm = Quickjs::VM.new


### PR DESCRIPTION
## Summary

- Adds `VM#call(name, *args)` to invoke a named JavaScript function directly with Ruby arguments
- Supports dot notation (`'counter.inc'`), bracket notation (`'obj["my-fn"]'`), and Symbol/String names
- Async functions are automatically awaited
- Extracts `to_rb_return_value` shared helper between `eval_code` and `call`

## Examples

```rb
vm = Quickjs::VM.new
vm.eval_code('function add(a, b) { return a + b; }')
vm.call('add', 1, 2)           #=> 3
vm.call(:add, 1, 2)            #=> 3

# Nested — preserves `this` binding
vm.eval_code('const counter = { n: 0, inc() { return ++this.n; } }')
vm.call('counter.inc')         #=> 1
vm.call('counter.inc')         #=> 2

# Keys with special characters via bracket notation
vm.eval_code("const obj = {}; obj['my-fn'] = x => x * 2;")
vm.call('obj["my-fn"]', 21)    #=> 42

# Async — automatically awaited
vm.eval_code('async function fetchVal() { return 42; }')
vm.call('fetchVal')            #=> 42
```

## Test plan

- [ ] `bundle exec rake` passes on Ruby 3.2 / 3.3 / 3.4
- [ ] New `describe "Call"` block in `quickjs_test.rb` covers: basic call, Symbol name, async, dot/bracket notation, error propagation

🤖 Generated with [Claude Code](https://claude.com/claude-code)