### PR TITLE
Look up defined function by Symbol ID, not string round-trip

### DIFF
--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -482,16 +482,19 @@ static VALUE r_try_call_proc(VALUE r_try_args)
 
 static JSValue js_quickjsrb_call_global(JSContext *ctx, JSValueConst _this, int argc, JSValueConst *argv, int _magic, JSValue *func_data)
 {
-  const char *funcName = JS_ToCString(ctx, func_data[0]);
+  // func_data[0] holds the Ruby Symbol ID for the defined function (stored by
+  // vm_m_defineGlobalFunction). Looking up by ID avoids a JS_ToCString +
+  // rb_intern round-trip on every call.
+  int64_t key_id;
+  JS_ToInt64(ctx, &key_id, func_data[0]);
 
   VMData *data = JS_GetContextOpaque(ctx);
-  VALUE r_proc = rb_hash_aref(data->defined_functions, ID2SYM(rb_intern(funcName)));
+  VALUE r_proc = rb_hash_aref(data->defined_functions, ID2SYM((ID)key_id));
   // Shouldn't happen
   if (r_proc == Qnil)
   {
-    return JS_ThrowReferenceError(ctx, "Proc `%s` is not defined", funcName); // TODO: Free funcnName
+    return JS_ThrowReferenceError(ctx, "Proc is not defined");
   }
-  JS_FreeCString(ctx, funcName);
 
   VALUE r_call_args = rb_ary_new();
   rb_ary_push(r_call_args, r_proc);
@@ -904,7 +907,7 @@ static VALUE vm_m_defineGlobalFunction(int argc, VALUE *argv, VALUE r_self)
     char *funcName = StringValueCStr(r_func_seg_str);
 
     JSValueConst ruby_data[2];
-    ruby_data[0] = JS_NewString(data->context, StringValueCStr(r_key_str));
+    ruby_data[0] = JS_NewInt64(data->context, (int64_t)SYM2ID(r_key_sym));
     ruby_data[1] = JS_NewBool(data->context, RTEST(rb_funcall(r_flags, rb_intern("include?"), 1, ID2SYM(rb_intern("async")))));
 
     // Resolve the parent object to attach the function to.
@@ -969,7 +972,7 @@ static VALUE vm_m_defineGlobalFunction(int argc, VALUE *argv, VALUE r_self)
     char *funcName = StringValueCStr(r_name_str);
 
     JSValueConst ruby_data[2];
-    ruby_data[0] = JS_NewString(data->context, funcName);
+    ruby_data[0] = JS_NewInt64(data->context, (int64_t)SYM2ID(r_name_sym));
     ruby_data[1] = JS_NewBool(data->context, RTEST(rb_funcall(r_flags, rb_intern("include?"), 1, ID2SYM(rb_intern("async")))));
 
     JSValue j_global = JS_GetGlobalObject(data->context);


### PR DESCRIPTION
## Summary

`js_quickjsrb_call_global` was looking up the Ruby Proc for a defined function via:

```c
const char *funcName = JS_ToCString(func_data[0]);
VALUE r_proc = rb_hash_aref(data->defined_functions, ID2SYM(rb_intern(funcName)));
JS_FreeCString(ctx, funcName);
```

Replace with stashing the Symbol's `ID` in `func_data[0]` as an int64 at definition time, and reconstructing the symbol via `ID2SYM((ID)key_id)` in the callback. Skips the `JS_ToCString` / `rb_intern` / `JS_FreeCString` triple per call and incidentally fixes a small C-string leak on the unreachable \"Proc not defined\" error path (the old code's `// TODO: Free funcnName` comment).

`defined_functions` keeps Symbol keys; only the marshalling on the JS side changes.

## Microbenchmark (500K iterations, `vm.eval_code('noop()')`)

Before: 2.383s — After: 2.354s (~1%).

The string round-trip was a tiny share of total dispatch cost; most of the time is spent in the Ruby-side `_with_timeout` wrapper plus argument marshalling. Still ships as a tidiness win + the leak fix.

## Notes

`ID` is `unsigned long`, but Ruby symbol IDs in practice fit comfortably under 2^53, so the float64 representation that `JS_NewInt64` falls back to (when the value doesn't fit in int32) round-trips exactly.

## Test plan
- [x] `bundle exec rake test` (381 runs, 531 assertions, 0 failures, 0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)