### PR TITLE
Add async: false option to eval_code for sync-only mode

### DIFF
--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -862,6 +862,7 @@ static VALUE vm_m_evalCode(int argc, VALUE *argv, VALUE r_self)
   }
 
   const char *filename = "<code>";
+  bool async_mode = true;
   if (!NIL_P(r_opts))
   {
     VALUE r_filename = rb_hash_aref(r_opts, ID2SYM(rb_intern("filename")));
@@ -870,12 +871,23 @@ static VALUE vm_m_evalCode(int argc, VALUE *argv, VALUE r_self)
       Check_Type(r_filename, T_STRING);
       filename = StringValueCStr(r_filename);
     }
+
+    VALUE r_async = rb_hash_aref(r_opts, ID2SYM(rb_intern("async")));
+    if (r_async == Qfalse)
+      async_mode = false;
   }
 
   clock_gettime(CLOCK_MONOTONIC, &data->eval_time->started_at);
   JS_SetInterruptHandler(JS_GetRuntime(data->context), interrupt_handler, data->eval_time);
 
   StringValue(r_code);
+
+  if (!async_mode)
+  {
+    JSValue j_codeResult = JS_Eval(data->context, RSTRING_PTR(r_code), RSTRING_LEN(r_code), filename, JS_EVAL_TYPE_GLOBAL);
+    return to_rb_return_value(data->context, j_codeResult);
+  }
+
   JSValue j_codeResult = JS_Eval(data->context, RSTRING_PTR(r_code), RSTRING_LEN(r_code), filename, JS_EVAL_TYPE_GLOBAL | JS_EVAL_FLAG_ASYNC);
   JSValue j_awaitedResult = js_std_await(data->context, j_codeResult); // This frees j_codeResult
   // JS_EVAL_FLAG_ASYNC wraps the result in {value, done} — extract the actual value

--- a/lib/quickjs.rb
+++ b/lib/quickjs.rb
@@ -20,6 +20,7 @@ module Quickjs
   def eval_code(code, overwrite_opts = {})
     eval_opts = {}
     eval_opts[:filename] = overwrite_opts.delete(:filename) if overwrite_opts.key?(:filename)
+    eval_opts[:async] = overwrite_opts.delete(:async) if overwrite_opts.key?(:async)
     vm = Quickjs::VM.new(**overwrite_opts)
     res = vm.eval_code(code, **eval_opts)
     vm = nil

--- a/sig/quickjs.rbs
+++ b/sig/quickjs.rbs
@@ -21,7 +21,7 @@ module Quickjs
   class VM
     def initialize: (?features: Array[Symbol], ?memory_limit: Integer, ?max_stack_size: Integer, ?timeout_msec: Integer) -> void
 
-    def eval_code: (String code, ?filename: String) -> untyped
+    def eval_code: (String code, ?async: bool, ?filename: String) -> untyped
 
     def call: (String | Symbol name, *untyped args) -> untyped
 

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -193,6 +193,28 @@ describe Quickjs do
     end
   end
 
+  describe "SyncEval" do
+    it "evaluates synchronously when async: false" do
+      vm = Quickjs::VM.new
+      _(vm.eval_code('1 + 1', async: false)).must_equal 2
+      _(vm.eval_code('"hi"', async: false)).must_equal "hi"
+    end
+
+    it "returns a Promise object instead of awaiting in sync mode" do
+      vm = Quickjs::VM.new
+      # In async (default) mode this would await and resolve to "ok".
+      # In sync mode the Promise leaks back to the embedder; we surface it via
+      # the existing NoAwaitError.
+      _ {
+        vm.eval_code('Promise.resolve("ok")', async: false)
+      }.must_raise Quickjs::NoAwaitError
+    end
+
+    it "Quickjs.eval_code forwards async: option" do
+      _(::Quickjs.eval_code('1 + 2', async: false)).must_equal 3
+    end
+  end
+
   it "std module can be enabled" do
     assert_code("typeof std === 'undefined'", true)
     _(::Quickjs.eval_code("!!std.urlGet", { features: [::Quickjs::MODULE_STD] })).must_equal true


### PR DESCRIPTION
## Summary

Today every `eval_code` wraps the source in `JS_EVAL_FLAG_ASYNC` and resolves it via `js_std_await`. That's what top-level `await` needs, but it has a cost: if user JS returns or leaks a pending Promise that nobody awaits, the await keeps spinning, and state that was supposed to be transient lingers in the job queue.

Add an opt-in keyword:

```ruby
vm.eval_code('1 + 1', async: false)               # => 2
vm.eval_code('Promise.resolve(1)', async: false)  # => raises Quickjs::NoAwaitError
```

In sync mode the result returns directly (just `JS_EVAL_TYPE_GLOBAL`); a returned Promise surfaces via the existing `NoAwaitError` rather than blocking. Top-level `await` becomes a `SyntaxError` in this mode since we no longer wrap in an async function — caller's responsibility to opt in only when their workload doesn't use it.

`Quickjs.eval_code` forwards the option through the one-shot convenience wrapper.

## Why

Useful for embedders running predictable, sync-only JS where awaiting an unintentionally-pending Promise would manifest as a hang.

## Test plan
- [x] Added tests covering: sync evaluation works, returned Promise raises NoAwaitError instead of being awaited, `Quickjs.eval_code` forwards the option
- [x] `bundle exec rake test` (384 runs, 535 assertions, 0 failures, 0 errors)

## Note

Independent of #22 / #23. Branched off main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)