### PR TITLE
Add Quickjs::Function to represent JS functions in Ruby

### DIFF
--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -287,6 +287,18 @@ VALUE to_rb_value(JSContext *ctx, JSValue j_val)
       return Qnil;
     }
 
+    if (JS_IsFunction(ctx, j_val))
+    {
+      JSValue j_toStringFunc = JS_GetPropertyStr(ctx, j_val, "toString");
+      JSValue j_source = JS_Call(ctx, j_toStringFunc, j_val, 0, NULL);
+      JS_FreeValue(ctx, j_toStringFunc);
+      const char *source = JS_ToCString(ctx, j_source);
+      JS_FreeValue(ctx, j_source);
+      VALUE r_source = rb_str_new2(source);
+      JS_FreeCString(ctx, source);
+      return rb_funcall(rb_path2class("Quickjs::Function"), rb_intern("new"), 1, r_source);
+    }
+
     if (JS_IsError(ctx, j_val))
     {
       VALUE r_maybe_ruby_error = find_ruby_error(ctx, j_val);

--- a/lib/quickjs.rb
+++ b/lib/quickjs.rb
@@ -5,6 +5,7 @@ require "timeout"
 require_relative "quickjs/version"
 require_relative "quickjs/subtle_crypto"
 require_relative "quickjs/crypto_key"
+require_relative "quickjs/function"
 require_relative "quickjs/quickjsrb"
 
 module Quickjs

--- a/lib/quickjs/function.rb
+++ b/lib/quickjs/function.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'json'
+
+module Quickjs
+  class Function
+    def initialize(source)
+      @source = source
+    end
+
+    def source
+      @source
+    end
+
+    def call(*args, on: nil)
+      case on
+      when Quickjs::VM
+        _call_on(on, args)
+      when nil, Hash
+        vm = Quickjs::VM.new(**on || {})
+        res = _call_on(vm, args)
+        vm = nil
+        res
+      else
+        raise ArgumentError, 'on: must be a Quickjs::VM, a Hash of VM options, or nil'
+      end
+    end
+
+    private
+
+    def _call_on(vm, args)
+      args_js = args.map { |a| JSON.generate(a) }.join(', ')
+      vm.eval_code("(#{@source})(#{args_js})")
+    end
+  end
+end

--- a/sig/quickjs.rbs
+++ b/sig/quickjs.rbs
@@ -43,6 +43,14 @@ module Quickjs
     end
   end
 
+  class Function
+    def initialize: (String source) -> void
+
+    def source: () -> String
+
+    def call: (*untyped args, ?on: VM | Hash[Symbol, untyped] | nil) -> untyped
+  end
+
   class RuntimeError < ::RuntimeError
     def initialize: (String message, String? js_name) -> void
 

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -81,11 +81,11 @@ describe Quickjs do
 
     it "non-plain objects fall back to JSON conversion" do
       assert_code("new Date('2024-01-01T00:00:00.000Z').toISOString()", "2024-01-01T00:00:00.000Z")
-      assert_code("() => 'hi'", Quickjs::Value::UNDEFINED)
     end
 
-    it "void (undefined per JSON.stringify) becomes a specific constant" do
-      assert_code("() => 'hi'", Quickjs::Value::UNDEFINED)
+    it "function becomes Quickjs::Function" do
+      result = ::Quickjs.eval_code("() => 'hi'")
+      _(result).must_be_instance_of Quickjs::Function
     end
   end
 
@@ -579,6 +579,84 @@ describe Quickjs::VM do
       _(@vm.call('a.b["c-d"]')).must_equal 'mixed'
     end
 
+  end
+
+  describe "Function" do
+    before do
+      @vm = Quickjs::VM.new
+    end
+
+    it "JS function passed to Ruby becomes a Quickjs::Function" do
+      received = nil
+      @vm.define_function("capture") { |fn| received = fn }
+      @vm.eval_code("capture((a, b) => a + b)")
+      _(received).must_be_instance_of Quickjs::Function
+    end
+
+    it "exposes the JS source via source" do
+      received = nil
+      @vm.define_function("capture") { |fn| received = fn }
+      @vm.eval_code("capture((a, b) => a + b)")
+      _(received.source).must_equal "(a, b) => a + b"
+    end
+
+    it "call with no args runs on a fresh VM" do
+      received = nil
+      @vm.define_function("capture") { |fn| received = fn }
+      @vm.eval_code("capture(() => 42)")
+      _(received.call).must_equal 42
+    end
+
+    it "call passes args to the function" do
+      received = nil
+      @vm.define_function("capture") { |fn| received = fn }
+      @vm.eval_code("capture((a, b) => a + b)")
+      _(received.call(3, 4)).must_equal 7
+    end
+
+    it "call with on: vm runs on the given VM" do
+      received = nil
+      @vm.define_function("capture") { |fn| received = fn }
+      @vm.eval_code("capture((x) => x * 2)")
+      other_vm = Quickjs::VM.new
+      _(received.call(5, on: other_vm)).must_equal 10
+    end
+
+    it "call with on: Hash passes VM options" do
+      received = nil
+      @vm.define_function("capture") { |fn| received = fn }
+      @vm.eval_code("capture(() => !!std)")
+      _(received.call(on: { features: [Quickjs::MODULE_STD] })).must_equal true
+    end
+
+    it "is independent of the original VM" do
+      received = nil
+      @vm.define_function("capture") { |fn| received = fn }
+      @vm.eval_code("capture((x) => x + 1)")
+      @vm = nil
+      _(received.call(10)).must_equal 11
+    end
+
+    it "named function is callable" do
+      received = nil
+      @vm.define_function("capture") { |fn| received = fn }
+      @vm.eval_code("capture(function add(a, b) { return a + b; })")
+      _(received.call(2, 3)).must_equal 5
+    end
+
+    it "passes complex args" do
+      received = nil
+      @vm.define_function("capture") { |fn| received = fn }
+      @vm.eval_code("capture((obj) => obj.x + obj.y)")
+      _(received.call({ x: 1, y: 2 })).must_equal 3
+    end
+
+    it "raises ArgumentError for invalid on: argument" do
+      received = nil
+      @vm.define_function("capture") { |fn| received = fn }
+      @vm.eval_code("capture(() => 1)")
+      _ { received.call(on: "bad") }.must_raise ArgumentError
+    end
   end
 
   describe "Import" do


### PR DESCRIPTION
JS functions passed as arguments to Ruby-defined functions are now converted to `Quickjs::Function` via `Function.prototype.toString()`, making them VM-independent and storable. `call(*args, on:)` follows the same interface as `Quickjs::Runnable` (not a public feature yet).