### PR TITLE
Widen timeout_msec test tolerance from 10ms to 100ms

### DIFF
--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -391,7 +391,10 @@ describe Quickjs::VM do
 
     started = Time.now.to_f * 1000
     _ { vm.eval_code("while(1) {}") }.must_raise Quickjs::InterruptedError
-    assert_in_delta(started + 200, Time.now.to_f * 1000, 10)
+    # CI runners under load have been observed drifting ~55ms past the
+    # configured 200ms. Widen the window so the test catches "timer wildly
+    # wrong" (orders of magnitude off) without flapping on normal noise.
+    assert_in_delta(started + 200, Time.now.to_f * 1000, 100)
   end
 
   it "can enable setTimeout selectively" do


### PR DESCRIPTION
## Summary

`test/quickjs_test.rb:394` asserts that a 200ms `timeout_msec` interrupt fires within ±10ms of the configured deadline. CI runners under load drift past that — most recently a 54ms drift on Ruby 3.3 ubuntu in PR #44's run. The flake is independent of the PR under test; the tolerance has been too tight for CI from day one.

Widening to ±100ms:

- still catches "timer is orders of magnitude wrong" (the real failure mode this assertion protects against),
- absorbs realistic noise on busy CI runners,
- leaves the companion `must_raise Quickjs::InterruptedError` check responsible for "interrupt fires at all."

## Test plan

- [x] Test passes locally
- [ ] All matrix jobs pass on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)