### PR TITLE
Tidy two interop call sites in quickjsrb.c

### DIFF
--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -134,10 +134,7 @@ JSValue to_js_value(JSContext *ctx, VALUE r_value)
       if (!JS_IsUndefined(data->j_file_proxy_creator))
         return quickjsrb_file_to_js(ctx, r_value);
     }
-    if (TYPE(r_value) == T_OBJECT && RTEST(rb_funcall(
-                                         r_value,
-                                         rb_intern("is_a?"),
-                                         1, rb_const_get(rb_cClass, rb_intern("Exception")))))
+    if (rb_obj_is_kind_of(r_value, rb_eException))
     {
       return j_error_from_ruby_error(ctx, r_value);
     }
@@ -856,8 +853,8 @@ static VALUE vm_m_evalCode(VALUE r_self, VALUE r_code)
   clock_gettime(CLOCK_MONOTONIC, &data->eval_time->started_at);
   JS_SetInterruptHandler(JS_GetRuntime(data->context), interrupt_handler, data->eval_time);
 
-  char *code = StringValueCStr(r_code);
-  JSValue j_codeResult = JS_Eval(data->context, code, strlen(code), "<code>", JS_EVAL_TYPE_GLOBAL | JS_EVAL_FLAG_ASYNC);
+  StringValue(r_code);
+  JSValue j_codeResult = JS_Eval(data->context, RSTRING_PTR(r_code), RSTRING_LEN(r_code), "<code>", JS_EVAL_TYPE_GLOBAL | JS_EVAL_FLAG_ASYNC);
   JSValue j_awaitedResult = js_std_await(data->context, j_codeResult); // This frees j_codeResult
   // JS_EVAL_FLAG_ASYNC wraps the result in {value, done} — extract the actual value
   // Free j_awaitedResult before to_rb_return_value because it may raise (longjmp), which would skip cleanup

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -40,6 +40,10 @@ describe Quickjs do
       assert_code("'🆔'", "🆔")
     end
 
+    it "source code containing an embedded NUL byte is not truncated" do
+      assert_code("'a\0b'.length", 3)
+    end
+
     it "number for integer becomes Integer" do
       assert_code("2+3", 5)
       assert_code("18014398509481982n", 18014398509481982)


### PR DESCRIPTION
Two small follow-ups to #18, both basically zero-risk.

## Summary
- `to_js_value` default branch: replace `TYPE(r_value) == T_OBJECT && rb_funcall(:is_a?, Exception)` with `rb_obj_is_kind_of(r_value, rb_eException)`. Saves a method dispatch + a constant lookup per non-primitive Ruby->JS conversion, and the `T_OBJECT` guard isn't needed (some `Exception` subclasses aren't `T_OBJECT` — e.g. `SystemCallError` instances).
- `vm_m_evalCode`: use `RSTRING_PTR` / `RSTRING_LEN` instead of `StringValueCStr` + `strlen`. Skips the `strlen` scan and, more importantly, allows JS source containing embedded NUL bytes through to `JS_Eval`. Pre-fix this would raise `ArgumentError: string contains null byte` from `StringValueCStr`.

## Test plan
- [x] Added a regression test for the embedded-NUL eval case (verified it errors without the fix and passes with it)
- [x] `bundle exec rake test` (382 runs, 532 assertions, 0 failures, 0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)