### PR TITLE
Convert QuickJS rope strings (JS_TAG_STRING_ROPE) to Ruby

### DIFF
--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -270,7 +270,11 @@ VALUE to_rb_value(JSContext *ctx, JSValue j_val)
     return JS_ToBool(ctx, j_val) > 0 ? Qtrue : Qfalse;
   }
   case JS_TAG_STRING:
+  case JS_TAG_STRING_ROPE:
   {
+    // QuickJS keeps long `s += chunk` chains as a rope (JS_TAG_STRING_ROPE)
+    // until something materialises them. JS_ToCStringLen flattens ropes
+    // transparently, so both tags share the same conversion path.
     size_t len;
     const char *str = JS_ToCStringLen(ctx, &len, j_val);
     if (str == NULL)

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -44,6 +44,15 @@ describe Quickjs do
       assert_code("'a\0b'.length", 3)
     end
 
+    it "string built via repeated concat (QuickJS rope) round-trips" do
+      result = ::Quickjs.eval_code(<<~JS)
+        let s = "";
+        for (let i = 0; i < 10000; i++) s += "abc";
+        s;
+      JS
+      _(result).must_equal 'abc' * 10000
+    end
+
     it "number for integer becomes Integer" do
       assert_code("2+3", 5)
       assert_code("18014398509481982n", 18014398509481982)


### PR DESCRIPTION
## Bug

Long `s += chunk` chains in JS leave the result as `JS_TAG_STRING_ROPE` rather than `JS_TAG_STRING` — QuickJS only materialises the flat string when something forces it. `to_rb_value`'s `switch (JS_VALUE_GET_NORM_TAG(j_val))` only matched `JS_TAG_STRING`, so a rope hit the `default: return Qnil` fall-through and the **entire return value was silently nilled out**.

Reproducer (fails on `main`, passes here):

```ruby
Quickjs.eval_code(<<~JS)
  let s = "";
  for (let i = 0; i < 10000; i++) s += "abc";
  s;
JS
# main: nil
# fixed: 30000-byte String
```

The threshold at which QuickJS switches to a rope is internal and not size-stable — anything that builds a string by repeated concatenation in a loop is a candidate. [capybara-simulated](https://github.com/ursm/capybara-simulated) hit this when a JS-side hex encoder accumulated bytes via `s += b.toString(16)`; the workaround until now was a JS-side `.normalize()` to flatten before crossing the bridge, or chunked `.substr()` reads.

## Fix

```c
case JS_TAG_STRING:
case JS_TAG_STRING_ROPE:
{
  // QuickJS keeps long `s += chunk` chains as a rope (JS_TAG_STRING_ROPE)
  // until something materialises them. JS_ToCStringLen flattens ropes
  // transparently, so both tags share the same conversion path.
  ...
}
```

`JS_ToCStringLen` calls `JS_ToString` internally which flattens ropes, so both string tags can share the existing conversion path. One added `case` line.

## Tests

New regression test under `ResultConversion`:

```
"string built via repeated concat (QuickJS rope) round-trips"
  → 30000-byte String (was: nil)
```

Manually exercised across sizes 10/1k/10k/100k/1M iterations — all round-trip with the correct bytesize.

🤖 Generated with [Claude Code](https://claude.com/claude-code)