### PR TITLE
Extend vm.module_loader= to a 2-arity callback with scope-aware return

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,40 @@ vm.import(['a'], filename: 'a')
 vm.eval_code('a()') #=> 'a-b-result'
 ```
 
-The Proc receives the (already normalized) module specifier and returns the module source as a `String`, or `nil` to signal "not found" (which raises `Quickjs::ReferenceError` on the JS side). Pass `nil` to clear a previously set loader.
+The Proc may accept one or two arguments. Single-arity (`->(specifier) { ... }`) is the legacy shape: the Proc gets the raw import specifier and returns the source for it. Two-arity (`->(specifier, importer) { ... }`) additionally receives the file that issued the `import`, which is what you need for importmap-style scoping. Pass `nil` to clear a previously set loader.
+
+Return value:
+
+- A `String` — that's the source. The canonical name used for QuickJS's module cache is the specifier itself.
+- A `Hash` `{ code:, as: }` — `code:` is the source, `as:` becomes the canonical name. Use this when the same specifier should resolve to different modules depending on the importer (importmap "scopes"), since QuickJS caches by canonical name and changing the canonical is what isolates the two modules.
+- `nil` or `false` — raises `Quickjs::ReferenceError` on the JS side ("module not found").
+- Anything else — `Quickjs::TypeError`.
+
+Importmap scope example:
+
+```rb
+modules = {
+  '/vendor/lodash.js'       => 'export default { v: "global" };',
+  '/vendor/lodash-admin.js' => 'export default { v: "admin"  };',
+  '/app/admin/main.js'      => "import _ from 'lodash'; export const tag = _.v;"
+}
+
+vm.module_loader = ->(specifier, importer) {
+  case specifier
+  when 'lodash'
+    importer.start_with?('/app/admin/') \
+      ? { code: modules['/vendor/lodash-admin.js'], as: '/vendor/lodash-admin.js' }
+      : { code: modules['/vendor/lodash.js'],       as: '/vendor/lodash.js' }
+  else
+    modules[specifier]
+  end
+}
+
+vm.import(['tag'], filename: '/app/admin/main.js')
+vm.eval_code('tag') #=> 'admin'
+```
+
+Without `as:`, the canonical equals the raw `specifier`. That means relative imports (`./foo.js`) from different importers all share one canonical (`./foo.js`) and therefore one cached module instance — which is rarely what you want. If you support relative imports from a plain `String` return, resolve them to absolute paths yourself before returning, or use the `Hash` form with `as:` set to the resolved path. The user-facing Proc is called at most once per `(specifier, importer)` pair across the VM's lifetime; subsequent imports hit a per-VM resolution cache.
 
 When `module_loader=` is set, pass `filename:` to `import` instead of `from:` to resolve a named specifier directly through the loader — no inline bridge source needed. Passing both `from:` and `filename:` raises `ArgumentError`.
 

--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -516,24 +516,48 @@ static VALUE to_rb_value_inner(JSContext *ctx, JSValue j_val, VALUE r_visited)
 struct module_loader_call_args
 {
   VALUE proc;
-  VALUE r_module_name;
+  VALUE r_specifier;
+  VALUE r_importer;
 };
 
+// Calls the user's loader with one or two args based on its arity. Procs
+// declared with a single positional (`->(name) { ... }`) get the legacy
+// 1-arg form so existing callers keep working; everything else (2-arity
+// lambdas, varargs procs) receives `(specifier, importer)`.
 static VALUE r_module_loader_call(VALUE r_args_val)
 {
   struct module_loader_call_args *args = (struct module_loader_call_args *)r_args_val;
-  return rb_funcall(args->proc, rb_intern("call"), 1, args->r_module_name);
+  int arity = NUM2INT(rb_funcall(args->proc, rb_intern("arity"), 0));
+  if (arity == 1)
+    return rb_funcall(args->proc, rb_intern("call"), 1, args->r_specifier);
+  return rb_funcall(args->proc, rb_intern("call"), 2, args->r_specifier, args->r_importer);
 }
 
-static JSModuleDef *quickjsrb_module_loader(JSContext *ctx, const char *module_name, void *opaque, JSValueConst attributes)
+// Normalize hook. Resolves `(specifier, importer)` to a canonical name by
+// consulting the resolution cache or invoking the user's loader Proc.
+// The Proc's return value drives both the canonical name AND the source
+// the load hook will eval:
+//   - String          → canonical = specifier, source = the string
+//   - { code:, as: }  → canonical = as,        source = code
+//   - nil / false     → ReferenceError
+// Source is stashed in `module_source_cache` keyed by canonical so the
+// load hook can pick it up. The resolution cache memoizes the call so
+// the Proc fires at most once per `(specifier, importer)` pair.
+static char *quickjsrb_module_normalize(JSContext *ctx, const char *base_name, const char *name, void *opaque)
 {
   VMData *data = JS_GetContextOpaque(ctx);
-  if (NIL_P(data->module_loader))
-    return js_module_loader(ctx, module_name, opaque, attributes);
 
-  struct module_loader_call_args args = {data->module_loader, rb_str_new_cstr(module_name)};
+  VALUE r_specifier = rb_str_new_cstr(name);
+  VALUE r_importer = rb_str_new_cstr(base_name);
+  VALUE r_key = rb_ary_new3(2, r_specifier, r_importer);
+
+  VALUE r_cached_canonical = rb_hash_aref(data->module_resolution_cache, r_key);
+  if (!NIL_P(r_cached_canonical))
+    return js_strdup(ctx, StringValueCStr(r_cached_canonical));
+
+  struct module_loader_call_args args = {data->module_loader, r_specifier, r_importer};
   int state;
-  VALUE r_source = rb_protect(r_module_loader_call, (VALUE)&args, &state);
+  VALUE r_return = rb_protect(r_module_loader_call, (VALUE)&args, &state);
   if (state)
   {
     VALUE r_error = rb_errinfo();
@@ -543,17 +567,61 @@ static JSModuleDef *quickjsrb_module_loader(JSContext *ctx, const char *module_n
     return NULL;
   }
 
-  if (NIL_P(r_source) || r_source == Qfalse)
+  if (NIL_P(r_return) || r_return == Qfalse)
   {
-    JS_ThrowReferenceError(ctx, "module loader returned no source for '%s'", module_name);
+    JS_ThrowReferenceError(ctx, "module loader returned no source for '%s'", name);
     return NULL;
   }
 
-  if (!RB_TYPE_P(r_source, T_STRING))
+  VALUE r_canonical, r_source;
+  if (RB_TYPE_P(r_return, T_STRING))
   {
-    JS_ThrowTypeError(ctx, "module loader must return a String or nil, got %s", rb_obj_classname(r_source));
+    r_canonical = r_specifier;
+    r_source = r_return;
+  }
+  else if (RB_TYPE_P(r_return, T_HASH))
+  {
+    r_source = rb_hash_aref(r_return, ID2SYM(rb_intern("code")));
+    r_canonical = rb_hash_aref(r_return, ID2SYM(rb_intern("as")));
+    if (!RB_TYPE_P(r_source, T_STRING))
+    {
+      JS_ThrowTypeError(ctx, "module loader Hash must include code: (String, the module source)");
+      return NULL;
+    }
+    if (!RB_TYPE_P(r_canonical, T_STRING))
+    {
+      JS_ThrowTypeError(ctx, "module loader Hash must include as: (String, the canonical module name)");
+      return NULL;
+    }
+  }
+  else
+  {
+    JS_ThrowTypeError(ctx, "module loader must return a String, a Hash with code: and as:, or nil; got %s",
+                      rb_obj_classname(r_return));
     return NULL;
   }
+
+  rb_hash_aset(data->module_source_cache, r_canonical, r_source);
+  rb_hash_aset(data->module_resolution_cache, r_key, r_canonical);
+
+  return js_strdup(ctx, StringValueCStr(r_canonical));
+}
+
+static JSModuleDef *quickjsrb_module_loader(JSContext *ctx, const char *module_name, void *opaque, JSValueConst attributes)
+{
+  VMData *data = JS_GetContextOpaque(ctx);
+
+  VALUE r_canonical = rb_str_new_cstr(module_name);
+  VALUE r_source = rb_hash_aref(data->module_source_cache, r_canonical);
+  if (NIL_P(r_source))
+  {
+    // Defensive: normalize populates this on every miss.
+    JS_ThrowReferenceError(ctx, "module loader: no cached source for '%s'", module_name);
+    return NULL;
+  }
+  // QuickJS won't call load again for this canonical — its own module cache
+  // takes over — so the source is dead weight once we've compiled it.
+  rb_hash_delete(data->module_source_cache, r_canonical);
 
   JSValue j_func = JS_Eval(ctx, RSTRING_PTR(r_source), RSTRING_LEN(r_source), module_name,
                            JS_EVAL_TYPE_MODULE | JS_EVAL_FLAG_COMPILE_ONLY);
@@ -564,6 +632,18 @@ static JSModuleDef *quickjsrb_module_loader(JSContext *ctx, const char *module_n
   JSModuleDef *m = JS_VALUE_GET_PTR(j_func);
   JS_FreeValue(ctx, j_func);
   return m;
+}
+
+// When no Ruby loader is set we hand resolution back to QuickJS's defaults
+// (URL-style normalize + filesystem load). When a loader is set we own both
+// phases so we can thread (specifier, importer) through and honor `as:`.
+static void register_module_loader_funcs(VMData *data)
+{
+  JSRuntime *runtime = JS_GetRuntime(data->context);
+  if (NIL_P(data->module_loader))
+    JS_SetModuleLoaderFunc2(runtime, NULL, js_module_loader, js_module_check_attributes, NULL);
+  else
+    JS_SetModuleLoaderFunc2(runtime, quickjsrb_module_normalize, quickjsrb_module_loader, js_module_check_attributes, NULL);
 }
 
 static VALUE r_exception_from_js_reason(JSContext *ctx, JSValueConst j_reason)
@@ -931,7 +1011,7 @@ static VALUE vm_m_initialize(int argc, VALUE *argv, VALUE r_self)
   JS_SetMemoryLimit(runtime, NUM2UINT(r_memory_limit));
   JS_SetMaxStackSize(runtime, NUM2UINT(r_max_stack_size));
 
-  JS_SetModuleLoaderFunc2(runtime, NULL, quickjsrb_module_loader, js_module_check_attributes, NULL);
+  register_module_loader_funcs(data);
   JS_SetHostPromiseRejectionTracker(runtime, quickjsrb_promise_rejection_tracker, NULL);
   js_std_init_handlers(runtime);
 
@@ -1473,6 +1553,11 @@ static VALUE vm_m_set_module_loader(VALUE r_self, VALUE r_loader)
     rb_raise(rb_eTypeError, "module_loader must be a Proc or nil");
 
   data->module_loader = r_loader;
+  // Stale entries from the previous loader's policy would survive the
+  // swap and silently shadow the new behavior.
+  rb_hash_clear(data->module_resolution_cache);
+  rb_hash_clear(data->module_source_cache);
+  register_module_loader_funcs(data);
   return r_loader;
 }
 
@@ -1518,6 +1603,7 @@ static VALUE vm_m_import(int argc, VALUE *argv, VALUE r_self)
   check_disposed(data);
 
   char *filename;
+  VALUE r_seeded_key = Qnil;
   if (!NIL_P(r_filename))
   {
     filename = StringValueCStr(r_filename);
@@ -1533,6 +1619,18 @@ static VALUE vm_m_import(int argc, VALUE *argv, VALUE r_self)
       return to_rb_value(data->context, module);
     }
     js_module_set_import_meta(data->context, module, TRUE, FALSE);
+    // The bridge module below will `import` this filename; without a
+    // resolution-cache seed, our normalize hook would ask the user's
+    // module_loader for it (and fail), even though QuickJS already has
+    // the module loaded from the JS_Eval just above. Each `from:` call
+    // mints a fresh random filename, so we also delete the entry once
+    // the bridge eval finishes — otherwise the cache grows unboundedly.
+    if (!NIL_P(data->module_loader))
+    {
+      VALUE r_filename_str = rb_str_new_cstr(filename);
+      r_seeded_key = rb_ary_new3(2, r_filename_str, rb_str_new2("<vm>"));
+      rb_hash_aset(data->module_resolution_cache, r_seeded_key, r_filename_str);
+    }
     JS_FreeValue(data->context, module);
   }
 
@@ -1572,6 +1670,9 @@ static VALUE vm_m_import(int argc, VALUE *argv, VALUE r_self)
   if (JS_IsException(j_awaited))
     return to_rb_value(data->context, j_awaited);
   JS_FreeValue(data->context, j_awaited);
+
+  if (!NIL_P(r_seeded_key))
+    rb_hash_delete(data->module_resolution_cache, r_seeded_key);
 
   return Qtrue;
 }

--- a/ext/quickjsrb/quickjsrb.h
+++ b/ext/quickjsrb/quickjsrb.h
@@ -58,6 +58,15 @@ typedef struct VMData
   VALUE alive_objects;
   VALUE module_loader;
   VALUE on_unhandled_rejection;
+  // Memoize (specifier, importer) → canonical so the user's loader Proc
+  // runs at most once per distinct pair across the VM's lifetime. Without
+  // this, QuickJS calls normalize on every import statement — including
+  // duplicates within the same file — and we'd re-invoke the user proc.
+  VALUE module_resolution_cache;
+  // Carries `code` from the normalize-phase Proc call to the load-phase
+  // JS_Eval that follows. Keyed by canonical; populated when the user's
+  // loader returns either a raw source String or `{ code:, as: }`.
+  VALUE module_source_cache;
   JSValue j_file_proxy_creator;
   // Once the runtime has hit JS-level "out of memory", the QuickJS heap is in
   // a fragile state where further evaluation can trigger a use-after-free in
@@ -109,6 +118,8 @@ static void vm_mark(void *ptr)
   rb_gc_mark_movable(data->alive_objects);
   rb_gc_mark_movable(data->module_loader);
   rb_gc_mark_movable(data->on_unhandled_rejection);
+  rb_gc_mark_movable(data->module_resolution_cache);
+  rb_gc_mark_movable(data->module_source_cache);
 }
 
 static void vm_compact(void *ptr)
@@ -119,6 +130,8 @@ static void vm_compact(void *ptr)
   data->alive_objects = rb_gc_location(data->alive_objects);
   data->module_loader = rb_gc_location(data->module_loader);
   data->on_unhandled_rejection = rb_gc_location(data->on_unhandled_rejection);
+  data->module_resolution_cache = rb_gc_location(data->module_resolution_cache);
+  data->module_source_cache = rb_gc_location(data->module_source_cache);
 }
 
 static const rb_data_type_t vm_type = {
@@ -153,6 +166,8 @@ static VALUE vm_alloc(VALUE r_self)
   data->alive_objects = rb_hash_new();
   data->module_loader = Qnil;
   data->on_unhandled_rejection = Qnil;
+  data->module_resolution_cache = rb_hash_new();
+  data->module_source_cache = rb_hash_new();
   data->j_file_proxy_creator = JS_UNDEFINED;
   data->oom_poisoned = false;
   data->disposed = false;

--- a/sig/quickjs.rbs
+++ b/sig/quickjs.rbs
@@ -33,9 +33,12 @@ module Quickjs
     def import: (String | Array[String] | Hash[Symbol, String] imported, from: String, ?code_to_expose: String?) -> true
               | (String | Array[String] | Hash[Symbol, String] imported, filename: String, ?code_to_expose: String?) -> true
 
-    def module_loader: () -> (^(String) -> String? | nil)
+    type module_loader_return = String | Hash[Symbol, String] | nil
+    type module_loader_proc = ^(String, String) -> module_loader_return | ^(String) -> module_loader_return
 
-    def module_loader=: (^(String) -> String? | nil) -> (^(String) -> String? | nil)
+    def module_loader: () -> (module_loader_proc | nil)
+
+    def module_loader=: (module_loader_proc | nil) -> (module_loader_proc | nil)
 
     def on_unhandled_rejection: () { (Quickjs::RuntimeError) -> void } -> nil
 

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -1055,6 +1055,98 @@ describe Quickjs::VM do
     it "rejects non-Proc, non-nil values" do
       _ { @vm.module_loader = 'not a proc' }.must_raise TypeError
     end
+
+    it "passes the importer as a second arg to a 2-arity loader" do
+      seen = []
+      @vm.module_loader = ->(specifier, importer) {
+        seen << [specifier, importer]
+        case specifier
+        when 'a' then "import { b } from 'b'; export const a = () => b();"
+        when 'b' then "export const b = () => 'b-result';"
+        end
+      }
+      @vm.import(['a'], filename: 'a')
+
+      _(seen).must_include ['b', 'a']
+    end
+
+    it "supports importmap-style scopes via the Hash return form" do
+      modules = {
+        '/vendor/lodash.js'       => 'export default { v: "global" };',
+        '/vendor/lodash-admin.js' => 'export default { v: "admin"  };',
+        '/app/admin/main.js'      => "import _ from 'lodash'; export const tag = _.v;",
+        '/app/main.js'            => "import _ from 'lodash'; export const tag = _.v;"
+      }
+      @vm.module_loader = ->(specifier, importer) {
+        case specifier
+        when 'lodash'
+          target = importer.start_with?('/app/admin/') ? '/vendor/lodash-admin.js' : '/vendor/lodash.js'
+          {code: modules[target], as: target}
+        else
+          modules[specifier]
+        end
+      }
+      @vm.import(['tag'], filename: '/app/admin/main.js')
+      _(@vm.eval_code('tag')).must_equal 'admin'
+
+      vm2 = Quickjs::VM.new
+      vm2.module_loader = @vm.module_loader
+      vm2.import(['tag'], filename: '/app/main.js')
+      _(vm2.eval_code('tag')).must_equal 'global'
+    end
+
+    it "memoizes resolution per (specifier, importer) so the loader fires once" do
+      call_count = 0
+      @vm.module_loader = ->(specifier, _importer) {
+        call_count += 1
+        'export const x = 1;' if specifier == 'mod'
+      }
+      @vm.eval_code(<<~JS, async: true)
+        await import('mod');
+        await import('mod');
+        await import('mod');
+      JS
+
+      _(call_count).must_equal 1
+    end
+
+    it "raises TypeError when the loader Hash is missing code:" do
+      @vm.module_loader = ->(_specifier, _importer) { {as: '/anywhere'} }
+      _ {
+        @vm.import(['x'], from: "import { x } from 'mod'; export { x };")
+      }.must_raise Quickjs::TypeError
+    end
+
+    it "raises TypeError when the loader Hash is missing as:" do
+      @vm.module_loader = ->(_specifier, _importer) { {code: 'export const x = 1;'} }
+      _ {
+        @vm.import(['x'], from: "import { x } from 'mod'; export { x };")
+      }.must_raise Quickjs::TypeError
+    end
+
+    it "raises TypeError when the loader returns an unexpected type" do
+      @vm.module_loader = ->(_specifier, _importer) { 42 }
+      _ {
+        @vm.import(['x'], from: "import { x } from 'mod'; export { x };")
+      }.must_raise Quickjs::TypeError
+    end
+
+    it "fires the loader again when the same specifier comes from a different importer" do
+      call_count = 0
+      @vm.module_loader = ->(specifier, _importer) {
+        call_count += 1
+        case specifier
+        when 'app1' then "import 'dep'; export const x = 1;"
+        when 'app2' then "import 'dep'; export const x = 2;"
+        when 'dep'  then 'export const d = 1;'
+        end
+      }
+      @vm.import(['x'], filename: 'app1')
+      @vm.import(['x'], filename: 'app2')
+
+      # 'app1', 'app2' once each; 'dep' resolved from each — distinct importer pairs.
+      _(call_count).must_equal 4
+    end
   end
 
   describe "Runnable" do


### PR DESCRIPTION
## Summary

Reworks #44 around the single-callback design hashed out in the [discussion](https://github.com/hmsk/quickjs.rb/pull/44#issuecomment-4505792891). `vm.module_loader` is now (optionally) 2-arity and can return a `Hash` to override the canonical cache key — which is what makes importmap `scopes` work without a second method.

## Loader contract

```rb
vm.module_loader = ->(specifier, importer) {
  # ...
}
```

Return value:

- **`String`** — that's the source; canonical = specifier. Current 1-arity behavior, unchanged.
- **`{ code:, as: }`** — `code` is the source; `as` becomes the canonical name. Use this for scoped resolution where the same `specifier` should resolve to different modules per `importer` — without distinct canonicals, QuickJS's module cache collapses the two into one.
- **`nil` / `false`** — `Quickjs::ReferenceError` ("module not found"), matching today's behavior.
- **anything else** — `Quickjs::TypeError`.

The 1-arity form (`->(name) { ... }`) keeps working: the wrapper inspects `Proc#arity` and only passes one arg when the Proc declared one.

## Importmap scopes example

```rb
vm.module_loader = ->(specifier, importer) {
  case specifier
  when 'lodash'
    target = importer.start_with?('/app/admin/') ? '/vendor/lodash-admin.js' : '/vendor/lodash.js'
    {code: SOURCES[target], as: target}
  else
    SOURCES[specifier]
  end
}

vm.import(['tag'], filename: '/app/admin/main.js')
vm.eval_code('tag') #=> 'admin'
```

## Internals

- Registered both a normalize hook and a load hook (only when a Ruby loader is set; otherwise QuickJS's URL-relative normalize + filesystem loader stay in place).
- VMData carries two new caches:
  - `module_resolution_cache`: `[specifier, importer] → canonical`. Memoizes the user Proc per distinct pair across the VM's lifetime.
  - `module_source_cache`: `canonical → source`. Hands the normalize-time source to the load-time `JS_Eval`; entries are deleted after consumption so this doesn't grow unboundedly.
- `vm_m_set_module_loader` clears both caches on swap — stale entries from the previous policy would silently shadow new behavior otherwise.
- `vm.import(from:)` seeds the resolution cache for the random bridge filename so our normalize doesn't ask the user Proc for an internal detail. The seed is cleaned up after the bridge eval finishes, so repeated `from:` calls don't accumulate entries.

## Notes

- Relative imports (`./foo.js`) without `as:` will collapse across importers since canonical defaults to the raw specifier. Documented in the README under the loader section.
- The previous design's `vm.module_normalizer=` method is gone — its scopes-aware role is absorbed into the loader's Hash return.

## Test plan

- [x] `bundle exec rake` (452 runs, 661 assertions, 0 failures, 7 skips — skip count unchanged from `main`)
- [x] 1-arity loader still works (regression test)
- [x] 2-arity loader receives importer
- [x] Importmap scopes pattern with `{ code:, as: }`
- [x] Resolution cache memoizes per `(specifier, importer)` (one fire for three `await import('mod')`)
- [x] Loader fires again for different importer (negative case)
- [x] `nil`/`false` return raises `Quickjs::ReferenceError`
- [x] `Hash` missing `code:` or `as:` raises `Quickjs::TypeError`
- [x] Non-String/non-Hash/non-nil return raises `Quickjs::TypeError`
- [x] Ruby exception inside the loader propagates as Ruby error
- [x] Setting `nil` clears the loader; non-Proc rejected with `TypeError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)