### PR TITLE
Release the GVL during VM construction

### DIFF
--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -785,6 +785,40 @@ static JSValue js_console_error(JSContext *ctx, JSValueConst this, int argc, JSV
   return js_quickjsrb_log(ctx, this, argc, argv, "error");
 }
 
+// Polyfill bytecode load + eval is the heavy part of VM construction
+// (POLYFILL_INTL alone is ~140ms — FormatJS locale data + IANA TZ tables).
+// Run it without the GVL so a background warmer thread can populate a VM
+// pool in parallel with the main thread on multi-core hosts.
+//
+// Releasing the GVL here is only safe because the polyfills are pure JS
+// (FormatJS / file / encoding / URL bundles) and no Ruby-bridged callbacks
+// have been registered on globalThis yet at this point in vm_m_initialize.
+// If the order ever changes — e.g. moving define_function setup ahead of
+// the polyfill loads — the polyfill bytecode could re-enter Ruby without
+// the GVL held. Keep host callback registration after polyfill loading.
+struct polyfill_load_args
+{
+  JSContext *ctx;
+  const uint8_t *buf;
+  size_t buf_len;
+  JSValue result;
+};
+
+static void *polyfill_load_no_gvl(void *p)
+{
+  struct polyfill_load_args *args = p;
+  JSValue obj = JS_ReadObject(args->ctx, args->buf, args->buf_len, JS_READ_OBJ_BYTECODE);
+  args->result = JS_EvalFunction(args->ctx, obj); // frees obj
+  return NULL;
+}
+
+static JSValue load_polyfill_bytecode(JSContext *ctx, const uint8_t *buf, size_t buf_len)
+{
+  struct polyfill_load_args args = {ctx, buf, buf_len, JS_UNDEFINED};
+  rb_thread_call_without_gvl(polyfill_load_no_gvl, &args, NULL, NULL);
+  return args.result;
+}
+
 static VALUE vm_m_initialize(int argc, VALUE *argv, VALUE r_self)
 {
   VALUE r_opts;
@@ -850,15 +884,13 @@ static VALUE vm_m_initialize(int argc, VALUE *argv, VALUE r_self)
     JSValue j_defineIntl = JS_Eval(data->context, defineIntl, strlen(defineIntl), "<vm>", JS_EVAL_TYPE_GLOBAL);
     JS_FreeValue(data->context, j_defineIntl);
 
-    JSValue j_polyfillIntlObject = JS_ReadObject(data->context, &qjsc_polyfill_intl_en_min, qjsc_polyfill_intl_en_min_size, JS_READ_OBJ_BYTECODE);
-    JSValue j_polyfillIntlResult = JS_EvalFunction(data->context, j_polyfillIntlObject); // Frees polyfillIntlObject
+    JSValue j_polyfillIntlResult = load_polyfill_bytecode(data->context, &qjsc_polyfill_intl_en_min, qjsc_polyfill_intl_en_min_size);
     JS_FreeValue(data->context, j_polyfillIntlResult);
   }
 
   if (RTEST(rb_funcall(r_features, rb_intern("include?"), 1, QUICKJSRB_SYM(featurePolyfillFileId))))
   {
-    JSValue j_polyfillFileObject = JS_ReadObject(data->context, &qjsc_polyfill_file_min, qjsc_polyfill_file_min_size, JS_READ_OBJ_BYTECODE);
-    JSValue j_polyfillFileResult = JS_EvalFunction(data->context, j_polyfillFileObject);
+    JSValue j_polyfillFileResult = load_polyfill_bytecode(data->context, &qjsc_polyfill_file_min, qjsc_polyfill_file_min_size);
     JS_FreeValue(data->context, j_polyfillFileResult);
 
     quickjsrb_init_file_proxy(data);
@@ -866,15 +898,13 @@ static VALUE vm_m_initialize(int argc, VALUE *argv, VALUE r_self)
 
   if (RTEST(rb_funcall(r_features, rb_intern("include?"), 1, QUICKJSRB_SYM(featurePolyfillEncodingId))))
   {
-    JSValue j_polyfillEncodingObject = JS_ReadObject(data->context, &qjsc_polyfill_encoding_min, qjsc_polyfill_encoding_min_size, JS_READ_OBJ_BYTECODE);
-    JSValue j_polyfillEncodingResult = JS_EvalFunction(data->context, j_polyfillEncodingObject);
+    JSValue j_polyfillEncodingResult = load_polyfill_bytecode(data->context, &qjsc_polyfill_encoding_min, qjsc_polyfill_encoding_min_size);
     JS_FreeValue(data->context, j_polyfillEncodingResult);
   }
 
   if (RTEST(rb_funcall(r_features, rb_intern("include?"), 1, QUICKJSRB_SYM(featurePolyfillUrlId))))
   {
-    JSValue j_polyfillUrlObject = JS_ReadObject(data->context, &qjsc_polyfill_url_min, qjsc_polyfill_url_min_size, JS_READ_OBJ_BYTECODE);
-    JSValue j_polyfillUrlResult = JS_EvalFunction(data->context, j_polyfillUrlObject);
+    JSValue j_polyfillUrlResult = load_polyfill_bytecode(data->context, &qjsc_polyfill_url_min, qjsc_polyfill_url_min_size);
     JS_FreeValue(data->context, j_polyfillUrlResult);
   }
 

--- a/ext/quickjsrb/quickjsrb.h
+++ b/ext/quickjsrb/quickjsrb.h
@@ -3,6 +3,7 @@
 
 #include "ruby.h"
 #include "ruby/encoding.h"
+#include "ruby/thread.h"
 
 #include "quickjs.h"
 #include "quickjs-libc.h"
@@ -110,6 +111,18 @@ static const rb_data_type_t vm_type = {
     .flags = RUBY_TYPED_FREE_IMMEDIATELY,
 };
 
+struct vm_create_args
+{
+  JSContext *context;
+};
+
+static void *vm_create_no_gvl(void *p)
+{
+  struct vm_create_args *args = p;
+  args->context = JS_NewContext(JS_NewRuntime());
+  return NULL;
+}
+
 static VALUE vm_alloc(VALUE r_self)
 {
   VMData *data;
@@ -123,8 +136,12 @@ static VALUE vm_alloc(VALUE r_self)
   EvalTime *eval_time = malloc(sizeof(EvalTime));
   data->eval_time = eval_time;
 
-  JSRuntime *runtime = JS_NewRuntime();
-  data->context = JS_NewContext(runtime);
+  // JSRuntime / JSContext creation is pure QuickJS C work — no Ruby state
+  // touched. Release the GVL so a background warmer thread can run this in
+  // parallel with the main thread on multi-core hosts.
+  struct vm_create_args args = {NULL};
+  rb_thread_call_without_gvl(vm_create_no_gvl, &args, NULL, NULL);
+  data->context = args.context;
 
   return obj;
 }


### PR DESCRIPTION
## Why

`Quickjs::VM.new` currently holds the GVL through every step of bootstrap, including `JS_NewRuntime` / `JS_NewContext` / polyfill bytecode evaluation. With `POLYFILL_INTL` enabled, that's a ~140 ms span on every construction during which **no other Ruby thread can make progress**, even on a machine with idle cores.

The downstream pain point is [capybara-simulated](https://github.com/ursm/capybara-simulated): a Capybara-shared-spec run needs ~16 fresh `Quickjs::VM` instances per second to keep up with test throughput when each visit gets a clean VM. A single-threaded warmer caps at ~7 inits/sec on this hardware (~140ms × 1) — far short of the 16/sec required, and crucially, **adding warmer threads doesn't help on MRI** because the GVL serialises VM construction. The pool falls behind under load and the foreground thread blocks waiting for a warm VM.

(Background context: this came up while exploring options to replace capybara-simulated's `__resetPage()` logic with per-visit fresh VMs — see [#35](https://github.com/hmsk/quickjs.rb/issues/35) for the broader thread on isolation strategies. A throwaway-pool approach is the simplest path *if* warming can run in parallel; this PR is the missing piece for that.)

## What

Wrap two pure-QuickJS spans with `rb_thread_call_without_gvl`:

1. `JS_NewRuntime` + `JS_NewContext` in `vm_alloc`
2. Each polyfill's `JS_ReadObject` + `JS_EvalFunction` pair in `vm_m_initialize`, via a small `load_polyfill_bytecode` helper

These regions touch only QuickJS C state, no Ruby APIs, so they're safe to release the GVL from. QuickJS's threading contract (one runtime per thread, but distinct runtimes may run on distinct threads concurrently) is exactly what a background warmer wants.

No API change; existing callers see identical behaviour.

## Numbers

Microbench: build 8 VMs with `features: [Quickjs::POLYFILL_INTL]`, single-threaded vs in 8 parallel threads.

| | wall time | per VM |
|---|---|---|
| Serial | 1103.7 ms | 138.0 ms |
| Parallel × 8 | 160.2 ms | 20.0 ms |
| **Speedup** | **6.89×** | |

Wall ≈ CPU before this change; wall ≪ CPU after, confirming GVL is genuinely released.

## Test plan

- [x] `bundle exec rake test` — 401 runs, 558 assertions, 0 failures
- [x] Functional sanity post-parallel-build: every parallel-built VM evaluates `typeof Intl.DateTimeFormat` correctly
- [x] No new public API to test; behaviour is identical to before for sequential callers

🤖 Generated with [Claude Code](https://claude.com/claude-code)