### PR TITLE
Add VM#on_load_module hook and import(filename:) for virtual module resolution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,14 @@ Tests use minitest with `describe`/`it` blocks. Key test files:
 - `test/quickjs_test.rb` — Main test suite (value conversion, errors, VM features, ESM imports, function definitions)
 - `test/quickjs_polyfill_test.rb` — Intl polyfill tests
 
+## Release Process
+
+1. On `main`, run `bundle exec rake polyfills:build` — rebuilds polyfill bundles and syncs `polyfills/package.json` version to match the gem version
+2. Bump `lib/quickjs/version.rb` and `Gemfile.lock` to the new version
+3. Commit `lib/quickjs/version.rb`, `Gemfile.lock`, `polyfills/package.json`, `polyfills/package-lock.json` as `"prepare vX.Y.Z"`
+4. Run `bundle exec rake release` — tags, pushes to GitHub, and publishes to RubyGems (human step)
+5. Create a GitHub release via `gh release create` with notes following the pattern of previous releases
+
 ## Build Notes
 
 - `extconf.rb` compiles with `-DNDEBUG` to avoid conflicts with Ruby 4.0 GC assertions

--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -470,6 +470,59 @@ VALUE to_rb_value(JSContext *ctx, JSValue j_val)
   }
 }
 
+struct module_loader_call_args
+{
+  VALUE proc;
+  VALUE r_module_name;
+};
+
+static VALUE r_module_loader_call(VALUE r_args_val)
+{
+  struct module_loader_call_args *args = (struct module_loader_call_args *)r_args_val;
+  return rb_funcall(args->proc, rb_intern("call"), 1, args->r_module_name);
+}
+
+static JSModuleDef *quickjsrb_module_loader(JSContext *ctx, const char *module_name, void *opaque, JSValueConst attributes)
+{
+  VMData *data = JS_GetContextOpaque(ctx);
+  if (NIL_P(data->module_loader))
+    return js_module_loader(ctx, module_name, opaque, attributes);
+
+  struct module_loader_call_args args = {data->module_loader, rb_str_new_cstr(module_name)};
+  int state;
+  VALUE r_source = rb_protect(r_module_loader_call, (VALUE)&args, &state);
+  if (state)
+  {
+    VALUE r_error = rb_errinfo();
+    rb_set_errinfo(Qnil);
+    JSValue j_error = j_error_from_ruby_error(ctx, r_error);
+    JS_Throw(ctx, j_error);
+    return NULL;
+  }
+
+  if (NIL_P(r_source) || r_source == Qfalse)
+  {
+    JS_ThrowReferenceError(ctx, "on_load_module returned no source for '%s'", module_name);
+    return NULL;
+  }
+
+  if (!RB_TYPE_P(r_source, T_STRING))
+  {
+    JS_ThrowTypeError(ctx, "on_load_module must return a String or nil, got %s", rb_obj_classname(r_source));
+    return NULL;
+  }
+
+  JSValue j_func = JS_Eval(ctx, RSTRING_PTR(r_source), RSTRING_LEN(r_source), module_name,
+                           JS_EVAL_TYPE_MODULE | JS_EVAL_FLAG_COMPILE_ONLY);
+  if (JS_IsException(j_func))
+    return NULL;
+
+  js_module_set_import_meta(ctx, j_func, FALSE, FALSE);
+  JSModuleDef *m = JS_VALUE_GET_PTR(j_func);
+  JS_FreeValue(ctx, j_func);
+  return m;
+}
+
 static VALUE r_try_call_proc(VALUE r_try_args)
 {
   return rb_funcall(
@@ -610,6 +663,18 @@ static int dispatch_log(VMData *data, const char *severity, VALUE r_row)
   return error;
 }
 
+static VALUE vm_m_on_load_module(VALUE r_self)
+{
+  rb_need_block();
+
+  VMData *data;
+  TypedData_Get_Struct(r_self, VMData, &vm_type, data);
+
+  data->module_loader = rb_block_proc();
+
+  return Qnil;
+}
+
 static VALUE vm_m_on_log(VALUE r_self)
 {
   rb_need_block();
@@ -732,7 +797,7 @@ static VALUE vm_m_initialize(int argc, VALUE *argv, VALUE r_self)
   JS_SetMemoryLimit(runtime, NUM2UINT(r_memory_limit));
   JS_SetMaxStackSize(runtime, NUM2UINT(r_max_stack_size));
 
-  JS_SetModuleLoaderFunc2(runtime, NULL, js_module_loader, js_module_check_attributes, NULL);
+  JS_SetModuleLoaderFunc2(runtime, NULL, quickjsrb_module_loader, js_module_check_attributes, NULL);
   js_std_init_handlers(runtime);
 
   JSValue j_global = JS_GetGlobalObject(data->context);
@@ -1219,6 +1284,7 @@ RUBY_FUNC_EXPORTED void Init_quickjsrb(void)
   rb_define_method(r_class_vm, "call", vm_m_callGlobalFunction, -1);
   rb_define_method(r_class_vm, "define_function", vm_m_defineGlobalFunction, -1);
   rb_define_method(r_class_vm, "import", vm_m_import, -1);
+  rb_define_method(r_class_vm, "on_load_module", vm_m_on_load_module, 0);
   rb_define_method(r_class_vm, "on_log", vm_m_on_log, 0);
   r_define_log_class(r_class_vm);
 }

--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -1215,7 +1215,8 @@ static VALUE vm_m_import(int argc, VALUE *argv, VALUE r_self)
   if (NIL_P(r_opts))
     r_opts = rb_hash_new();
   VALUE r_from = rb_hash_aref(r_opts, ID2SYM(rb_intern("from")));
-  if (NIL_P(r_from))
+  VALUE r_filename = rb_hash_aref(r_opts, ID2SYM(rb_intern("filename")));
+  if (NIL_P(r_from) && NIL_P(r_filename))
   {
     VALUE r_error_message = rb_str_new2("missing import source");
     rb_exc_raise(rb_funcall(QUICKJSRB_ERROR_FOR(QUICKJSRB_ROOT_RUNTIME_ERROR), rb_intern("new"), 2, r_error_message, Qnil));
@@ -1226,16 +1227,24 @@ static VALUE vm_m_import(int argc, VALUE *argv, VALUE r_self)
   VMData *data;
   TypedData_Get_Struct(r_self, VMData, &vm_type, data);
 
-  char *filename = random_string();
-  char *source = StringValueCStr(r_from);
-  JSValue module = JS_Eval(data->context, source, strlen(source), filename, JS_EVAL_TYPE_MODULE | JS_EVAL_FLAG_COMPILE_ONLY);
-  if (JS_IsException(module))
+  char *filename;
+  if (!NIL_P(r_filename))
   {
-    JS_FreeValue(data->context, module);
-    return to_rb_value(data->context, module);
+    filename = StringValueCStr(r_filename);
   }
-  js_module_set_import_meta(data->context, module, TRUE, FALSE);
-  JS_FreeValue(data->context, module);
+  else
+  {
+    filename = random_string();
+    char *source = StringValueCStr(r_from);
+    JSValue module = JS_Eval(data->context, source, strlen(source), filename, JS_EVAL_TYPE_MODULE | JS_EVAL_FLAG_COMPILE_ONLY);
+    if (JS_IsException(module))
+    {
+      JS_FreeValue(data->context, module);
+      return to_rb_value(data->context, module);
+    }
+    js_module_set_import_meta(data->context, module, TRUE, FALSE);
+    JS_FreeValue(data->context, module);
+  }
 
   VALUE r_import_settings = rb_funcall(
       rb_const_get(rb_cClass, rb_intern("Quickjs")),

--- a/ext/quickjsrb/quickjsrb.h
+++ b/ext/quickjsrb/quickjsrb.h
@@ -51,6 +51,7 @@ typedef struct VMData
 {
   struct JSContext *context;
   VALUE defined_functions;
+  VALUE module_loader;
   struct EvalTime *eval_time;
   VALUE log_listener;
   VALUE alive_objects;
@@ -83,6 +84,7 @@ static void vm_mark(void *ptr)
 {
   VMData *data = (VMData *)ptr;
   rb_gc_mark_movable(data->defined_functions);
+  rb_gc_mark_movable(data->module_loader);
   rb_gc_mark_movable(data->log_listener);
   rb_gc_mark_movable(data->alive_objects);
 }
@@ -91,6 +93,7 @@ static void vm_compact(void *ptr)
 {
   VMData *data = (VMData *)ptr;
   data->defined_functions = rb_gc_location(data->defined_functions);
+  data->module_loader = rb_gc_location(data->module_loader);
   data->log_listener = rb_gc_location(data->log_listener);
   data->alive_objects = rb_gc_location(data->alive_objects);
 }
@@ -111,6 +114,7 @@ static VALUE vm_alloc(VALUE r_self)
   VMData *data;
   VALUE obj = TypedData_Make_Struct(r_self, VMData, &vm_type, data);
   data->defined_functions = rb_hash_new();
+  data->module_loader = Qnil;
   data->log_listener = Qnil;
   data->alive_objects = rb_hash_new();
   data->j_file_proxy_creator = JS_UNDEFINED;

--- a/sig/quickjs.rbs
+++ b/sig/quickjs.rbs
@@ -29,6 +29,7 @@ module Quickjs
                        | (Array[String | Symbol] path, *Symbol flags) { (*untyped) -> untyped } -> Array[Symbol]
 
     def import: (String | Array[String] | Hash[Symbol, String] imported, from: String, ?code_to_expose: String?) -> true
+              | (String | Array[String] | Hash[Symbol, String] imported, filename: String) -> true
 
     def on_load_module: () { (String) -> String? } -> nil
 

--- a/sig/quickjs.rbs
+++ b/sig/quickjs.rbs
@@ -30,6 +30,8 @@ module Quickjs
 
     def import: (String | Array[String] | Hash[Symbol, String] imported, from: String, ?code_to_expose: String?) -> true
 
+    def on_load_module: () { (String) -> String? } -> nil
+
     def on_log: () { (Log) -> void } -> nil
 
     class Log

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -734,6 +734,58 @@ describe Quickjs::VM do
     end
   end
 
+  describe "OnLoadModule" do
+    before do
+      @vm = Quickjs::VM.new
+    end
+
+    it "resolves bare specifiers via a block" do
+      @vm.on_load_module { |name| "export const greet = (who) => `Hello, ${who}!`;" if name == 'greet' }
+      @vm.import(['greet'], from: "import { greet } from 'greet'; export { greet };")
+
+      _(@vm.eval_code("greet('world')")).must_equal 'Hello, world!'
+    end
+
+    it "resolves transitive imports across multiple in-memory modules" do
+      modules = {
+        'a' => "import { b } from 'b'; export const a = () => `a-${b()}`;",
+        'b' => "export const b = () => 'b-result';"
+      }
+      @vm.on_load_module { |name| modules[name] }
+      @vm.import(['a'], from: "import { a } from 'a'; export { a };")
+
+      _(@vm.eval_code('a()')).must_equal 'a-b-result'
+    end
+
+    it "raises ReferenceError when the block returns nil" do
+      @vm.on_load_module { |_| nil }
+      _ {
+        @vm.import('Helper', from: "import x from 'missing'; export default x;")
+      }.must_raise Quickjs::ReferenceError
+    end
+
+    it "raises TypeError when the block returns a non-string" do
+      @vm.on_load_module { |_| 42 }
+      _ {
+        @vm.import('Helper', from: "import x from 'mod'; export default x;")
+      }.must_raise Quickjs::TypeError
+    end
+
+    it "propagates Ruby exceptions raised inside the block" do
+      @vm.on_load_module { |_| raise 'boom from loader' }
+      err = _ {
+        @vm.import('Helper', from: "import x from 'mod'; export default x;")
+      }.must_raise RuntimeError
+      _(err.message).must_match(/boom from loader/)
+    end
+
+    it "falls back to the filesystem loader when no block is set" do
+      _ {
+        @vm.import('Helper', from: "import x from 'missing'; export default x;")
+      }.must_raise Quickjs::ReferenceError
+    end
+  end
+
   describe "ConsoleLoggers" do
     before do
       @vm = Quickjs::VM.new

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -784,6 +784,13 @@ describe Quickjs::VM do
         @vm.import('Helper', from: "import x from 'missing'; export default x;")
       }.must_raise Quickjs::ReferenceError
     end
+
+    it "imports from a specifier via filename: without inline source" do
+      @vm.on_load_module { |name| "export const greet = (who) => `Hello, ${who}!`;" if name == 'greet' }
+      @vm.import(['greet'], filename: 'greet')
+
+      _(@vm.eval_code("greet('world')")).must_equal 'Hello, world!'
+    end
   end
 
   describe "ConsoleLoggers" do


### PR DESCRIPTION
## Context

Alternative to #27 (`module_loader=`) exploring a block-based interface consistent with the existing `on_log` pattern, plus a harmonized `filename:` option on `import`.

## Changes

### `VM#on_load_module` — block-based module loader hook

```ruby
vm = Quickjs::VM.new
modules = {
  'a' => "import { b } from 'b'; export const a = () => `a-${b()}`;",
  'b' => "export const b = () => 'b-result';"
}
vm.on_load_module { |name| modules[name] }

vm.import(['a'], from: "import { a } from 'a'; export { a };")
vm.eval_code('a()') #=> 'a-b-result'
```

The block receives the module specifier and returns source as a `String`, or `nil` for "not found" (→ `Quickjs::ReferenceError`). Ruby exceptions raised inside the block propagate back through the existing error bridge. When no block is set, behavior is unchanged — imports fall through to QuickJS's filesystem loader.

The name borrows `load` from the ECMA-262 `HostLoadImportedModule` host hook — the spec-level name for this operation.

### `import(filename:)` — resolve via loader without inline source

When a loader is set, the bridge module boilerplate can be eliminated by passing `filename:` instead of `from:`:

```ruby
vm.on_load_module { |name| modules[name] }

# before
vm.import(['a'], from: "import { a } from 'a'; export { a };")

# after
vm.import(['a'], filename: 'a')
```

`filename:` is consistent with `eval_code(source, filename:)` and `preload_module(source, filename:)` — it means "the name of this module in the JS engine."

## vs #27 (`module_loader=`)

Same C-level machinery, different Ruby surface:

| | #27 `module_loader=` | This PR |
|---|---|---|
| Style | attr-writer, takes a Proc | block method, like `on_log` |
| Consistent with | — | `on_log`, `eval_code(filename:)` |
| Clearable | `vm.module_loader = nil` | not supported |

@ursm would love your take on which interface feels more natural for the capybara-simulated use case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)