### PR TITLE
Document code_to_expose on vm.import

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,22 @@ vm.import('DefaultExport', from: File.read('exports.esm.js'))
 vm.import('* as all', from: File.read('exports.esm.js'))
 ```
 
+By default each imported binding is attached to `globalThis` under its own name so later `eval_code` / `call` can see it. Pass `code_to_expose:` to replace that step with your own JS — useful for renaming, attaching the import somewhere other than `globalThis`, or skipping the global assignment entirely for side-effect-only imports.
+
+```rb
+# Rename on the way in
+vm.import('Imported', from: File.read('exports.esm.js'),
+          code_to_expose: 'globalThis.RenamedImported = Imported;')
+
+vm.eval_code('RenamedImported()')   #=> calls the default export
+vm.eval_code('!!globalThis.Imported') #=> false — the original name was never assigned
+
+# Side-effect-only import: run the module body but don't expose anything
+vm.import('initSomething', from: File.read('setup.esm.js'), code_to_expose: '')
+```
+
+`code_to_expose` is just a JavaScript fragment that runs after the `import` statement, with the imported binding(s) in scope under the name(s) you requested. It works with both `from:` and `filename:`.
+
 #### `Quickjs::VM#module_loader=`: 🧩 Resolve `import` specifiers from Ruby
 
 By default, `import` specifiers that aren't already loaded fall through to QuickJS's filesystem loader. Set a `module_loader` Proc to resolve specifiers in-memory instead — useful when the source code lives in a database, an importmap, or a virtual filesystem.

--- a/sig/quickjs.rbs
+++ b/sig/quickjs.rbs
@@ -31,7 +31,7 @@ module Quickjs
                        | (Array[String | Symbol] path, *Symbol flags) { (*untyped) -> untyped } -> Array[Symbol]
 
     def import: (String | Array[String] | Hash[Symbol, String] imported, from: String, ?code_to_expose: String?) -> true
-              | (String | Array[String] | Hash[Symbol, String] imported, filename: String) -> true
+              | (String | Array[String] | Hash[Symbol, String] imported, filename: String, ?code_to_expose: String?) -> true
 
     def module_loader: () -> (^(String) -> String? | nil)
 

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -840,6 +840,21 @@ describe Quickjs::VM do
       _(@vm.eval_code('!!globalThis.Imported')).must_equal false
     end
 
+    it "code_to_expose with an empty string runs the module for side effects only" do
+      @vm.import('Imported', from: 'globalThis.sideEffect = true; export default 1;', code_to_expose: '')
+
+      _(@vm.eval_code('globalThis.sideEffect')).must_equal true
+      _(@vm.eval_code('!!globalThis.Imported')).must_equal false
+    end
+
+    it "code_to_expose also works with filename:" do
+      @vm.module_loader = ->(name) { 'export const greet = () => "hi";' if name == 'greet' }
+      @vm.import(['greet'], filename: 'greet', code_to_expose: 'globalThis.shout = () => greet().toUpperCase();')
+
+      _(@vm.eval_code('shout()')).must_equal 'HI'
+      _(@vm.eval_code('typeof globalThis.greet')).must_equal 'undefined'
+    end
+
     it "imports a script which throws error result raising an exception" do
       _ {
         @vm.import('* as all', from: 'should be syntax error')


### PR DESCRIPTION
## Summary

- Adds a README section covering the existing `code_to_expose:` option on `vm.import`. The option has been functional for some time but is currently only discoverable by reading the C source or the test file.
- Fixes the RBS signature: `code_to_expose` was declared only on the `from:` branch, but the C extension reads it [before the from/filename split](https://github.com/hmsk/quickjs.rb/blob/main/ext/quickjsrb/quickjsrb.c#L1411), so it has always worked with `filename:` too. The signature now reflects that.
- Adds two tests pinning the documented behaviors (empty-string side-effect-only pattern, `filename:` combo).

## Motivation

`code_to_expose` is the escape hatch for the import path: it replaces the default "assign each imported binding to `globalThis`" step with whatever JS you want. Useful patterns:

- **Rename on the way in**: `globalThis.RenamedX = X;`
- **Attach to a namespace object**: `app.helpers.X = X;`
- **Side-effect-only import**: pass `''` to skip globalization entirely — the module body still runs

I hit the renaming use case in a downstream and only found the option by grepping the C source. One short section in the README would have saved that trip.

## Test plan

- [x] `bundle exec rake` (425 runs, 603 assertions, 0 failures)
- [x] `code_to_expose: ''` runs the module body and exposes nothing
- [x] `code_to_expose` combined with `filename:` works as documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)