### PR TITLE
Add Quickjs::VM#preload_module for in-memory module registration

### DIFF
--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -1143,6 +1143,41 @@ static VALUE vm_m_callGlobalFunction(int argc, VALUE *argv, VALUE r_self)
   return to_rb_return_value(data->context, js_std_await(data->context, j_result));
 }
 
+static VALUE vm_m_preload_module(int argc, VALUE *argv, VALUE r_self)
+{
+  VALUE r_source, r_opts;
+  rb_scan_args(argc, argv, "1:", &r_source, &r_opts);
+  if (NIL_P(r_opts))
+    r_opts = rb_hash_new();
+  VALUE r_filename = rb_hash_aref(r_opts, ID2SYM(rb_intern("filename")));
+  if (NIL_P(r_filename))
+  {
+    VALUE r_error_message = rb_str_new2("missing filename");
+    rb_exc_raise(rb_funcall(QUICKJSRB_ERROR_FOR(QUICKJSRB_ROOT_RUNTIME_ERROR), rb_intern("new"), 2, r_error_message, Qnil));
+    return Qnil;
+  }
+
+  VMData *data;
+  TypedData_Get_Struct(r_self, VMData, &vm_type, data);
+
+  if (RTEST(rb_hash_aref(data->preloaded_modules, r_filename)))
+    rb_raise(rb_eArgError, "module '%s' is already preloaded", StringValueCStr(r_filename));
+
+  char *filename = StringValueCStr(r_filename);
+  char *source = StringValueCStr(r_source);
+  JSValue module = JS_Eval(data->context, source, strlen(source), filename, JS_EVAL_TYPE_MODULE | JS_EVAL_FLAG_COMPILE_ONLY);
+  if (JS_IsException(module))
+  {
+    JS_FreeValue(data->context, module);
+    return to_rb_value(data->context, module);
+  }
+  js_module_set_import_meta(data->context, module, TRUE, FALSE);
+  JS_FreeValue(data->context, module);
+
+  rb_hash_aset(data->preloaded_modules, r_filename, Qtrue);
+  return Qtrue;
+}
+
 static VALUE vm_m_import(int argc, VALUE *argv, VALUE r_self)
 {
   VALUE r_import_string, r_opts;
@@ -1218,6 +1253,7 @@ RUBY_FUNC_EXPORTED void Init_quickjsrb(void)
   rb_define_method(r_class_vm, "eval_code", vm_m_evalCode, -1);
   rb_define_method(r_class_vm, "call", vm_m_callGlobalFunction, -1);
   rb_define_method(r_class_vm, "define_function", vm_m_defineGlobalFunction, -1);
+  rb_define_method(r_class_vm, "preload_module", vm_m_preload_module, -1);
   rb_define_method(r_class_vm, "import", vm_m_import, -1);
   rb_define_method(r_class_vm, "on_log", vm_m_on_log, 0);
   r_define_log_class(r_class_vm);

--- a/ext/quickjsrb/quickjsrb.h
+++ b/ext/quickjsrb/quickjsrb.h
@@ -51,6 +51,7 @@ typedef struct VMData
 {
   struct JSContext *context;
   VALUE defined_functions;
+  VALUE preloaded_modules;
   struct EvalTime *eval_time;
   VALUE log_listener;
   VALUE alive_objects;
@@ -83,6 +84,7 @@ static void vm_mark(void *ptr)
 {
   VMData *data = (VMData *)ptr;
   rb_gc_mark_movable(data->defined_functions);
+  rb_gc_mark_movable(data->preloaded_modules);
   rb_gc_mark_movable(data->log_listener);
   rb_gc_mark_movable(data->alive_objects);
 }
@@ -91,6 +93,7 @@ static void vm_compact(void *ptr)
 {
   VMData *data = (VMData *)ptr;
   data->defined_functions = rb_gc_location(data->defined_functions);
+  data->preloaded_modules = rb_gc_location(data->preloaded_modules);
   data->log_listener = rb_gc_location(data->log_listener);
   data->alive_objects = rb_gc_location(data->alive_objects);
 }
@@ -111,6 +114,7 @@ static VALUE vm_alloc(VALUE r_self)
   VMData *data;
   VALUE obj = TypedData_Make_Struct(r_self, VMData, &vm_type, data);
   data->defined_functions = rb_hash_new();
+  data->preloaded_modules = rb_hash_new();
   data->log_listener = Qnil;
   data->alive_objects = rb_hash_new();
   data->j_file_proxy_creator = JS_UNDEFINED;

--- a/sig/quickjs.rbs
+++ b/sig/quickjs.rbs
@@ -28,6 +28,8 @@ module Quickjs
     def define_function: (String | Symbol name, *Symbol flags) { (*untyped) -> untyped } -> Symbol
                        | (Array[String | Symbol] path, *Symbol flags) { (*untyped) -> untyped } -> Array[Symbol]
 
+    def preload_module: (String source, filename: String) -> true
+
     def import: (String | Array[String] | Hash[Symbol, String] imported, from: String, ?code_to_expose: String?) -> true
 
     def on_log: () { (Log) -> void } -> nil

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -734,6 +734,46 @@ describe Quickjs::VM do
     end
   end
 
+  describe "PreloadModule" do
+    before do
+      @vm = Quickjs::VM.new
+    end
+
+    it "makes a module importable by filename" do
+      @vm.preload_module("export const greet = (who) => `Hello, ${who}!`;", filename: 'greet')
+      @vm.import(['greet'], from: "import { greet } from 'greet'; export { greet };")
+
+      _(@vm.eval_code("greet('world')")).must_equal 'Hello, world!'
+    end
+
+    it "supports transitive imports across multiple preloaded modules" do
+      @vm.preload_module("export const b = () => 'b-result';", filename: 'b')
+      @vm.preload_module("import { b } from 'b'; export const a = () => `a-${b()}`;", filename: 'a')
+      @vm.import(['a'], from: "import { a } from 'a'; export { a };")
+
+      _(@vm.eval_code('a()')).must_equal 'a-b-result'
+    end
+
+    it "raises SyntaxError for invalid source" do
+      _ {
+        @vm.preload_module('should be syntax error', filename: 'bad')
+      }.must_raise Quickjs::SyntaxError
+    end
+
+    it "raises RuntimeError when filename is missing" do
+      _ {
+        @vm.preload_module("export const x = 1;")
+      }.must_raise Quickjs::RuntimeError
+    end
+
+    it "raises ArgumentError when the same filename is preloaded twice" do
+      @vm.preload_module("export const x = 1;", filename: 'mod')
+      _ {
+        @vm.preload_module("export const x = 2;", filename: 'mod')
+      }.must_raise ArgumentError
+    end
+  end
+
   describe "ConsoleLoggers" do
     before do
       @vm = Quickjs::VM.new


### PR DESCRIPTION
## Context

This is an alternative proposal to #27, which exposed a `module_loader=` Proc-based callback. After some design exploration, the core problem that PR solves is: **modules registered via `import` get a random internal filename, so other JS modules can't `import` from them by a known specifier.**

## Approach

Rather than exposing the full QuickJS module loader hook, this PR adds a narrower `preload_module` method that registers a source string under a named specifier — analogous to [`<link rel="modulepreload">`](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel/modulepreload) in browsers.

The `filename:` keyword is consistent with the existing `eval_code(source, filename:)` API added in #26.

```ruby
vm = Quickjs::VM.new
vm.preload_module("export const b = () => 'b-result';", filename: 'b')
vm.preload_module("import { b } from 'b'; export const a = () => `a-${b()}`;", filename: 'a')

vm.import(['a'], from: "import { a } from 'a'; export { a };")
vm.eval_code('a()') #=> 'a-b-result'
```

Registering the same filename twice raises `ArgumentError`.

## vs #27

| | #27 `module_loader=` | This PR `preload_module` |
|---|---|---|
| API shape | Proc callback (dynamic) | Named registration (static) |
| Common case | `vm.module_loader = ->(name) { map[name] }` | `vm.preload_module(src, filename: 'name')` |
| Duplicate filename | silently ignored (first wins) | raises `ArgumentError` |
| Fallback to filesystem | configurable | unchanged (always available) |

@ursm would love your thoughts — happy to hear if you think the Proc-based approach is worth the added flexibility, or if this narrower API covers the use case well enough.

## Test plan

- New `PreloadModule` describe block in `test/quickjs_test.rb` (5 cases): basic resolution; transitive imports; syntax error; missing filename; duplicate filename
- `bundle exec rake test` — 390 runs, 550 assertions, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)