### PR TITLE
Add filename: option to eval_code for JS stack traces

### DIFF
--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -844,10 +844,13 @@ static VALUE to_rb_return_value(JSContext *ctx, JSValue j_val)
   return result;
 }
 
-static VALUE vm_m_evalCode(VALUE r_self, VALUE r_code)
+static VALUE vm_m_evalCode(int argc, VALUE *argv, VALUE r_self)
 {
   VMData *data;
   TypedData_Get_Struct(r_self, VMData, &vm_type, data);
+
+  VALUE r_code, r_opts;
+  rb_scan_args(argc, argv, "1:", &r_code, &r_opts);
 
   if (!RB_TYPE_P(r_code, T_STRING))
   {
@@ -855,11 +858,22 @@ static VALUE vm_m_evalCode(VALUE r_self, VALUE r_code)
     rb_raise(rb_eTypeError, "JavaScript code must be a String, got %s", StringValueCStr(r_code_class));
   }
 
+  const char *filename = "<code>";
+  if (!NIL_P(r_opts))
+  {
+    VALUE r_filename = rb_hash_aref(r_opts, ID2SYM(rb_intern("filename")));
+    if (!NIL_P(r_filename))
+    {
+      Check_Type(r_filename, T_STRING);
+      filename = StringValueCStr(r_filename);
+    }
+  }
+
   clock_gettime(CLOCK_MONOTONIC, &data->eval_time->started_at);
   JS_SetInterruptHandler(JS_GetRuntime(data->context), interrupt_handler, data->eval_time);
 
   StringValue(r_code);
-  JSValue j_codeResult = JS_Eval(data->context, RSTRING_PTR(r_code), RSTRING_LEN(r_code), "<code>", JS_EVAL_TYPE_GLOBAL | JS_EVAL_FLAG_ASYNC);
+  JSValue j_codeResult = JS_Eval(data->context, RSTRING_PTR(r_code), RSTRING_LEN(r_code), filename, JS_EVAL_TYPE_GLOBAL | JS_EVAL_FLAG_ASYNC);
   JSValue j_awaitedResult = js_std_await(data->context, j_codeResult); // This frees j_codeResult
   // JS_EVAL_FLAG_ASYNC wraps the result in {value, done} — extract the actual value
   // Free j_awaitedResult before to_rb_return_value because it may raise (longjmp), which would skip cleanup
@@ -1198,7 +1212,7 @@ RUBY_FUNC_EXPORTED void Init_quickjsrb(void)
   VALUE r_class_vm = rb_define_class_under(r_module_quickjs, "VM", rb_cObject);
   rb_define_alloc_func(r_class_vm, vm_alloc);
   rb_define_method(r_class_vm, "initialize", vm_m_initialize, -1);
-  rb_define_method(r_class_vm, "eval_code", vm_m_evalCode, 1);
+  rb_define_method(r_class_vm, "eval_code", vm_m_evalCode, -1);
   rb_define_method(r_class_vm, "call", vm_m_callGlobalFunction, -1);
   rb_define_method(r_class_vm, "define_function", vm_m_defineGlobalFunction, -1);
   rb_define_method(r_class_vm, "import", vm_m_import, -1);

--- a/lib/quickjs.rb
+++ b/lib/quickjs.rb
@@ -18,8 +18,10 @@ module Quickjs
   end
 
   def eval_code(code, overwrite_opts = {})
+    eval_opts = {}
+    eval_opts[:filename] = overwrite_opts.delete(:filename) if overwrite_opts.key?(:filename)
     vm = Quickjs::VM.new(**overwrite_opts)
-    res = vm.eval_code(code)
+    res = vm.eval_code(code, **eval_opts)
     vm = nil
     res
   end

--- a/sig/quickjs.rbs
+++ b/sig/quickjs.rbs
@@ -21,7 +21,7 @@ module Quickjs
   class VM
     def initialize: (?features: Array[Symbol], ?memory_limit: Integer, ?max_stack_size: Integer, ?timeout_msec: Integer) -> void
 
-    def eval_code: (String code) -> untyped
+    def eval_code: (String code, ?filename: String) -> untyped
 
     def call: (String | Symbol name, *untyped args) -> untyped
 

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -169,6 +169,30 @@ describe Quickjs do
     end
   end
 
+  describe "EvalFilename" do
+    it "uses '<code>' as the source name by default" do
+      stack = ::Quickjs.eval_code(<<~JS)
+        try { throw new Error('boom') } catch (e) { e.stack }
+      JS
+      _(stack).must_match(/<code>/)
+    end
+
+    it "carries filename: through to JS stack traces" do
+      stack = ::Quickjs.eval_code(<<~JS, filename: '/path/to/jquery.js')
+        try { throw new Error('boom') } catch (e) { e.stack }
+      JS
+      _(stack).must_match(%r{/path/to/jquery\.js})
+    end
+
+    it "Quickjs::VM#eval_code accepts filename: too" do
+      vm = Quickjs::VM.new
+      stack = vm.eval_code(<<~JS, filename: 'foo.js')
+        try { throw new Error('x') } catch (e) { e.stack }
+      JS
+      _(stack).must_match(/foo\.js/)
+    end
+  end
+
   it "std module can be enabled" do
     assert_code("typeof std === 'undefined'", true)
     _(::Quickjs.eval_code("!!std.urlGet", { features: [::Quickjs::MODULE_STD] })).must_equal true


### PR DESCRIPTION
## Summary

`JS_Eval`'s fourth argument is the source name that QuickJS records in backtrace frames. quickjs.rb hardcodes `"<code>"`, so when an embedder loads multiple scripts into the same VM (jQuery, app code, polyfills) every JS stack frame reads `at <code>:N:M` and they're indistinguishable.

Accept a `filename:` keyword on `Quickjs::VM#eval_code` and on the `Quickjs.eval_code` one-shot wrapper, and pass it through:

```ruby
vm.eval_code(jquery_src, filename: '/jquery.js')
# JS side: throw new Error('x').stack
#   "    at /jquery.js:N:M\n..."
```

Default behaviour is unchanged (`\"<code>\"`).

## Test plan
- [x] Verified default tag is `<code>`, custom filename appears in `.stack`, both module-level and instance-level entry points carry it through
- [x] `bundle exec rake test` (384 runs, 537 assertions, 0 failures, 0 errors)

## Note

Independent of #22 / #23 / #25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)