### PR TITLE
Refuse further evaluation after JS-level out-of-memory

### DIFF
--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -29,6 +29,9 @@ static int dispatch_log(VMData *data, const char *severity, VALUE r_row);
 JSValue to_js_value(JSContext *ctx, VALUE r_value);
 VALUE to_rb_value(JSContext *ctx, JSValue j_val);
 static VALUE to_rb_value_inner(JSContext *ctx, JSValue j_val, VALUE r_visited);
+static VALUE vm_m_memoryUsage(VALUE r_self);
+static VALUE vm_m_runGC(VALUE r_self);
+static VALUE vm_m_oomPoisoned(VALUE r_self);
 
 JSValue j_error_from_ruby_error(JSContext *ctx, VALUE r_error)
 {
@@ -448,6 +451,14 @@ static VALUE to_rb_value_inner(JSContext *ctx, JSValue j_val, VALUE r_visited)
       else if (strcmp(errorClassName, "Quickjs::InterruptedError") == 0)
       {
         r_error_class = QUICKJSRB_ERROR_FOR(QUICKJSRB_INTERRUPTED_ERROR);
+      }
+      else if (strcmp(errorClassName, "InternalError") == 0 && strstr(errorClassMessage, "out of memory") != NULL)
+      {
+        // Once OOM has fired, the QuickJS heap is in a state where another
+        // throw inside the parser-error path can corrupt the shape table and
+        // segfault. Mark the VM so further eval/call calls refuse cleanly.
+        data->oom_poisoned = true;
+        r_error_class = QUICKJSRB_ERROR_FOR(QUICKJSRB_ROOT_RUNTIME_ERROR);
       }
       else
       {
@@ -955,10 +966,21 @@ static void arm_eval_timer(VMData *data)
   JS_SetInterruptHandler(JS_GetRuntime(data->context), interrupt_handler, data->eval_time);
 }
 
+static void check_oom_poisoned(VMData *data)
+{
+  if (data->oom_poisoned)
+  {
+    VALUE r_msg = rb_str_new2("VM is poisoned: a previous evaluation hit out-of-memory; further evaluation may segfault. Recreate the Quickjs::VM.");
+    rb_exc_raise(rb_funcall(QUICKJSRB_ERROR_FOR(QUICKJSRB_ROOT_RUNTIME_ERROR), rb_intern("new"), 2, r_msg, Qnil));
+  }
+}
+
 static VALUE vm_m_evalCode(int argc, VALUE *argv, VALUE r_self)
 {
   VMData *data;
   TypedData_Get_Struct(r_self, VMData, &vm_type, data);
+
+  check_oom_poisoned(data);
 
   VALUE r_code, r_opts;
   rb_scan_args(argc, argv, "1:", &r_code, &r_opts);
@@ -996,6 +1018,8 @@ static VALUE vm_m_compile(int argc, VALUE *argv, VALUE r_self)
   VMData *data;
   TypedData_Get_Struct(r_self, VMData, &vm_type, data);
 
+  check_oom_poisoned(data);
+
   VALUE r_code, r_opts;
   rb_scan_args(argc, argv, "1:", &r_code, &r_opts);
   const char *filename = parse_code_and_filename(r_code, r_opts);
@@ -1029,6 +1053,8 @@ static VALUE vm_m_evalBytecode(VALUE r_self, VALUE r_bytecode)
 {
   VMData *data;
   TypedData_Get_Struct(r_self, VMData, &vm_type, data);
+
+  check_oom_poisoned(data);
 
   if (!RB_TYPE_P(r_bytecode, T_STRING))
   {
@@ -1187,6 +1213,8 @@ static VALUE vm_m_callGlobalFunction(int argc, VALUE *argv, VALUE r_self)
 
   VMData *data;
   TypedData_Get_Struct(r_self, VMData, &vm_type, data);
+
+  check_oom_poisoned(data);
 
   JSValue j_this = JS_UNDEFINED;
   JSValue j_func;
@@ -1423,5 +1451,45 @@ RUBY_FUNC_EXPORTED void Init_quickjsrb(void)
   rb_define_method(r_class_vm, "module_loader", vm_m_get_module_loader, 0);
   rb_define_method(r_class_vm, "module_loader=", vm_m_set_module_loader, 1);
   rb_define_method(r_class_vm, "on_log", vm_m_on_log, 0);
+  rb_define_method(r_class_vm, "memory_usage", vm_m_memoryUsage, 0);
+  rb_define_method(r_class_vm, "gc!", vm_m_runGC, 0);
+  rb_define_method(r_class_vm, "oom_poisoned?", vm_m_oomPoisoned, 0);
   r_define_log_class(r_class_vm);
+}
+
+static VALUE vm_m_memoryUsage(VALUE r_self)
+{
+  VMData *data;
+  TypedData_Get_Struct(r_self, VMData, &vm_type, data);
+  JSMemoryUsage s;
+  JS_ComputeMemoryUsage(JS_GetRuntime(data->context), &s);
+  VALUE h = rb_hash_new();
+  rb_hash_aset(h, ID2SYM(rb_intern("malloc_size")), LL2NUM(s.malloc_size));
+  rb_hash_aset(h, ID2SYM(rb_intern("malloc_limit")), LL2NUM(s.malloc_limit));
+  rb_hash_aset(h, ID2SYM(rb_intern("memory_used_size")), LL2NUM(s.memory_used_size));
+  rb_hash_aset(h, ID2SYM(rb_intern("atom_count")), LL2NUM(s.atom_count));
+  rb_hash_aset(h, ID2SYM(rb_intern("str_count")), LL2NUM(s.str_count));
+  rb_hash_aset(h, ID2SYM(rb_intern("obj_count")), LL2NUM(s.obj_count));
+  rb_hash_aset(h, ID2SYM(rb_intern("prop_count")), LL2NUM(s.prop_count));
+  rb_hash_aset(h, ID2SYM(rb_intern("shape_count")), LL2NUM(s.shape_count));
+  rb_hash_aset(h, ID2SYM(rb_intern("js_func_count")), LL2NUM(s.js_func_count));
+  rb_hash_aset(h, ID2SYM(rb_intern("js_func_code_size")), LL2NUM(s.js_func_code_size));
+  rb_hash_aset(h, ID2SYM(rb_intern("c_func_count")), LL2NUM(s.c_func_count));
+  rb_hash_aset(h, ID2SYM(rb_intern("array_count")), LL2NUM(s.array_count));
+  return h;
+}
+
+static VALUE vm_m_runGC(VALUE r_self)
+{
+  VMData *data;
+  TypedData_Get_Struct(r_self, VMData, &vm_type, data);
+  JS_RunGC(JS_GetRuntime(data->context));
+  return Qnil;
+}
+
+static VALUE vm_m_oomPoisoned(VALUE r_self)
+{
+  VMData *data;
+  TypedData_Get_Struct(r_self, VMData, &vm_type, data);
+  return data->oom_poisoned ? Qtrue : Qfalse;
 }

--- a/ext/quickjsrb/quickjsrb.h
+++ b/ext/quickjsrb/quickjsrb.h
@@ -57,6 +57,12 @@ typedef struct VMData
   VALUE alive_objects;
   VALUE module_loader;
   JSValue j_file_proxy_creator;
+  // Once the runtime has hit JS-level "out of memory", the QuickJS heap is in
+  // a fragile state where further evaluation can trigger a use-after-free in
+  // the parser-error-during-OOM cascade (segfault inside js_shape_hash_unlink).
+  // Trip this flag so subsequent eval_code/call calls refuse cleanly with a
+  // Ruby exception instead of risking a process crash.
+  bool oom_poisoned;
 } VMData;
 
 static void vm_free(void *ptr)
@@ -119,6 +125,7 @@ static VALUE vm_alloc(VALUE r_self)
   data->alive_objects = rb_hash_new();
   data->module_loader = Qnil;
   data->j_file_proxy_creator = JS_UNDEFINED;
+  data->oom_poisoned = false;
 
   EvalTime *eval_time = malloc(sizeof(EvalTime));
   data->eval_time = eval_time;

--- a/sig/quickjs.rbs
+++ b/sig/quickjs.rbs
@@ -39,6 +39,12 @@ module Quickjs
 
     def on_log: () { (Log) -> void } -> nil
 
+    def memory_usage: () -> Hash[Symbol, Integer]
+
+    def gc!: () -> nil
+
+    def oom_poisoned?: () -> bool
+
     class Log
       attr_reader severity: Symbol
 

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -310,8 +310,30 @@ describe Quickjs::VM do
     it "maintains the same context within a vm" do
       @vm.eval_code('const a = { b: "c" };')
       _(@vm.eval_code('a.b')).must_equal "c"
+      _(@vm.eval_code('a.b')).must_equal "c"
       @vm.eval_code('a.b = "d"')
       _(@vm.eval_code('a.b')).must_equal "d"
+    end
+
+    it "after OOM, marks the VM poisoned and refuses further evaluation" do
+      # 1 MB limit; allocate a single buffer larger than that.
+      vm = Quickjs::VM.new(memory_limit: 1024 * 1024)
+      _(vm.oom_poisoned?).must_equal false
+      _ { vm.eval_code('new Array(2_000_000).fill(0); void 0') }.must_raise Quickjs::RuntimeError
+      _(vm.oom_poisoned?).must_equal true
+      err = _ { vm.eval_code('1 + 1') }.must_raise Quickjs::RuntimeError
+      _(err.message).must_match(/poisoned/)
+    end
+
+    it "memory_usage returns a hash of QuickJS heap stats" do
+      stats = @vm.memory_usage
+      _(stats).must_be_kind_of Hash
+      _(stats[:malloc_size]).must_be :>, 0
+      _(stats[:obj_count]).must_be :>, 0
+    end
+
+    it "gc! returns nil and is callable" do
+      _(@vm.gc!).must_be_nil
     end
 
     it "does not enable std/os module as default" do


### PR DESCRIPTION
## Summary

Defensive fix for the long-running-VM segfault hit by [`capybara-simulated`](https://github.com/ursm/capybara-simulated) running the full Capybara shared spec.

The crash chain inside QuickJS is:

```
js_parse_error_v
  -> build_backtrace
    -> JS_DefinePropertyValue  (adds 'stack' to the SyntaxError)
      -> resize_properties
        -> js_malloc -> OOM -> JS_ThrowOutOfMemory
          -> JS_Throw
            -> JS_FreeValue(old current_exception)
              -> js_free_shape -> js_shape_hash_unlink -> SEGV at *psh
```

Project policy says no QuickJS-core patches and the submodule pin tracks bellard's official releases (current pin: `fa628f8 new release`). So we keep the runtime out of that re-entrant throw state from the embedder side: detect `InternalError: out of memory` in the existing exception-marshalling path, trip a new `oom_poisoned` flag on `VMData`, and have `eval_code` / `call` raise `Quickjs::RuntimeError("VM is poisoned: ... Recreate the Quickjs::VM.")` up front before invoking `JS_Eval`. Caller gets a recoverable Ruby exception they can rescue (e.g. discard the VM and create a fresh one).

Companion APIs added for diagnosing pressure in production:
```ruby
vm.memory_usage    # => { malloc_size:, malloc_limit:, obj_count:, atom_count:, shape_count:, ... }
vm.gc!             # JS_RunGC, useful for cycle collection
vm.oom_poisoned?   # Boolean
```

## What this *doesn't* fix

`capybara-simulated`'s full shared spec also hits the same crash chain via a path that an upstream optimization ([`a6816be`](https://github.com/bellard/quickjs/commit/a6816be23ae2bc511c7797489326f58934968323) "optimized global variable access") happens to avoid, but `a6816be` is post-release master and isn't included here per the official-release-only policy. Adopting it will have to wait for bellard's next release.

The repro itself fills the heap because the caller's bootstrap holds a `Map` of every `setTimeout` callback ever registered (jQuery's ready queue + delayed handlers), retaining the entire jQuery closure scope per call. That's reachable memory — `vm.gc!` won't free it. The right long-term fix is on the caller side (drain the Map between iterations, or recreate the VM proactively). This PR makes hitting OOM non-fatal so the caller can do the latter cleanly.

## Verification (downstream)

| build                              | `pure_quickjs_repro.rb 2000` | full Capybara shared spec               |
| ---------------------------------- | ---------------------------- | --------------------------------------- |
| 0.15.0 (release)                   | core dump @ ~iter 800        | core dump                               |
| Poisoning defense (this PR)        | survived, RSS ~205 MB        | exit 1, 1198/1357 passing, 3 recycles   |

## Test plan

- [x] Added a regression test that exhausts a 1 MB-limited VM and verifies `oom_poisoned?` flips and subsequent `eval_code` raises with `/poisoned/` in the message
- [x] Added smoke tests for `memory_usage` and `gc!`
- [x] `bundle exec rake test` (390 runs, 553 assertions, 0 failures, 0 errors)
- [x] `pure_quickjs_repro.rb 3000` survives

## Note

Stacked on #22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)