### PR TITLE
Speed up Ruby <-> JS value conversion hot paths

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,7 +19,7 @@ GEM
     rbs (3.10.3)
       logger
       tsort
-    securerandom (0.3.1)
+    securerandom (0.4.1)
     tsort (0.2.0)
 
 PLATFORMS

--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -57,8 +57,21 @@ typedef struct
 static int rb_hash_entry_to_js(VALUE r_key, VALUE r_val, VALUE extra)
 {
   RbHashToJsArg *arg = (RbHashToJsArg *)extra;
-  VALUE r_key_str = rb_funcall(r_key, rb_intern("to_s"), 0);
-  JS_SetPropertyStr(arg->ctx, arg->j_obj, StringValueCStr(r_key_str), to_js_value(arg->ctx, r_val));
+  const char *key_cstr;
+  if (SYMBOL_P(r_key))
+  {
+    key_cstr = rb_id2name(SYM2ID(r_key));
+  }
+  else if (RB_TYPE_P(r_key, T_STRING))
+  {
+    key_cstr = StringValueCStr(r_key);
+  }
+  else
+  {
+    VALUE r_key_str = rb_funcall(r_key, rb_intern("to_s"), 0);
+    key_cstr = StringValueCStr(r_key_str);
+  }
+  JS_SetPropertyStr(arg->ctx, arg->j_obj, key_cstr, to_js_value(arg->ctx, r_val));
   return ST_CONTINUE;
 }
 
@@ -69,26 +82,23 @@ JSValue to_js_value(JSContext *ctx, VALUE r_value)
   case T_NIL:
     return JS_NULL;
   case T_FIXNUM:
+    return JS_NewInt64(ctx, NUM2LL(r_value));
   case T_FLOAT:
+    return JS_NewFloat64(ctx, NUM2DBL(r_value));
+  case T_BIGNUM:
   {
     VALUE r_str = rb_funcall(r_value, rb_intern("to_s"), 0);
-    char *str = StringValueCStr(r_str);
+    JSValue j_str = JS_NewStringLen(ctx, RSTRING_PTR(r_str), RSTRING_LEN(r_str));
     JSValue j_global = JS_GetGlobalObject(ctx);
     JSValue j_numberClass = JS_GetPropertyStr(ctx, j_global, "Number");
-    JSValue j_str = JS_NewString(ctx, str);
-    JSValue j_stringified = JS_Call(ctx, j_numberClass, JS_UNDEFINED, 1, (JSValueConst *)&j_str);
-    JS_FreeValue(ctx, j_global);
-    JS_FreeValue(ctx, j_numberClass);
+    JSValue j_num = JS_Call(ctx, j_numberClass, JS_UNDEFINED, 1, (JSValueConst *)&j_str);
     JS_FreeValue(ctx, j_str);
-
-    return j_stringified;
+    JS_FreeValue(ctx, j_numberClass);
+    JS_FreeValue(ctx, j_global);
+    return j_num;
   }
   case T_STRING:
-  {
-    char *str = StringValueCStr(r_value);
-
-    return JS_NewString(ctx, str);
-  }
+    return JS_NewStringLen(ctx, RSTRING_PTR(r_value), RSTRING_LEN(r_value));
   case T_SYMBOL:
   {
     if (r_value == QUICKJSRB_SYM(undefinedId))
@@ -100,10 +110,8 @@ JSValue to_js_value(JSContext *ctx, VALUE r_value)
       JS_FreeValue(ctx, j_global);
       return j_nan;
     }
-    VALUE r_str = rb_funcall(r_value, rb_intern("to_s"), 0);
-    char *str = StringValueCStr(r_str);
-
-    return JS_NewString(ctx, str);
+    const char *name = rb_id2name(SYM2ID(r_value));
+    return JS_NewString(ctx, name);
   }
   case T_TRUE:
     return JS_TRUE;
@@ -266,16 +274,13 @@ VALUE to_rb_value(JSContext *ctx, JSValue j_val)
   }
   case JS_TAG_STRING:
   {
-    int couldntParse;
-    VALUE r_result = rb_protect(r_try_json_parse, to_r_json(ctx, j_val), &couldntParse);
-    if (couldntParse)
-    {
+    size_t len;
+    const char *str = JS_ToCStringLen(ctx, &len, j_val);
+    if (str == NULL)
       return Qnil;
-    }
-    else
-    {
-      return r_result;
-    }
+    VALUE r_str = rb_utf8_str_new(str, (long)len);
+    JS_FreeCString(ctx, str);
+    return r_str;
   }
   case JS_TAG_OBJECT:
   {


### PR DESCRIPTION
## Summary
- Ruby->JS numbers: replace the `Number(str)` round-trip with direct `JS_NewInt64` / `JS_NewFloat64` (Bignum keeps the existing `Number(str)` path)
- JS->Ruby strings: replace the `JSON.stringify` + `JSON.parse` round-trip with a direct `JS_ToCStringLen` + `rb_utf8_str_new`
- Hash keys: skip `rb_funcall(:to_s)` for Symbol/String keys when building a JS object from a Ruby Hash

## Microbenchmark (200K iterations)

`vm.call('sum', ...)` where `sum = (a, b, c, d) => a + b + c + d`:

| args | before | after | speedup |
|---|---|---|---|
| int × 4    | 304ms | 192ms | **1.59x** |
| float × 4  | 426ms | 182ms | **2.34x** |
| string × 4 | 313ms | 231ms | **1.36x** |

`vm.eval_code('"hello world"')` (100K iterations): 185ms → 134ms (**1.38x**).

## Note on Gemfile.lock
Bumps `securerandom` to 0.4.1 because Ruby 4.0 ships 0.4.1 as a default gem and the pinned 0.3.1 caused `bundle exec rake compile` to fail. Happy to drop this from the PR if you'd prefer it as a separate change.

## Test plan
- [x] `bundle exec rake test` (381 runs, 0 failures, 0 errors, 7 pre-existing skips)
- [x] Microbench above on Linux / Ruby 4.0.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)