### PR TITLE
Add VM#dispose! to release the JS heap eagerly

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,26 @@ rescue Quickjs::RuntimeError => e
 end
 ```
 
+#### `Quickjs::VM#dispose!`: 🧹 Release the underlying C-side runtime eagerly
+
+By default, the `JSRuntime` / `JSContext` behind a `Quickjs::VM` lives until Ruby's GC reclaims the wrapping object. Ruby's GC sizes its trigger by the Ruby-side object footprint (a few pointers) and doesn't see the C-side JS heap, so a workload that rebuilds VMs frequently — per-request, per-page-visit, throwaway pool — can let several megabytes per dead VM accumulate before a major GC fires.
+
+`dispose!` frees the runtime immediately and marks the VM unusable:
+
+```rb
+vm = Quickjs::VM.new(features: [::Quickjs::POLYFILL_INTL])
+vm.eval_code('…')
+vm.dispose!           # frees JSContext + JSRuntime now
+vm.disposed?          #=> true
+vm.eval_code('1 + 1') # raises Quickjs::RuntimeError "VM has been disposed"
+```
+
+`dispose!` is idempotent and safe to call before letting Ruby drop the reference — the dfree handler is a no-op on an already-disposed VM. The teardown itself can take tens of milliseconds on a VM with polyfills loaded; the GVL is released during the free so other Ruby threads (e.g. a background pool builder) keep running. For fire-and-forget teardown that doesn't block the caller, wrap it in a thread:
+
+```rb
+Thread.new { vm.dispose! }
+```
+
 ### Value Conversion
 
 | JavaScript | | Ruby | Note |

--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -32,6 +32,8 @@ static VALUE to_rb_value_inner(JSContext *ctx, JSValue j_val, VALUE r_visited);
 static VALUE vm_m_memoryUsage(VALUE r_self);
 static VALUE vm_m_runGC(VALUE r_self);
 static VALUE vm_m_memoryPoisoned(VALUE r_self);
+static VALUE vm_m_dispose(VALUE r_self);
+static VALUE vm_m_disposed(VALUE r_self);
 
 JSValue j_error_from_ruby_error(JSContext *ctx, VALUE r_error)
 {
@@ -984,6 +986,15 @@ static void check_oom_poisoned(VMData *data)
   }
 }
 
+static void check_disposed(VMData *data)
+{
+  if (data->disposed)
+  {
+    VALUE r_msg = rb_str_new2("VM has been disposed; create a new Quickjs::VM");
+    rb_exc_raise(rb_funcall(QUICKJSRB_ERROR_FOR(QUICKJSRB_ROOT_RUNTIME_ERROR), rb_intern("new"), 2, r_msg, Qnil));
+  }
+}
+
 // Validate that r_code is a String and resolve the :filename option (default "<code>")
 // from the keyword-args hash that rb_scan_args(... "1:") collects. Both eval_code and
 // compile share this argument shape.
@@ -1014,6 +1025,7 @@ static VALUE vm_m_evalCode(int argc, VALUE *argv, VALUE r_self)
   VMData *data;
   TypedData_Get_Struct(r_self, VMData, &vm_type, data);
 
+  check_disposed(data);
   check_oom_poisoned(data);
 
   VALUE r_code, r_opts;
@@ -1052,6 +1064,8 @@ static VALUE vm_m_compile(int argc, VALUE *argv, VALUE r_self)
   VMData *data;
   TypedData_Get_Struct(r_self, VMData, &vm_type, data);
 
+  check_disposed(data);
+
   VALUE r_code, r_opts;
   rb_scan_args(argc, argv, "1:", &r_code, &r_opts);
   const char *filename = parse_code_and_filename(r_code, r_opts);
@@ -1085,6 +1099,8 @@ static VALUE vm_m_evalBytecode(VALUE r_self, VALUE r_bytecode)
 {
   VMData *data;
   TypedData_Get_Struct(r_self, VMData, &vm_type, data);
+
+  check_disposed(data);
 
   if (!RB_TYPE_P(r_bytecode, T_STRING))
   {
@@ -1126,6 +1142,8 @@ static VALUE vm_m_defineGlobalFunction(int argc, VALUE *argv, VALUE r_self)
 
   VMData *data;
   TypedData_Get_Struct(r_self, VMData, &vm_type, data);
+
+  check_disposed(data);
 
   if (RB_TYPE_P(r_name, T_ARRAY))
   {
@@ -1247,6 +1265,7 @@ static VALUE vm_m_callGlobalFunction(int argc, VALUE *argv, VALUE r_self)
   VMData *data;
   TypedData_Get_Struct(r_self, VMData, &vm_type, data);
 
+  check_disposed(data);
   check_oom_poisoned(data);
 
   JSValue j_this = JS_UNDEFINED;
@@ -1413,6 +1432,8 @@ static VALUE vm_m_import(int argc, VALUE *argv, VALUE r_self)
   VMData *data;
   TypedData_Get_Struct(r_self, VMData, &vm_type, data);
 
+  check_disposed(data);
+
   char *filename;
   if (!NIL_P(r_filename))
   {
@@ -1487,6 +1508,8 @@ RUBY_FUNC_EXPORTED void Init_quickjsrb(void)
   rb_define_method(r_class_vm, "memory_usage", vm_m_memoryUsage, 0);
   rb_define_method(r_class_vm, "gc!", vm_m_runGC, 0);
   rb_define_method(r_class_vm, "memory_poisoned?", vm_m_memoryPoisoned, 0);
+  rb_define_method(r_class_vm, "dispose!", vm_m_dispose, 0);
+  rb_define_method(r_class_vm, "disposed?", vm_m_disposed, 0);
   r_define_log_class(r_class_vm);
 }
 
@@ -1494,6 +1517,7 @@ static VALUE vm_m_memoryUsage(VALUE r_self)
 {
   VMData *data;
   TypedData_Get_Struct(r_self, VMData, &vm_type, data);
+  check_disposed(data);
   JSMemoryUsage s;
   JS_ComputeMemoryUsage(JS_GetRuntime(data->context), &s);
   VALUE h = rb_hash_new();
@@ -1516,6 +1540,7 @@ static VALUE vm_m_runGC(VALUE r_self)
 {
   VMData *data;
   TypedData_Get_Struct(r_self, VMData, &vm_type, data);
+  check_disposed(data);
   JS_RunGC(JS_GetRuntime(data->context));
   return Qnil;
 }
@@ -1525,4 +1550,54 @@ static VALUE vm_m_memoryPoisoned(VALUE r_self)
   VMData *data;
   TypedData_Get_Struct(r_self, VMData, &vm_type, data);
   return data->oom_poisoned ? Qtrue : Qfalse;
+}
+
+// JS_FreeContext + JS_FreeRuntime walk the entire heap to run finalisers.
+// On a VM with polyfills loaded this can be tens of milliseconds — run it
+// without the GVL so other Ruby threads (e.g. the next pool builder) keep
+// progressing. Safe to release because nothing in the teardown path calls
+// back into Ruby: module_loader, console, and define_function callbacks
+// only fire during JS execution, not during free.
+static void *vm_dispose_no_gvl(void *p)
+{
+  vm_teardown_context((JSContext *)p);
+  return NULL;
+}
+
+static VALUE vm_m_dispose(VALUE r_self)
+{
+  VMData *data;
+  TypedData_Get_Struct(r_self, VMData, &vm_type, data);
+
+  if (data->disposed)
+    return Qnil;
+
+  if (!JS_IsUndefined(data->j_file_proxy_creator))
+  {
+    JS_FreeValue(data->context, data->j_file_proxy_creator);
+    data->j_file_proxy_creator = JS_UNDEFINED;
+  }
+
+  // Mark disposed before releasing the GVL so a concurrent dfree finds
+  // disposed=true and skips its own teardown.
+  data->disposed = true;
+
+  rb_thread_call_without_gvl(vm_dispose_no_gvl, data->context, NULL, NULL);
+
+  // Drop references to user-supplied closures so Ruby GC can reclaim them
+  // (and anything they captured) before the wrapping VM object itself is
+  // collected. Matters for pool-rebuild workloads that dispose eagerly.
+  data->defined_functions = rb_hash_new();
+  data->alive_objects = rb_hash_new();
+  data->log_listener = Qnil;
+  data->module_loader = Qnil;
+
+  return Qnil;
+}
+
+static VALUE vm_m_disposed(VALUE r_self)
+{
+  VMData *data;
+  TypedData_Get_Struct(r_self, VMData, &vm_type, data);
+  return data->disposed ? Qtrue : Qfalse;
 }

--- a/ext/quickjsrb/quickjsrb.h
+++ b/ext/quickjsrb/quickjsrb.h
@@ -64,21 +64,33 @@ typedef struct VMData
   // Trip this flag so subsequent eval_code/call calls refuse cleanly with a
   // Ruby exception instead of risking a process crash.
   bool oom_poisoned;
+  // Set by VM#dispose! to release the multi-MB JS heap before Ruby GC sees
+  // enough pressure to collect the wrapper. Doubles as a double-free guard
+  // for the dfree handler.
+  bool disposed;
 } VMData;
+
+static void vm_teardown_context(JSContext *ctx)
+{
+  JSRuntime *runtime = JS_GetRuntime(ctx);
+  JS_SetInterruptHandler(runtime, NULL, NULL);
+  js_std_free_handlers(runtime);
+  JS_FreeContext(ctx);
+  JS_FreeRuntime(runtime);
+}
 
 static void vm_free(void *ptr)
 {
   VMData *data = (VMData *)ptr;
   free(data->eval_time);
 
-  if (!JS_IsUndefined(data->j_file_proxy_creator))
-    JS_FreeValue(data->context, data->j_file_proxy_creator);
+  if (!data->disposed)
+  {
+    if (!JS_IsUndefined(data->j_file_proxy_creator))
+      JS_FreeValue(data->context, data->j_file_proxy_creator);
 
-  JSRuntime *runtime = JS_GetRuntime(data->context);
-  JS_SetInterruptHandler(runtime, NULL, NULL);
-  js_std_free_handlers(runtime);
-  JS_FreeContext(data->context);
-  JS_FreeRuntime(runtime);
+    vm_teardown_context(data->context);
+  }
 
   xfree(ptr);
 }
@@ -139,6 +151,7 @@ static VALUE vm_alloc(VALUE r_self)
   data->module_loader = Qnil;
   data->j_file_proxy_creator = JS_UNDEFINED;
   data->oom_poisoned = false;
+  data->disposed = false;
 
   EvalTime *eval_time = malloc(sizeof(EvalTime));
   data->eval_time = eval_time;

--- a/sig/quickjs.rbs
+++ b/sig/quickjs.rbs
@@ -45,6 +45,10 @@ module Quickjs
 
     def memory_poisoned?: () -> bool
 
+    def dispose!: () -> nil
+
+    def disposed?: () -> bool
+
     class Log
       attr_reader severity: Symbol
 

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -358,6 +358,51 @@ describe Quickjs::VM do
     end
   end
 
+  describe "Dispose" do
+    it "dispose! returns nil and flips disposed?" do
+      vm = Quickjs::VM.new
+      _(vm.disposed?).must_equal false
+      _(vm.dispose!).must_be_nil
+      _(vm.disposed?).must_equal true
+    end
+
+    it "dispose! is idempotent" do
+      vm = Quickjs::VM.new
+      vm.dispose!
+      _(vm.dispose!).must_be_nil
+      _(vm.disposed?).must_equal true
+    end
+
+    {
+      eval_code:       ->(vm) { vm.eval_code('1 + 1') },
+      compile:         ->(vm) { vm.compile('1 + 1') },
+      call:            ->(vm) { vm.call('foo') },
+      define_function: ->(vm) { vm.define_function('foo') { 1 } },
+      import:          ->(vm) { vm.import('x', from: 'export default 1') },
+      memory_usage:    ->(vm) { vm.memory_usage },
+      gc!:             ->(vm) { vm.gc! }
+    }.each do |method, invoke|
+      it "#{method} on a disposed VM raises Quickjs::RuntimeError" do
+        vm = Quickjs::VM.new
+        vm.dispose!
+        err = _ { invoke.call(vm) }.must_raise Quickjs::RuntimeError
+        _(err.message).must_match(/disposed/)
+      end
+    end
+
+    it "memory_poisoned? remains queryable after dispose" do
+      vm = Quickjs::VM.new
+      vm.dispose!
+      _(vm.memory_poisoned?).must_equal false
+    end
+
+    it "lets Ruby GC reclaim a disposed VM without double-free" do
+      10.times { Quickjs::VM.new.dispose! }
+      GC.start
+      pass
+    end
+  end
+
   it "accepts some options to constrain its resource" do
     vm = Quickjs::VM.new(
       memory_limit: 1024 * 1024,


### PR DESCRIPTION
## Summary

Adds `Quickjs::VM#dispose` and `#disposed?` so callers can release the underlying `JSContext` + `JSRuntime` immediately rather than waiting for Ruby GC.

```rb
vm = Quickjs::VM.new(features: [::Quickjs::POLYFILL_INTL])
vm.eval_code('…')
vm.dispose            # frees JSContext + JSRuntime now (GVL released)
vm.disposed?          #=> true
vm.eval_code('1 + 1') # raises Quickjs::RuntimeError "VM has been disposed"
```

## Motivation

Ruby's GC sizes its trigger by the Ruby-side object footprint (a `VMData` struct, a few pointers). It has no visibility into the multi-MB C-side JS heap that QuickJS owns. Workloads that rebuild VMs frequently — per-request, per-page-visit emulators, throwaway pools — can let several megabytes per dead VM accumulate before a major GC actually fires. The dfree handler eventually runs and the memory comes back, but transient RSS scales with `(VM peak heap) × (rebuilds before next GC)`.

Mirrors what `v8::Isolate::Dispose()` exposes in mini_racer; lets a quickjs.rb backend match V8Runtime's teardown ergonomics in embedders that swap engines (relevant for `capybara-simulated` v3 and similar).

## Behavior

- `dispose` frees `JSContext` + `JSRuntime` immediately. The free walks the entire heap to run finalisers and can take tens of milliseconds on a VM with polyfills loaded — it runs via `rb_thread_call_without_gvl` so other Ruby threads keep progressing.
- `dispose` is idempotent. Calling it on an already-disposed VM is a no-op.
- The `dfree` handler short-circuits on `disposed=true`, so `dispose` followed by Ruby GC is not a double-free.
- A new `check_disposed` guard is threaded through every method that touches `data->context` (`eval_code`, `compile`, `_run_bytecode`, `call`, `define_function`, `import`, `memory_usage`, `gc!`) — calls after dispose raise `Quickjs::RuntimeError` with a "VM has been disposed" message.
- `disposed?` returns the current state; `memory_poisoned?` remains queryable on a disposed VM (it just reads a flag).
- Ruby-side refs held by `VMData` (`defined_functions`, `alive_objects`, `log_listener`, `module_loader`) are dropped during dispose so user-supplied Procs and captured state become collectable without waiting for the wrapper itself.

For fire-and-forget teardown, wrap in `Thread.new { vm.dispose }`.

## Test plan

- [x] `bundle exec rake test` — 434 runs, 627 assertions, 0 failures
- [x] New `Dispose` describe block covers: `disposed?` state transition, idempotency, every guarded method raises (parametric loop over `eval_code`/`compile`/`call`/`define_function`/`import`/`memory_usage`/`gc!`), `memory_poisoned?` still queryable post-dispose, Ruby GC reclaim doesn't double-free (`10.times { Quickjs::VM.new.dispose }; GC.start`)