### PR TITLE
Don't crash on JSON-incompatible objects in to_r_json

### DIFF
--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -188,12 +188,24 @@ VALUE to_r_json(JSContext *ctx, JSValue j_val)
 {
   JSValue j_stringified = JS_JSONStringify(ctx, j_val, JS_UNDEFINED, JS_UNDEFINED);
 
+  // JSON.stringify throws on circular structures (e.g. jQuery objects'
+  // prevObject chain). Clear the pending exception so it doesn't poison
+  // subsequent eval, and return nil so callers fall through to "couldn't
+  // parse" handling rather than crashing on rb_str_new2(NULL) below.
+  if (JS_IsException(j_stringified))
+  {
+    JS_FreeValue(ctx, j_stringified);
+    JSValue j_pending = JS_GetException(ctx);
+    JS_FreeValue(ctx, j_pending);
+    return Qnil;
+  }
+
   const char *msg = JS_ToCString(ctx, j_stringified);
+  JS_FreeValue(ctx, j_stringified);
+  if (msg == NULL)
+    return Qnil;
   VALUE r_str = rb_str_new2(msg);
   JS_FreeCString(ctx, msg);
-
-  JS_FreeValue(ctx, j_stringified);
-
   return r_str;
 }
 


### PR DESCRIPTION
Rebased from #22 (originally authored by @ursm) onto current main after #33 landed.

## What this adds on top of main

The cycle-detection work in #33 handles circular plain objects and arrays at the Ruby value conversion layer. This PR adds a separate guard in `to_r_json` itself:

- If `JSON.stringify` throws (e.g. on objects with `BigInt` values, or other non-serialisable types), detect the exception, clear the QuickJS pending exception so subsequent eval isn't poisoned, and return `Qnil` rather than passing `JS_EXCEPTION` into `JS_ToCString` → `rb_str_new2(NULL)` → `ArgumentError: NULL pointer given`.
- Also guards `JS_ToCString`'s return value for any remaining edge case where it returns `NULL`.

## Conflict resolution

The test assertions from #22 expected `nil` for the whole circular object. Since #33 changed that behaviour to `{'self' => nil}`, those tests were dropped in favour of the ones already on main. No net test coverage lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)