### PR TITLE
Refuse further evaluation after JS-level out-of-memory

### DIFF
--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -29,6 +29,9 @@ static int dispatch_log(VMData *data, const char *severity, VALUE r_row);
 JSValue to_js_value(JSContext *ctx, VALUE r_value);
 VALUE to_rb_value(JSContext *ctx, JSValue j_val);
 static VALUE to_rb_value_inner(JSContext *ctx, JSValue j_val, VALUE r_visited);
+static VALUE vm_m_memoryUsage(VALUE r_self);
+static VALUE vm_m_runGC(VALUE r_self);
+static VALUE vm_m_oomPoisoned(VALUE r_self);
 
 JSValue j_error_from_ruby_error(JSContext *ctx, VALUE r_error)
 {
@@ -448,6 +451,14 @@ static VALUE to_rb_value_inner(JSContext *ctx, JSValue j_val, VALUE r_visited)
       else if (strcmp(errorClassName, "Quickjs::InterruptedError") == 0)
       {
         r_error_class = QUICKJSRB_ERROR_FOR(QUICKJSRB_INTERRUPTED_ERROR);
+      }
+      else if (strcmp(errorClassName, "InternalError") == 0 && strstr(errorClassMessage, "out of memory") != NULL)
+      {
+        // Once OOM has fired, the QuickJS heap is in a state where another
+        // throw inside the parser-error path can corrupt the shape table and
+        // segfault. Mark the VM so further eval/call calls refuse cleanly.
+        data->oom_poisoned = true;
+        r_error_class = QUICKJSRB_ERROR_FOR(QUICKJSRB_ROOT_RUNTIME_ERROR);
       }
       else
       {
@@ -930,6 +941,15 @@ static VALUE to_rb_return_value(JSContext *ctx, JSValue j_val)
   return result;
 }
 
+static void check_oom_poisoned(VMData *data)
+{
+  if (data->oom_poisoned)
+  {
+    VALUE r_msg = rb_str_new2("VM is poisoned: a previous evaluation hit out-of-memory; further evaluation may segfault. Recreate the Quickjs::VM.");
+    rb_exc_raise(rb_funcall(QUICKJSRB_ERROR_FOR(QUICKJSRB_ROOT_RUNTIME_ERROR), rb_intern("new"), 2, r_msg, Qnil));
+  }
+}
+
 // Validate that r_code is a String and resolve the :filename option (default "<code>")
 // from the keyword-args hash that rb_scan_args(... "1:") collects. Both eval_code and
 // compile share this argument shape.
@@ -959,6 +979,8 @@ static VALUE vm_m_evalCode(int argc, VALUE *argv, VALUE r_self)
 {
   VMData *data;
   TypedData_Get_Struct(r_self, VMData, &vm_type, data);
+
+  check_oom_poisoned(data);
 
   VALUE r_code, r_opts;
   rb_scan_args(argc, argv, "1:", &r_code, &r_opts);
@@ -1187,6 +1209,8 @@ static VALUE vm_m_callGlobalFunction(int argc, VALUE *argv, VALUE r_self)
 
   VMData *data;
   TypedData_Get_Struct(r_self, VMData, &vm_type, data);
+
+  check_oom_poisoned(data);
 
   JSValue j_this = JS_UNDEFINED;
   JSValue j_func;
@@ -1423,5 +1447,45 @@ RUBY_FUNC_EXPORTED void Init_quickjsrb(void)
   rb_define_method(r_class_vm, "module_loader", vm_m_get_module_loader, 0);
   rb_define_method(r_class_vm, "module_loader=", vm_m_set_module_loader, 1);
   rb_define_method(r_class_vm, "on_log", vm_m_on_log, 0);
+  rb_define_method(r_class_vm, "memory_usage", vm_m_memoryUsage, 0);
+  rb_define_method(r_class_vm, "gc!", vm_m_runGC, 0);
+  rb_define_method(r_class_vm, "oom_poisoned?", vm_m_oomPoisoned, 0);
   r_define_log_class(r_class_vm);
+}
+
+static VALUE vm_m_memoryUsage(VALUE r_self)
+{
+  VMData *data;
+  TypedData_Get_Struct(r_self, VMData, &vm_type, data);
+  JSMemoryUsage s;
+  JS_ComputeMemoryUsage(JS_GetRuntime(data->context), &s);
+  VALUE h = rb_hash_new();
+  rb_hash_aset(h, ID2SYM(rb_intern("malloc_size")), LL2NUM(s.malloc_size));
+  rb_hash_aset(h, ID2SYM(rb_intern("malloc_limit")), LL2NUM(s.malloc_limit));
+  rb_hash_aset(h, ID2SYM(rb_intern("memory_used_size")), LL2NUM(s.memory_used_size));
+  rb_hash_aset(h, ID2SYM(rb_intern("atom_count")), LL2NUM(s.atom_count));
+  rb_hash_aset(h, ID2SYM(rb_intern("str_count")), LL2NUM(s.str_count));
+  rb_hash_aset(h, ID2SYM(rb_intern("obj_count")), LL2NUM(s.obj_count));
+  rb_hash_aset(h, ID2SYM(rb_intern("prop_count")), LL2NUM(s.prop_count));
+  rb_hash_aset(h, ID2SYM(rb_intern("shape_count")), LL2NUM(s.shape_count));
+  rb_hash_aset(h, ID2SYM(rb_intern("js_func_count")), LL2NUM(s.js_func_count));
+  rb_hash_aset(h, ID2SYM(rb_intern("js_func_code_size")), LL2NUM(s.js_func_code_size));
+  rb_hash_aset(h, ID2SYM(rb_intern("c_func_count")), LL2NUM(s.c_func_count));
+  rb_hash_aset(h, ID2SYM(rb_intern("array_count")), LL2NUM(s.array_count));
+  return h;
+}
+
+static VALUE vm_m_runGC(VALUE r_self)
+{
+  VMData *data;
+  TypedData_Get_Struct(r_self, VMData, &vm_type, data);
+  JS_RunGC(JS_GetRuntime(data->context));
+  return Qnil;
+}
+
+static VALUE vm_m_oomPoisoned(VALUE r_self)
+{
+  VMData *data;
+  TypedData_Get_Struct(r_self, VMData, &vm_type, data);
+  return data->oom_poisoned ? Qtrue : Qfalse;
 }

--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -31,7 +31,7 @@ VALUE to_rb_value(JSContext *ctx, JSValue j_val);
 static VALUE to_rb_value_inner(JSContext *ctx, JSValue j_val, VALUE r_visited);
 static VALUE vm_m_memoryUsage(VALUE r_self);
 static VALUE vm_m_runGC(VALUE r_self);
-static VALUE vm_m_oomPoisoned(VALUE r_self);
+static VALUE vm_m_memoryPoisoned(VALUE r_self);
 
 JSValue j_error_from_ruby_error(JSContext *ctx, VALUE r_error)
 {
@@ -1449,7 +1449,7 @@ RUBY_FUNC_EXPORTED void Init_quickjsrb(void)
   rb_define_method(r_class_vm, "on_log", vm_m_on_log, 0);
   rb_define_method(r_class_vm, "memory_usage", vm_m_memoryUsage, 0);
   rb_define_method(r_class_vm, "gc!", vm_m_runGC, 0);
-  rb_define_method(r_class_vm, "oom_poisoned?", vm_m_oomPoisoned, 0);
+  rb_define_method(r_class_vm, "memory_poisoned?", vm_m_memoryPoisoned, 0);
   r_define_log_class(r_class_vm);
 }
 
@@ -1483,7 +1483,7 @@ static VALUE vm_m_runGC(VALUE r_self)
   return Qnil;
 }
 
-static VALUE vm_m_oomPoisoned(VALUE r_self)
+static VALUE vm_m_memoryPoisoned(VALUE r_self)
 {
   VMData *data;
   TypedData_Get_Struct(r_self, VMData, &vm_type, data);

--- a/ext/quickjsrb/quickjsrb.h
+++ b/ext/quickjsrb/quickjsrb.h
@@ -57,6 +57,12 @@ typedef struct VMData
   VALUE alive_objects;
   VALUE module_loader;
   JSValue j_file_proxy_creator;
+  // Once the runtime has hit JS-level "out of memory", the QuickJS heap is in
+  // a fragile state where further evaluation can trigger a use-after-free in
+  // the parser-error-during-OOM cascade (segfault inside js_shape_hash_unlink).
+  // Trip this flag so subsequent eval_code/call calls refuse cleanly with a
+  // Ruby exception instead of risking a process crash.
+  bool oom_poisoned;
 } VMData;
 
 static void vm_free(void *ptr)
@@ -119,6 +125,7 @@ static VALUE vm_alloc(VALUE r_self)
   data->alive_objects = rb_hash_new();
   data->module_loader = Qnil;
   data->j_file_proxy_creator = JS_UNDEFINED;
+  data->oom_poisoned = false;
 
   EvalTime *eval_time = malloc(sizeof(EvalTime));
   data->eval_time = eval_time;

--- a/sig/quickjs.rbs
+++ b/sig/quickjs.rbs
@@ -39,6 +39,12 @@ module Quickjs
 
     def on_log: () { (Log) -> void } -> nil
 
+    def memory_usage: () -> Hash[Symbol, Integer]
+
+    def gc!: () -> nil
+
+    def oom_poisoned?: () -> bool
+
     class Log
       attr_reader severity: Symbol
 

--- a/sig/quickjs.rbs
+++ b/sig/quickjs.rbs
@@ -43,7 +43,7 @@ module Quickjs
 
     def gc!: () -> nil
 
-    def oom_poisoned?: () -> bool
+    def memory_poisoned?: () -> bool
 
     class Log
       attr_reader severity: Symbol

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -318,9 +318,9 @@ describe Quickjs::VM do
     it "after OOM, marks the VM poisoned and refuses further evaluation" do
       # 1 MB limit; allocate a single buffer larger than that.
       vm = Quickjs::VM.new(memory_limit: 1024 * 1024)
-      _(vm.oom_poisoned?).must_equal false
+      _(vm.memory_poisoned?).must_equal false
       _ { vm.eval_code('new Array(2_000_000).fill(0); void 0') }.must_raise Quickjs::RuntimeError
-      _(vm.oom_poisoned?).must_equal true
+      _(vm.memory_poisoned?).must_equal true
       err = _ { vm.eval_code('1 + 1') }.must_raise Quickjs::RuntimeError
       _(err.message).must_match(/poisoned/)
     end

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -310,8 +310,30 @@ describe Quickjs::VM do
     it "maintains the same context within a vm" do
       @vm.eval_code('const a = { b: "c" };')
       _(@vm.eval_code('a.b')).must_equal "c"
+      _(@vm.eval_code('a.b')).must_equal "c"
       @vm.eval_code('a.b = "d"')
       _(@vm.eval_code('a.b')).must_equal "d"
+    end
+
+    it "after OOM, marks the VM poisoned and refuses further evaluation" do
+      # 1 MB limit; allocate a single buffer larger than that.
+      vm = Quickjs::VM.new(memory_limit: 1024 * 1024)
+      _(vm.oom_poisoned?).must_equal false
+      _ { vm.eval_code('new Array(2_000_000).fill(0); void 0') }.must_raise Quickjs::RuntimeError
+      _(vm.oom_poisoned?).must_equal true
+      err = _ { vm.eval_code('1 + 1') }.must_raise Quickjs::RuntimeError
+      _(err.message).must_match(/poisoned/)
+    end
+
+    it "memory_usage returns a hash of QuickJS heap stats" do
+      stats = @vm.memory_usage
+      _(stats).must_be_kind_of Hash
+      _(stats[:malloc_size]).must_be :>, 0
+      _(stats[:obj_count]).must_be :>, 0
+    end
+
+    it "gc! returns nil and is callable" do
+      _(@vm.gc!).must_be_nil
     end
 
     it "does not enable std/os module as default" do


### PR DESCRIPTION
Rebased from #23 (originally authored by @ursm) onto current main.

## What this does

When QuickJS hits `InternalError: out of memory`, the heap is in a fragile state where a subsequent throw inside the parser-error path can corrupt the shape table and segfault the process. This PR prevents that by:

- Detecting `InternalError: out of memory` in the exception-marshalling path and setting an `oom_poisoned` flag on `VMData`
- Having `eval_code` and `call` check that flag up front and raise `Quickjs::RuntimeError` before invoking `JS_Eval`, so the caller gets a recoverable Ruby exception instead of a crash

Three diagnostic APIs are also added:

```ruby
vm.memory_usage     # => { malloc_size:, malloc_limit:, obj_count:, ... }
vm.gc!              # runs JS_RunGC for cycle collection
vm.memory_poisoned? # => true once OOM has been hit
```

## Naming

`oom_poisoned?` from the original PR was renamed to `memory_poisoned?` to be consistent with the `memory_` prefix used by `memory_usage`, and because "poisoned" alone captures the state better than the `oom_` prefix which names the cause rather than the effect. `gc!` is left unprefixed — the VM receiver already provides enough context.

## Conflict resolution

The two #22 commits that were stacked at the base were skipped (already in main via #37). The one genuine #23 commit had a conflict in `quickjsrb.c` from functions added by the bytecode-cache PR (#31) — `parse_code_and_filename` and `arm_eval_timer` — which are now placed after `check_oom_poisoned`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)