### PR TITLE
Add Quickjs::VM#module_loader= for in-memory module resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,24 @@ vm.import('DefaultExport', from: File.read('exports.esm.js'))
 vm.import('* as all', from: File.read('exports.esm.js'))
 ```
 
+#### `Quickjs::VM#module_loader=`: 🧩 Resolve `import` specifiers from Ruby
+
+By default, `import` specifiers that aren't already loaded fall through to QuickJS's filesystem loader. Set a `module_loader` Proc to resolve specifiers in-memory instead — useful when the source code lives in a database, an importmap, or a virtual filesystem.
+
+```rb
+vm = Quickjs::VM.new
+modules = {
+  'a' => "import { b } from 'b'; export const a = () => `a-${b()}`;",
+  'b' => "export const b = () => 'b-result';"
+}
+vm.module_loader = ->(name) { modules[name] }
+
+vm.import(['a'], from: "import { a } from 'a'; export { a };")
+vm.eval_code('a()') #=> 'a-b-result'
+```
+
+The Proc receives the (already normalized) module specifier and returns the module source as a `String`, or `nil` to signal "not found" (which raises `Quickjs::ReferenceError` on the JS side). Pass `nil` to clear a previously set loader.
+
 #### `Quickjs::VM#define_function`: 💎 Define a global function for JS by Ruby
 
 ```rb

--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -468,6 +468,59 @@ VALUE to_rb_value(JSContext *ctx, JSValue j_val)
   }
 }
 
+struct module_loader_call_args
+{
+  VALUE proc;
+  VALUE r_module_name;
+};
+
+static VALUE r_module_loader_call(VALUE r_args_val)
+{
+  struct module_loader_call_args *args = (struct module_loader_call_args *)r_args_val;
+  return rb_funcall(args->proc, rb_intern("call"), 1, args->r_module_name);
+}
+
+static JSModuleDef *quickjsrb_module_loader(JSContext *ctx, const char *module_name, void *opaque, JSValueConst attributes)
+{
+  VMData *data = JS_GetContextOpaque(ctx);
+  if (NIL_P(data->module_loader))
+    return js_module_loader(ctx, module_name, opaque, attributes);
+
+  struct module_loader_call_args args = {data->module_loader, rb_str_new_cstr(module_name)};
+  int state;
+  VALUE r_source = rb_protect(r_module_loader_call, (VALUE)&args, &state);
+  if (state)
+  {
+    VALUE r_error = rb_errinfo();
+    rb_set_errinfo(Qnil);
+    JSValue j_error = j_error_from_ruby_error(ctx, r_error);
+    JS_Throw(ctx, j_error);
+    return NULL;
+  }
+
+  if (NIL_P(r_source) || r_source == Qfalse)
+  {
+    JS_ThrowReferenceError(ctx, "module loader returned no source for '%s'", module_name);
+    return NULL;
+  }
+
+  if (!RB_TYPE_P(r_source, T_STRING))
+  {
+    JS_ThrowTypeError(ctx, "module loader must return a String or nil, got %s", rb_obj_classname(r_source));
+    return NULL;
+  }
+
+  JSValue j_func = JS_Eval(ctx, RSTRING_PTR(r_source), RSTRING_LEN(r_source), module_name,
+                           JS_EVAL_TYPE_MODULE | JS_EVAL_FLAG_COMPILE_ONLY);
+  if (JS_IsException(j_func))
+    return NULL;
+
+  js_module_set_import_meta(ctx, j_func, FALSE, FALSE);
+  JSModuleDef *m = JS_VALUE_GET_PTR(j_func);
+  JS_FreeValue(ctx, j_func);
+  return m;
+}
+
 static VALUE r_try_call_proc(VALUE r_try_args)
 {
   return rb_funcall(
@@ -727,7 +780,7 @@ static VALUE vm_m_initialize(int argc, VALUE *argv, VALUE r_self)
   JS_SetMemoryLimit(runtime, NUM2UINT(r_memory_limit));
   JS_SetMaxStackSize(runtime, NUM2UINT(r_max_stack_size));
 
-  JS_SetModuleLoaderFunc2(runtime, NULL, js_module_loader, js_module_check_attributes, NULL);
+  JS_SetModuleLoaderFunc2(runtime, NULL, quickjsrb_module_loader, js_module_check_attributes, NULL);
   js_std_init_handlers(runtime);
 
   JSValue j_global = JS_GetGlobalObject(data->context);
@@ -1124,6 +1177,25 @@ static VALUE vm_m_callGlobalFunction(int argc, VALUE *argv, VALUE r_self)
   return to_rb_return_value(data->context, js_std_await(data->context, j_result));
 }
 
+static VALUE vm_m_set_module_loader(VALUE r_self, VALUE r_loader)
+{
+  VMData *data;
+  TypedData_Get_Struct(r_self, VMData, &vm_type, data);
+
+  if (!NIL_P(r_loader) && !rb_obj_is_kind_of(r_loader, rb_cProc))
+    rb_raise(rb_eTypeError, "module_loader must be a Proc or nil");
+
+  data->module_loader = r_loader;
+  return r_loader;
+}
+
+static VALUE vm_m_get_module_loader(VALUE r_self)
+{
+  VMData *data;
+  TypedData_Get_Struct(r_self, VMData, &vm_type, data);
+  return data->module_loader;
+}
+
 static VALUE vm_m_import(int argc, VALUE *argv, VALUE r_self)
 {
   VALUE r_import_string, r_opts;
@@ -1200,6 +1272,8 @@ RUBY_FUNC_EXPORTED void Init_quickjsrb(void)
   rb_define_method(r_class_vm, "call", vm_m_callGlobalFunction, -1);
   rb_define_method(r_class_vm, "define_function", vm_m_defineGlobalFunction, -1);
   rb_define_method(r_class_vm, "import", vm_m_import, -1);
+  rb_define_method(r_class_vm, "module_loader", vm_m_get_module_loader, 0);
+  rb_define_method(r_class_vm, "module_loader=", vm_m_set_module_loader, 1);
   rb_define_method(r_class_vm, "on_log", vm_m_on_log, 0);
   r_define_log_class(r_class_vm);
 }

--- a/ext/quickjsrb/quickjsrb.h
+++ b/ext/quickjsrb/quickjsrb.h
@@ -54,6 +54,7 @@ typedef struct VMData
   struct EvalTime *eval_time;
   VALUE log_listener;
   VALUE alive_objects;
+  VALUE module_loader;
   JSValue j_file_proxy_creator;
 } VMData;
 
@@ -85,6 +86,7 @@ static void vm_mark(void *ptr)
   rb_gc_mark_movable(data->defined_functions);
   rb_gc_mark_movable(data->log_listener);
   rb_gc_mark_movable(data->alive_objects);
+  rb_gc_mark_movable(data->module_loader);
 }
 
 static void vm_compact(void *ptr)
@@ -93,6 +95,7 @@ static void vm_compact(void *ptr)
   data->defined_functions = rb_gc_location(data->defined_functions);
   data->log_listener = rb_gc_location(data->log_listener);
   data->alive_objects = rb_gc_location(data->alive_objects);
+  data->module_loader = rb_gc_location(data->module_loader);
 }
 
 static const rb_data_type_t vm_type = {
@@ -113,6 +116,7 @@ static VALUE vm_alloc(VALUE r_self)
   data->defined_functions = rb_hash_new();
   data->log_listener = Qnil;
   data->alive_objects = rb_hash_new();
+  data->module_loader = Qnil;
   data->j_file_proxy_creator = JS_UNDEFINED;
 
   EvalTime *eval_time = malloc(sizeof(EvalTime));

--- a/sig/quickjs.rbs
+++ b/sig/quickjs.rbs
@@ -30,6 +30,10 @@ module Quickjs
 
     def import: (String | Array[String] | Hash[Symbol, String] imported, from: String, ?code_to_expose: String?) -> true
 
+    def module_loader: () -> (^(String) -> String? | nil)
+
+    def module_loader=: (^(String) -> String? | nil) -> (^(String) -> String? | nil)
+
     def on_log: () { (Log) -> void } -> nil
 
     class Log

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -706,6 +706,68 @@ describe Quickjs::VM do
     end
   end
 
+  describe "ModuleLoader" do
+    before do
+      @vm = Quickjs::VM.new
+    end
+
+    it "is nil by default" do
+      _(@vm.module_loader).must_be_nil
+    end
+
+    it "resolves bare specifiers via a Ruby callback" do
+      @vm.module_loader = ->(name) {
+        'export const greet = (who) => `Hello, ${who}!`;' if name == 'greet'
+      }
+      @vm.import(['greet'], from: "import { greet } from 'greet'; export { greet };")
+
+      _(@vm.eval_code("greet('world')")).must_equal 'Hello, world!'
+    end
+
+    it "resolves transitive imports across multiple in-memory modules" do
+      modules = {
+        'a' => "import { b } from 'b'; export const a = () => `a-${b()}`;",
+        'b' => "export const b = () => 'b-result';"
+      }
+      @vm.module_loader = ->(name) { modules[name] }
+      @vm.import(['a'], from: "import { a } from 'a'; export { a };")
+
+      _(@vm.eval_code('a()')).must_equal 'a-b-result'
+    end
+
+    it "raises ReferenceError when the loader returns nil" do
+      @vm.module_loader = ->(_) { nil }
+      _ {
+        @vm.import('Helper', from: "import x from 'missing'; export default x;")
+      }.must_raise Quickjs::ReferenceError
+    end
+
+    it "raises TypeError when the loader returns a non-string" do
+      @vm.module_loader = ->(_) { 42 }
+      _ {
+        @vm.import('Helper', from: "import x from 'mod'; export default x;")
+      }.must_raise Quickjs::TypeError
+    end
+
+    it "propagates Ruby exceptions raised inside the loader" do
+      @vm.module_loader = ->(_) { raise 'boom from loader' }
+      err = _ {
+        @vm.import('Helper', from: "import x from 'mod'; export default x;")
+      }.must_raise RuntimeError
+      _(err.message).must_match(/boom from loader/)
+    end
+
+    it "accepts nil to clear a previously set loader" do
+      @vm.module_loader = ->(_) { 'export default 1;' }
+      @vm.module_loader = nil
+      _(@vm.module_loader).must_be_nil
+    end
+
+    it "rejects non-Proc, non-nil values" do
+      _ { @vm.module_loader = 'not a proc' }.must_raise TypeError
+    end
+  end
+
   describe "ConsoleLoggers" do
     before do
       @vm = Quickjs::VM.new


### PR DESCRIPTION
## Summary

QuickJS's default module loader is filesystem-only — it `fopen`s the specifier as a path. The only way to feed the gem an in-memory module today is via `Quickjs::VM#import`, which compiles the source under a randomly-generated filename. Two consequences:

- A second module can't `import` the first by name (the random filename isn't visible to user code).
- Flows like importmap-rails — multiple in-memory modules referencing each other by spec — can't run on quickjs.rb without monkey-patching.

This PR exposes the `JS_SetModuleLoaderFunc2` slot through a Ruby setter:

```ruby
vm = Quickjs::VM.new
modules = {
  'a' => "import { b } from 'b'; export const a = () => `a-${b()}`;",
  'b' => "export const b = () => 'b-result';"
}
vm.module_loader = ->(name) { modules[name] }

vm.import(['a'], from: "import { a } from 'a'; export { a };")
vm.eval_code('a()') #=> 'a-b-result'
```

The Proc receives the (already-normalized) specifier and returns the module source as a `String`, or `nil` for "not found" → `Quickjs::ReferenceError`. A non-string return raises `Quickjs::TypeError`. Ruby exceptions raised inside the loader propagate back through the existing JS-error/Ruby-error bridge in `to_rb_value`, so callers get the original Ruby exception.

When `module_loader` is `nil` (the default), behavior is unchanged: imports fall through to QuickJS's stock filesystem loader.

## Implementation notes

- New `VALUE module_loader` slot on `VMData`, marked + compacted by the existing GC callbacks.
- New `quickjsrb_module_loader` trampoline registered via `JS_SetModuleLoaderFunc2`. It short-circuits to `js_module_loader` (the stock loader) when `module_loader` is `nil`, so no behavior change for existing users.
- Public surface is two methods: `Quickjs::VM#module_loader` (reader) and `Quickjs::VM#module_loader=` (writer; type-checked to `Proc | nil`).

## Design questions

A couple of choices worth flagging for review — happy to change either:

- **Fallback policy.** Currently the custom loader is "all in" — once set, the stock filesystem loader isn't consulted. An alternative would be: if the Proc returns `nil`, fall back to filesystem. I went with no-fallback because the use case (importmap-rails / virtual filesystem) wants full control and silent filesystem reads would be surprising. If you'd prefer fallback, it's a one-line change.
- **Argument shape.** The Proc receives just the normalized specifier (`String`). Could also expose the importing module's basename and import attributes. Kept it minimal until there's a concrete need.

## Test plan

- [x] New `ModuleLoader` describe block in `test/quickjs_test.rb` (7 cases): default `nil`; bare specifier resolution; transitive imports across multiple in-memory modules; nil return → `ReferenceError`; non-string return → `TypeError`; Ruby exception propagation; clearing via `nil`; type-check rejecting non-Proc values.
- [x] `bundle exec rake test` (389 runs, 541 assertions, 0 failures, 0 errors)
- [x] RBS signatures updated in `sig/quickjs.rbs` (the existing RBS-completeness test enforces this).
- [x] README updated with a usage example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)