### PR TITLE
Don't crash on JSON-incompatible objects in to_r_json

### DIFF
--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -187,12 +187,24 @@ VALUE to_r_json(JSContext *ctx, JSValue j_val)
 {
   JSValue j_stringified = JS_JSONStringify(ctx, j_val, JS_UNDEFINED, JS_UNDEFINED);
 
+  // JSON.stringify throws on circular structures (e.g. jQuery objects'
+  // prevObject chain). Clear the pending exception so it doesn't poison
+  // subsequent eval, and return nil so callers fall through to "couldn't
+  // parse" handling rather than crashing on rb_str_new2(NULL) below.
+  if (JS_IsException(j_stringified))
+  {
+    JS_FreeValue(ctx, j_stringified);
+    JSValue j_pending = JS_GetException(ctx);
+    JS_FreeValue(ctx, j_pending);
+    return Qnil;
+  }
+
   const char *msg = JS_ToCString(ctx, j_stringified);
+  JS_FreeValue(ctx, j_stringified);
+  if (msg == NULL)
+    return Qnil;
   VALUE r_str = rb_str_new2(msg);
   JS_FreeCString(ctx, msg);
-
-  JS_FreeValue(ctx, j_stringified);
-
   return r_str;
 }
 

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -123,6 +123,18 @@ describe Quickjs do
       JS
     end
 
+    it "circular non-plain object via vm.call returns nil cleanly" do
+      vm = Quickjs::VM.new
+      vm.eval_code(<<~JS)
+        globalThis.makeCircular = () => {
+          const o = {};
+          o.self = o;
+          Object.setPrototypeOf(o, Object.create({ tag: 1 }));
+          return o;
+        };
+      JS
+      _(vm.call('makeCircular')).must_be_nil
+    end
 
     it "function becomes Quickjs::Function" do
       result = ::Quickjs.eval_code("() => 'hi'")

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -115,6 +115,15 @@ describe Quickjs do
       assert_code("/abc/g", {})
     end
 
+    it "circular non-plain object doesn't blow up" do
+      # JSON.stringify throws on cycles; this used to surface as
+      # `ArgumentError: NULL pointer given` from rb_str_new2.
+      assert_code(<<~JS, nil)
+        const o = {}; o.self = o; o.__proto__ = Object.create({ tag: 1 }); o;
+      JS
+    end
+
+
     it "function becomes Quickjs::Function" do
       result = ::Quickjs.eval_code("() => 'hi'")
       _(result).must_be_instance_of Quickjs::Function


### PR DESCRIPTION
## Summary

`JSON.stringify` throws `TypeError` on circular structures (e.g. jQuery objects' `prevObject` chain, real-world repro: `vm.eval_code('jQuery(\"body\")')`). The current `to_r_json` then runs `JS_ToCString` on the resulting `JS_EXCEPTION`, gets `NULL` back, and passes it to `rb_str_new2`, surfacing as:

```
ArgumentError: NULL pointer given
```

This both masks the original `TypeError` and leaves the QuickJS pending exception live, breaking any caller passing a circular object across the bridge.

## Fix

Detect the `JSON.stringify` exception in `to_r_json`, clear the pending exception so subsequent eval isn't poisoned, and return `Qnil`. Existing callers already treat \"can't parse\" as `nil`, so the user-visible result becomes `nil` instead of a crash. Also guards `JS_ToCString`'s NULL return for any remaining edge cases.

## Reduced repro
```js
const o = {}; o.self = o; o.__proto__ = Object.create({ tag: 1 }); o
```
Before: `ArgumentError: NULL pointer given`
After: `nil`

## Test plan
- [x] Added a regression test (verified it errors without the fix and passes with it)
- [x] `bundle exec rake test` (382 runs, 532 assertions, 0 failures, 0 errors)
- [x] Reduced jQuery repro from a downstream consumer (capybara-simulated): all 6 jQuery snippets that previously raised now return cleanly

## Notes / follow-ups

This is a band-aid: the result is `nil` rather than a useful representation. A nicer fix would walk own-enumerable-properties with a visited-set to handle cycles, but that's larger scope -- this PR focuses on stopping the crash. Filed separately: improving non-plain object representation (#20).

🤖 Generated with [Claude Code](https://claude.com/claude-code)