### PR TITLE
Allow import(filename:) to resolve via module_loader without inline source

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,11 +141,13 @@ modules = {
 }
 vm.module_loader = ->(name) { modules[name] }
 
-vm.import(['a'], from: "import { a } from 'a'; export { a };")
+vm.import(['a'], filename: 'a')
 vm.eval_code('a()') #=> 'a-b-result'
 ```
 
 The Proc receives the (already normalized) module specifier and returns the module source as a `String`, or `nil` to signal "not found" (which raises `Quickjs::ReferenceError` on the JS side). Pass `nil` to clear a previously set loader.
+
+When `module_loader=` is set, pass `filename:` to `import` instead of `from:` to resolve a named specifier directly through the loader — no inline bridge source needed.
 
 #### `Quickjs::VM#define_function`: 💎 Define a global function for JS by Ruby
 

--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -1222,7 +1222,8 @@ static VALUE vm_m_import(int argc, VALUE *argv, VALUE r_self)
   if (NIL_P(r_opts))
     r_opts = rb_hash_new();
   VALUE r_from = rb_hash_aref(r_opts, ID2SYM(rb_intern("from")));
-  if (NIL_P(r_from))
+  VALUE r_filename = rb_hash_aref(r_opts, ID2SYM(rb_intern("filename")));
+  if (NIL_P(r_from) && NIL_P(r_filename))
   {
     VALUE r_error_message = rb_str_new2("missing import source");
     rb_exc_raise(rb_funcall(QUICKJSRB_ERROR_FOR(QUICKJSRB_ROOT_RUNTIME_ERROR), rb_intern("new"), 2, r_error_message, Qnil));
@@ -1233,16 +1234,24 @@ static VALUE vm_m_import(int argc, VALUE *argv, VALUE r_self)
   VMData *data;
   TypedData_Get_Struct(r_self, VMData, &vm_type, data);
 
-  char *filename = random_string();
-  char *source = StringValueCStr(r_from);
-  JSValue module = JS_Eval(data->context, source, strlen(source), filename, JS_EVAL_TYPE_MODULE | JS_EVAL_FLAG_COMPILE_ONLY);
-  if (JS_IsException(module))
+  char *filename;
+  if (!NIL_P(r_filename))
   {
-    JS_FreeValue(data->context, module);
-    return to_rb_value(data->context, module);
+    filename = StringValueCStr(r_filename);
   }
-  js_module_set_import_meta(data->context, module, TRUE, FALSE);
-  JS_FreeValue(data->context, module);
+  else
+  {
+    filename = random_string();
+    char *source = StringValueCStr(r_from);
+    JSValue module = JS_Eval(data->context, source, strlen(source), filename, JS_EVAL_TYPE_MODULE | JS_EVAL_FLAG_COMPILE_ONLY);
+    if (JS_IsException(module))
+    {
+      JS_FreeValue(data->context, module);
+      return to_rb_value(data->context, module);
+    }
+    js_module_set_import_meta(data->context, module, TRUE, FALSE);
+    JS_FreeValue(data->context, module);
+  }
 
   VALUE r_import_settings = rb_funcall(
       rb_const_get(rb_cClass, rb_intern("Quickjs")),

--- a/sig/quickjs.rbs
+++ b/sig/quickjs.rbs
@@ -29,6 +29,7 @@ module Quickjs
                        | (Array[String | Symbol] path, *Symbol flags) { (*untyped) -> untyped } -> Array[Symbol]
 
     def import: (String | Array[String] | Hash[Symbol, String] imported, from: String, ?code_to_expose: String?) -> true
+              | (String | Array[String] | Hash[Symbol, String] imported, filename: String) -> true
 
     def module_loader: () -> (^(String) -> String? | nil)
 

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -732,6 +732,13 @@ describe Quickjs::VM do
         @vm.import('* as all', from: 'should be syntax error')
       }.must_raise Quickjs::SyntaxError
     end
+
+    it "resolves via module_loader when filename: is given instead of from:" do
+      @vm.module_loader = ->(name) { 'export const greet = (who) => `Hello, ${who}!`;' if name == 'greet' }
+      @vm.import(['greet'], filename: 'greet')
+
+      _(@vm.eval_code("greet('world')")).must_equal 'Hello, world!'
+    end
   end
 
   describe "ModuleLoader" do


### PR DESCRIPTION
## Summary

Follow-up to #27. When `module_loader=` is set, importing from a named module currently requires writing a bridge module inline:

```ruby
vm.module_loader = ->(name) { modules[name] }
vm.import(['a'], from: "import { a } from 'a'; export { a };")
```

This PR adds a `filename:` option to `import` that lets you reference a specifier directly, delegating resolution to the loader — no inline source needed:

```ruby
vm.module_loader = ->(name) { modules[name] }
vm.import(['a'], filename: 'a')
```

`filename:` is consistent with `eval_code(source, filename:)` — it means "the name of this module in the JS engine." When given, the compile step is skipped entirely and the bridge imports directly from the named specifier.

`from:` and `filename:` are mutually exclusive; passing neither raises the existing `RuntimeError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)