### PR TITLE
Expose JS Error.stack as the Ruby exception's backtrace

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ vm.eval_code("void Promise.reject(new TypeError('drift'));")
 
 Calling `on_unhandled_rejection` again with a new block replaces the previously registered one (matching `on_log`).
 
-The block receives a `Quickjs::*Error` matching the rejection reason (`Quickjs::TypeError` for `new TypeError`, etc.); non-`Error` rejections (`Promise.reject('str')`, `Promise.reject({})`) are wrapped in `Quickjs::RuntimeError`. Exceptions raised inside the block are swallowed — propagating them out would corrupt the QuickJS runtime.
+The block receives a `Quickjs::*Error` matching the rejection reason (`Quickjs::TypeError` for `new TypeError`, etc.); non-`Error` rejections (`Promise.reject('str')`, `Promise.reject({})`) are wrapped in `Quickjs::RuntimeError`. The exception's `#backtrace` carries the JS-side stack frames (`at func (file:line:col)`) for `Error` rejections, so the rejection site shows up directly when you log or re-raise. Exceptions raised inside the block are swallowed — propagating them out would corrupt the QuickJS runtime.
 
 The tracker fires synchronously when QuickJS first observes the rejection. A `.catch` attached later in the same tick does **not** suppress the notification, and a chain like `Promise.reject(x).then(y).then(z)` without a terminating `.catch` may emit a notification per intermediate promise. If that noise is a problem, attach handlers synchronously or dedupe by reason identity in your block. The block runs on the QuickJS stack — heavy work blocks JS execution.
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,27 @@ vm.eval_code('a()') #=> 'a-b-result'
 
 The Proc receives the (already normalized) module specifier and returns the module source as a `String`, or `nil` to signal "not found" (which raises `Quickjs::ReferenceError` on the JS side). Pass `nil` to clear a previously set loader.
 
-When `module_loader=` is set, pass `filename:` to `import` instead of `from:` to resolve a named specifier directly through the loader — no inline bridge source needed.
+When `module_loader=` is set, pass `filename:` to `import` instead of `from:` to resolve a named specifier directly through the loader — no inline bridge source needed. Passing both `from:` and `filename:` raises `ArgumentError`.
+
+`import` awaits the module's top-level evaluation — top-level `await`, synchronous body execution, and any chained dynamic `import()`. The call blocks until the module's settle promise resolves. A top-level throw, a failed dynamic `import()`, or a rejected top-level `await` propagates back to Ruby as the matching `Quickjs::*Error` instead of being silently dropped.
+
+#### `Quickjs::VM#on_unhandled_rejection=`: 🚨 Catch promise rejections that have no handler
+
+Set a `Proc` to be notified when a JS Promise rejects with no `.catch` / `then(_, onRejected)` attached at the time of rejection — fire-and-forget chains, failed dynamic imports without `try`, etc.
+
+```rb
+vm = Quickjs::VM.new
+vm.on_unhandled_rejection = ->(err) {
+  warn "[JS] unhandled rejection: #{err.class} #{err.message}"
+}
+
+vm.eval_code("const _p = Promise.reject(new TypeError('drift'));")
+#=> warns: [JS] unhandled rejection: Quickjs::TypeError drift
+```
+
+The callback receives a `Quickjs::*Error` matching the rejection reason (`Quickjs::TypeError` for `new TypeError`, etc.); non-`Error` rejections (`Promise.reject('str')`, `Promise.reject({})`) are wrapped in `Quickjs::RuntimeError`. Exceptions raised inside the callback are swallowed — propagating them out would corrupt the QuickJS runtime.
+
+The tracker fires synchronously when QuickJS first observes the rejection. A `.catch` attached later in the same tick does **not** suppress the notification, and a chain like `Promise.reject(x).then(y).then(z)` without a terminating `.catch` may emit a notification per intermediate promise. If that noise is a problem, attach handlers synchronously or dedupe by reason identity in your callback. The callback runs on the QuickJS stack — heavy work blocks JS execution.
 
 #### `Quickjs::VM#define_function`: 💎 Define a global function for JS by Ruby
 

--- a/README.md
+++ b/README.md
@@ -166,23 +166,25 @@ When `module_loader=` is set, pass `filename:` to `import` instead of `from:` to
 
 `import` awaits the module's top-level evaluation — top-level `await`, synchronous body execution, and any chained dynamic `import()`. The call blocks until the module's settle promise resolves. A top-level throw, a failed dynamic `import()`, or a rejected top-level `await` propagates back to Ruby as the matching `Quickjs::*Error` instead of being silently dropped.
 
-#### `Quickjs::VM#on_unhandled_rejection=`: 🚨 Catch promise rejections that have no handler
+#### `Quickjs::VM#on_unhandled_rejection`: 🚨 Catch promise rejections that have no handler
 
-Set a `Proc` to be notified when a JS Promise rejects with no `.catch` / `then(_, onRejected)` attached at the time of rejection — fire-and-forget chains, failed dynamic imports without `try`, etc.
+Register a block to be notified when a JS Promise rejects with no `.catch` / `then(_, onRejected)` attached at the time of rejection — fire-and-forget chains, failed dynamic imports without `try`, etc.
 
 ```rb
 vm = Quickjs::VM.new
-vm.on_unhandled_rejection = ->(err) {
+vm.on_unhandled_rejection do |err|
   warn "[JS] unhandled rejection: #{err.class} #{err.message}"
-}
+end
 
-vm.eval_code("const _p = Promise.reject(new TypeError('drift'));")
+vm.eval_code("void Promise.reject(new TypeError('drift'));")
 #=> warns: [JS] unhandled rejection: Quickjs::TypeError drift
 ```
 
-The callback receives a `Quickjs::*Error` matching the rejection reason (`Quickjs::TypeError` for `new TypeError`, etc.); non-`Error` rejections (`Promise.reject('str')`, `Promise.reject({})`) are wrapped in `Quickjs::RuntimeError`. Exceptions raised inside the callback are swallowed — propagating them out would corrupt the QuickJS runtime.
+Calling `on_unhandled_rejection` again with a new block replaces the previously registered one (matching `on_log`).
 
-The tracker fires synchronously when QuickJS first observes the rejection. A `.catch` attached later in the same tick does **not** suppress the notification, and a chain like `Promise.reject(x).then(y).then(z)` without a terminating `.catch` may emit a notification per intermediate promise. If that noise is a problem, attach handlers synchronously or dedupe by reason identity in your callback. The callback runs on the QuickJS stack — heavy work blocks JS execution.
+The block receives a `Quickjs::*Error` matching the rejection reason (`Quickjs::TypeError` for `new TypeError`, etc.); non-`Error` rejections (`Promise.reject('str')`, `Promise.reject({})`) are wrapped in `Quickjs::RuntimeError`. Exceptions raised inside the block are swallowed — propagating them out would corrupt the QuickJS runtime.
+
+The tracker fires synchronously when QuickJS first observes the rejection. A `.catch` attached later in the same tick does **not** suppress the notification, and a chain like `Promise.reject(x).then(y).then(z)` without a terminating `.catch` may emit a notification per intermediate promise. If that noise is a problem, attach handlers synchronously or dedupe by reason identity in your block. The block runs on the QuickJS stack — heavy work blocks JS execution.
 
 #### `Quickjs::VM#define_function`: 💎 Define a global function for JS by Ruby
 

--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -1464,23 +1464,15 @@ static VALUE vm_m_get_module_loader(VALUE r_self)
   return data->module_loader;
 }
 
-static VALUE vm_m_set_on_unhandled_rejection(VALUE r_self, VALUE r_callback)
+static VALUE vm_m_on_unhandled_rejection(VALUE r_self)
 {
+  rb_need_block();
+
   VMData *data;
   TypedData_Get_Struct(r_self, VMData, &vm_type, data);
 
-  if (!NIL_P(r_callback) && !rb_obj_is_kind_of(r_callback, rb_cProc))
-    rb_raise(rb_eTypeError, "on_unhandled_rejection must be a Proc or nil");
-
-  data->on_unhandled_rejection = r_callback;
-  return r_callback;
-}
-
-static VALUE vm_m_get_on_unhandled_rejection(VALUE r_self)
-{
-  VMData *data;
-  TypedData_Get_Struct(r_self, VMData, &vm_type, data);
-  return data->on_unhandled_rejection;
+  data->on_unhandled_rejection = rb_block_proc();
+  return Qnil;
 }
 
 static VALUE vm_m_import(int argc, VALUE *argv, VALUE r_self)
@@ -1583,8 +1575,7 @@ RUBY_FUNC_EXPORTED void Init_quickjsrb(void)
   rb_define_method(r_class_vm, "import", vm_m_import, -1);
   rb_define_method(r_class_vm, "module_loader", vm_m_get_module_loader, 0);
   rb_define_method(r_class_vm, "module_loader=", vm_m_set_module_loader, 1);
-  rb_define_method(r_class_vm, "on_unhandled_rejection", vm_m_get_on_unhandled_rejection, 0);
-  rb_define_method(r_class_vm, "on_unhandled_rejection=", vm_m_set_on_unhandled_rejection, 1);
+  rb_define_method(r_class_vm, "on_unhandled_rejection", vm_m_on_unhandled_rejection, 0);
   rb_define_method(r_class_vm, "on_log", vm_m_on_log, 0);
   rb_define_method(r_class_vm, "memory_usage", vm_m_memoryUsage, 0);
   rb_define_method(r_class_vm, "gc!", vm_m_runGC, 0);

--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -564,6 +564,75 @@ static JSModuleDef *quickjsrb_module_loader(JSContext *ctx, const char *module_n
   return m;
 }
 
+static VALUE r_exception_from_js_reason(JSContext *ctx, JSValueConst j_reason)
+{
+  if (JS_IsError(ctx, j_reason))
+  {
+    VALUE r_maybe_ruby_error = find_ruby_error(ctx, j_reason);
+    if (!NIL_P(r_maybe_ruby_error))
+      return r_maybe_ruby_error;
+
+    JSValue j_name = JS_GetPropertyStr(ctx, j_reason, "name");
+    JSValue j_message = JS_GetPropertyStr(ctx, j_reason, "message");
+    const char *name = JS_ToCString(ctx, j_name);
+    const char *message = JS_ToCString(ctx, j_message);
+
+    VALUE r_class = is_native_error_name(name)
+                        ? QUICKJSRB_ERROR_FOR(name)
+                        : QUICKJSRB_ERROR_FOR(QUICKJSRB_ROOT_RUNTIME_ERROR);
+    VALUE r_exc = rb_funcall(r_class, rb_intern("new"), 2,
+                             rb_str_new2(message), rb_str_new2(name));
+
+    JS_FreeCString(ctx, name);
+    JS_FreeCString(ctx, message);
+    JS_FreeValue(ctx, j_name);
+    JS_FreeValue(ctx, j_message);
+    return r_exc;
+  }
+
+  const char *str = JS_ToCString(ctx, j_reason);
+  VALUE r_exc = rb_funcall(QUICKJSRB_ERROR_FOR(QUICKJSRB_ROOT_RUNTIME_ERROR), rb_intern("new"),
+                           2, rb_str_new2(str ? str : "(non-stringifiable rejection)"), Qnil);
+  if (str)
+    JS_FreeCString(ctx, str);
+  return r_exc;
+}
+
+struct rejection_call_args
+{
+  VALUE proc;
+  VALUE r_reason;
+};
+
+static VALUE r_rejection_call(VALUE r_args_val)
+{
+  struct rejection_call_args *args = (struct rejection_call_args *)r_args_val;
+  return rb_funcall(args->proc, rb_intern("call"), 1, args->r_reason);
+}
+
+static void quickjsrb_promise_rejection_tracker(
+    JSContext *ctx, JSValueConst promise, JSValueConst reason,
+    JS_BOOL is_handled, void *opaque)
+{
+  if (is_handled)
+    return;
+
+  VMData *data = JS_GetContextOpaque(ctx);
+  if (NIL_P(data->on_unhandled_rejection))
+    return;
+
+  VALUE r_reason = r_exception_from_js_reason(ctx, reason);
+  struct rejection_call_args args = {data->on_unhandled_rejection, r_reason};
+  int state;
+  rb_protect(r_rejection_call, (VALUE)&args, &state);
+  if (state)
+  {
+    // Longjmping out of a QuickJS host callback corrupts the runtime, so
+    // a raise inside the user's tracker has to be dropped on the floor.
+    rb_set_errinfo(Qnil);
+  }
+}
+
 static VALUE r_try_call_proc(VALUE r_try_args)
 {
   return rb_funcall(
@@ -861,6 +930,7 @@ static VALUE vm_m_initialize(int argc, VALUE *argv, VALUE r_self)
   JS_SetMaxStackSize(runtime, NUM2UINT(r_max_stack_size));
 
   JS_SetModuleLoaderFunc2(runtime, NULL, quickjsrb_module_loader, js_module_check_attributes, NULL);
+  JS_SetHostPromiseRejectionTracker(runtime, quickjsrb_promise_rejection_tracker, NULL);
   js_std_init_handlers(runtime);
 
   JSValue j_global = JS_GetGlobalObject(data->context);
@@ -1394,6 +1464,25 @@ static VALUE vm_m_get_module_loader(VALUE r_self)
   return data->module_loader;
 }
 
+static VALUE vm_m_set_on_unhandled_rejection(VALUE r_self, VALUE r_callback)
+{
+  VMData *data;
+  TypedData_Get_Struct(r_self, VMData, &vm_type, data);
+
+  if (!NIL_P(r_callback) && !rb_obj_is_kind_of(r_callback, rb_cProc))
+    rb_raise(rb_eTypeError, "on_unhandled_rejection must be a Proc or nil");
+
+  data->on_unhandled_rejection = r_callback;
+  return r_callback;
+}
+
+static VALUE vm_m_get_on_unhandled_rejection(VALUE r_self)
+{
+  VMData *data;
+  TypedData_Get_Struct(r_self, VMData, &vm_type, data);
+  return data->on_unhandled_rejection;
+}
+
 static VALUE vm_m_import(int argc, VALUE *argv, VALUE r_self)
 {
   VALUE r_import_string, r_opts;
@@ -1408,6 +1497,8 @@ static VALUE vm_m_import(int argc, VALUE *argv, VALUE r_self)
     rb_exc_raise(rb_funcall(QUICKJSRB_ERROR_FOR(QUICKJSRB_ROOT_RUNTIME_ERROR), rb_intern("new"), 2, r_error_message, Qnil));
     return Qnil;
   }
+  if (!NIL_P(r_from) && !NIL_P(r_filename))
+    rb_raise(rb_eArgError, "pass either from: (inline source) or filename: (loader-resolved), not both");
   VALUE r_custom_exposure = rb_hash_aref(r_opts, ID2SYM(rb_intern("code_to_expose")));
 
   VMData *data;
@@ -1458,7 +1549,16 @@ static VALUE vm_m_import(int argc, VALUE *argv, VALUE r_self)
 
   JSValue j_codeResult = JS_Eval(data->context, result, strlen(result), "<vm>", JS_EVAL_TYPE_MODULE);
   free(result);
-  JS_FreeValue(data->context, j_codeResult);
+  if (JS_IsException(j_codeResult))
+    return to_rb_value(data->context, j_codeResult);
+
+  // Module eval returns a Promise. Awaiting it surfaces top-level throws,
+  // rejected dynamic imports, and rejected top-level awaits as Ruby
+  // exceptions instead of silently dropping them.
+  JSValue j_awaited = js_std_await(data->context, j_codeResult);
+  if (JS_IsException(j_awaited))
+    return to_rb_value(data->context, j_awaited);
+  JS_FreeValue(data->context, j_awaited);
 
   return Qtrue;
 }
@@ -1483,6 +1583,8 @@ RUBY_FUNC_EXPORTED void Init_quickjsrb(void)
   rb_define_method(r_class_vm, "import", vm_m_import, -1);
   rb_define_method(r_class_vm, "module_loader", vm_m_get_module_loader, 0);
   rb_define_method(r_class_vm, "module_loader=", vm_m_set_module_loader, 1);
+  rb_define_method(r_class_vm, "on_unhandled_rejection", vm_m_get_on_unhandled_rejection, 0);
+  rb_define_method(r_class_vm, "on_unhandled_rejection=", vm_m_set_on_unhandled_rejection, 1);
   rb_define_method(r_class_vm, "on_log", vm_m_on_log, 0);
   rb_define_method(r_class_vm, "memory_usage", vm_m_memoryUsage, 0);
   rb_define_method(r_class_vm, "gc!", vm_m_runGC, 0);

--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -187,6 +187,28 @@ VALUE r_try_json_parse(VALUE r_str)
   return rb_funcall(rb_const_get(rb_cClass, rb_intern("JSON")), rb_intern("parse"), 1, r_str);
 }
 
+// Convert a JS Error.stack string into a Ruby Array suitable for
+// Exception#set_backtrace. Lines are stripped; empty lines (including the
+// trailing newline that QuickJS appends) are dropped. The frames keep
+// QuickJS's native format ("at func (file:line)") — Ruby's backtrace API
+// doesn't enforce a layout, and reshaping into "file:line:in 'method'"
+// would lose information for no real win.
+static VALUE r_backtrace_from_js_stack(const char *stack)
+{
+  if (stack == NULL || stack[0] == '\0')
+    return Qnil;
+
+  VALUE r_lines = rb_str_split(rb_str_new_cstr(stack), "\n");
+  VALUE r_filtered = rb_ary_new();
+  for (long i = 0; i < RARRAY_LEN(r_lines); i++)
+  {
+    VALUE r_line = rb_funcall(rb_ary_entry(r_lines, i), rb_intern("strip"), 0);
+    if (RSTRING_LEN(r_line) > 0)
+      rb_ary_push(r_filtered, r_line);
+  }
+  return RARRAY_LEN(r_filtered) > 0 ? r_filtered : Qnil;
+}
+
 VALUE to_r_json(JSContext *ctx, JSValue j_val)
 {
   JSValue j_stringified = JS_JSONStringify(ctx, j_val, JS_UNDEFINED, JS_UNDEFINED);
@@ -431,14 +453,11 @@ static VALUE to_rb_value_inner(JSContext *ctx, JSValue j_val, VALUE r_visited)
       VMData *data = JS_GetContextOpaque(ctx);
       VALUE r_headline = rb_str_new2(headline);
       dispatch_log(data, "error", rb_ary_new3(1, r_log_body_new(r_headline, r_headline)));
-
-      JS_FreeValue(ctx, j_errorClassMessage);
-      JS_FreeValue(ctx, j_errorClassName);
-      JS_FreeValue(ctx, j_stackTrace);
-      JS_FreeCString(ctx, stackTrace);
       free(headline);
 
       VALUE r_error_class, r_error_message = rb_str_new2(errorClassMessage);
+      VALUE r_error_name = rb_str_new2(errorClassName);
+      VALUE r_backtrace = r_backtrace_from_js_stack(stackTrace);
       if (is_native_error_name(errorClassName))
       {
         r_error_class = QUICKJSRB_ERROR_FOR(errorClassName);
@@ -464,11 +483,18 @@ static VALUE to_rb_value_inner(JSContext *ctx, JSValue j_val, VALUE r_visited)
       {
         r_error_class = QUICKJSRB_ERROR_FOR(QUICKJSRB_ROOT_RUNTIME_ERROR);
       }
+      JS_FreeValue(ctx, j_errorClassMessage);
+      JS_FreeValue(ctx, j_errorClassName);
+      JS_FreeValue(ctx, j_stackTrace);
+      JS_FreeCString(ctx, stackTrace);
       JS_FreeCString(ctx, errorClassName);
       JS_FreeCString(ctx, errorClassMessage);
       JS_FreeValue(ctx, j_exceptionVal);
 
-      rb_exc_raise(rb_funcall(r_error_class, rb_intern("new"), 2, r_error_message, rb_str_new2(errorClassName)));
+      VALUE r_exc = rb_funcall(r_error_class, rb_intern("new"), 2, r_error_message, r_error_name);
+      if (!NIL_P(r_backtrace))
+        rb_funcall(r_exc, rb_intern("set_backtrace"), 1, r_backtrace);
+      rb_exc_raise(r_exc);
     }
     else // exception without Error object
     {
@@ -574,19 +600,27 @@ static VALUE r_exception_from_js_reason(JSContext *ctx, JSValueConst j_reason)
 
     JSValue j_name = JS_GetPropertyStr(ctx, j_reason, "name");
     JSValue j_message = JS_GetPropertyStr(ctx, j_reason, "message");
+    JSValue j_stack = JS_GetPropertyStr(ctx, j_reason, "stack");
     const char *name = JS_ToCString(ctx, j_name);
     const char *message = JS_ToCString(ctx, j_message);
+    const char *stack = JS_ToCString(ctx, j_stack);
 
     VALUE r_class = is_native_error_name(name)
                         ? QUICKJSRB_ERROR_FOR(name)
                         : QUICKJSRB_ERROR_FOR(QUICKJSRB_ROOT_RUNTIME_ERROR);
     VALUE r_exc = rb_funcall(r_class, rb_intern("new"), 2,
                              rb_str_new2(message), rb_str_new2(name));
+    VALUE r_backtrace = r_backtrace_from_js_stack(stack);
+    if (!NIL_P(r_backtrace))
+      rb_funcall(r_exc, rb_intern("set_backtrace"), 1, r_backtrace);
 
     JS_FreeCString(ctx, name);
     JS_FreeCString(ctx, message);
+    if (stack)
+      JS_FreeCString(ctx, stack);
     JS_FreeValue(ctx, j_name);
     JS_FreeValue(ctx, j_message);
+    JS_FreeValue(ctx, j_stack);
     return r_exc;
   }
 

--- a/ext/quickjsrb/quickjsrb.h
+++ b/ext/quickjsrb/quickjsrb.h
@@ -57,6 +57,7 @@ typedef struct VMData
   VALUE log_listener;
   VALUE alive_objects;
   VALUE module_loader;
+  VALUE on_unhandled_rejection;
   JSValue j_file_proxy_creator;
   // Once the runtime has hit JS-level "out of memory", the QuickJS heap is in
   // a fragile state where further evaluation can trigger a use-after-free in
@@ -95,6 +96,7 @@ static void vm_mark(void *ptr)
   rb_gc_mark_movable(data->log_listener);
   rb_gc_mark_movable(data->alive_objects);
   rb_gc_mark_movable(data->module_loader);
+  rb_gc_mark_movable(data->on_unhandled_rejection);
 }
 
 static void vm_compact(void *ptr)
@@ -104,6 +106,7 @@ static void vm_compact(void *ptr)
   data->log_listener = rb_gc_location(data->log_listener);
   data->alive_objects = rb_gc_location(data->alive_objects);
   data->module_loader = rb_gc_location(data->module_loader);
+  data->on_unhandled_rejection = rb_gc_location(data->on_unhandled_rejection);
 }
 
 static const rb_data_type_t vm_type = {
@@ -137,6 +140,7 @@ static VALUE vm_alloc(VALUE r_self)
   data->log_listener = Qnil;
   data->alive_objects = rb_hash_new();
   data->module_loader = Qnil;
+  data->on_unhandled_rejection = Qnil;
   data->j_file_proxy_creator = JS_UNDEFINED;
   data->oom_poisoned = false;
 

--- a/sig/quickjs.rbs
+++ b/sig/quickjs.rbs
@@ -37,6 +37,10 @@ module Quickjs
 
     def module_loader=: (^(String) -> String? | nil) -> (^(String) -> String? | nil)
 
+    def on_unhandled_rejection: () -> (^(Quickjs::RuntimeError) -> void | nil)
+
+    def on_unhandled_rejection=: (^(Quickjs::RuntimeError) -> void | nil) -> (^(Quickjs::RuntimeError) -> void | nil)
+
     def on_log: () { (Log) -> void } -> nil
 
     def memory_usage: () -> Hash[Symbol, Integer]

--- a/sig/quickjs.rbs
+++ b/sig/quickjs.rbs
@@ -37,9 +37,7 @@ module Quickjs
 
     def module_loader=: (^(String) -> String? | nil) -> (^(String) -> String? | nil)
 
-    def on_unhandled_rejection: () -> (^(Quickjs::RuntimeError) -> void | nil)
-
-    def on_unhandled_rejection=: (^(Quickjs::RuntimeError) -> void | nil) -> (^(Quickjs::RuntimeError) -> void | nil)
+    def on_unhandled_rejection: () { (Quickjs::RuntimeError) -> void } -> nil
 
     def on_log: () { (Log) -> void } -> nil
 

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -852,6 +852,83 @@ describe Quickjs::VM do
 
       _(@vm.eval_code("greet('world')")).must_equal 'Hello, world!'
     end
+
+    it "raises when a module body throws synchronously" do
+      err = _ {
+        @vm.import('* as x', from: "throw new TypeError('top-level boom');")
+      }.must_raise Quickjs::TypeError
+      _(err.message).must_match(/top-level boom/)
+    end
+
+    it "raises when the loader-resolved module throws synchronously" do
+      @vm.module_loader = ->(name) {
+        "export const x = 1; throw new RangeError('loader-throw');" if name == 'bad'
+      }
+      _ {
+        @vm.import(['x'], filename: 'bad')
+      }.must_raise Quickjs::RangeError
+    end
+
+    it "raises when top-level await rejects" do
+      err = _ {
+        @vm.import('* as x', from: "await Promise.reject(new Error('async boom'));")
+      }.must_raise Quickjs::RuntimeError
+      _(err.message).must_match(/async boom/)
+    end
+
+    it "raises ArgumentError when both from: and filename: are passed" do
+      _ {
+        @vm.import('x', from: 'export default 1;', filename: 'x')
+      }.must_raise ArgumentError
+    end
+  end
+
+  describe "on_unhandled_rejection" do
+    before do
+      @vm = Quickjs::VM.new
+    end
+
+    it "is nil by default" do
+      _(@vm.on_unhandled_rejection).must_be_nil
+    end
+
+    it "fires the callback with a Ruby exception for a fire-and-forget rejection" do
+      captured = []
+      @vm.on_unhandled_rejection = ->(err) { captured << err }
+      @vm.eval_code("void Promise.reject(new TypeError('drift'));")
+
+      _(captured.size).must_equal 1
+      _(captured.first).must_be_kind_of Quickjs::TypeError
+      _(captured.first.message).must_match(/drift/)
+    end
+
+    it "wraps non-Error rejection reasons in Quickjs::RuntimeError" do
+      captured = []
+      @vm.on_unhandled_rejection = ->(err) { captured << err }
+      @vm.eval_code("void Promise.reject('just-a-string');")
+
+      _(captured.first).must_be_kind_of Quickjs::RuntimeError
+      _(captured.first.message).must_match(/just-a-string/)
+    end
+
+    it "accepts nil to clear a previously set callback" do
+      @vm.on_unhandled_rejection = ->(err) {}
+      @vm.on_unhandled_rejection = nil
+      _(@vm.on_unhandled_rejection).must_be_nil
+    end
+
+    it "rejects non-Proc, non-nil values" do
+      _ { @vm.on_unhandled_rejection = 'not a proc' }.must_raise TypeError
+    end
+
+    it "swallows exceptions raised inside the callback" do
+      called = false
+      @vm.on_unhandled_rejection = ->(_) { called = true; raise 'callback boom' }
+      @vm.eval_code("void Promise.reject(new Error('x'));")
+
+      _(called).must_equal true
+      _(@vm.eval_code('42')).must_equal 42
+    end
   end
 
   describe "ModuleLoader" do

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -888,13 +888,9 @@ describe Quickjs::VM do
       @vm = Quickjs::VM.new
     end
 
-    it "is nil by default" do
-      _(@vm.on_unhandled_rejection).must_be_nil
-    end
-
-    it "fires the callback with a Ruby exception for a fire-and-forget rejection" do
+    it "fires the block with a Ruby exception for a fire-and-forget rejection" do
       captured = []
-      @vm.on_unhandled_rejection = ->(err) { captured << err }
+      @vm.on_unhandled_rejection { |err| captured << err }
       @vm.eval_code("void Promise.reject(new TypeError('drift'));")
 
       _(captured.size).must_equal 1
@@ -904,26 +900,31 @@ describe Quickjs::VM do
 
     it "wraps non-Error rejection reasons in Quickjs::RuntimeError" do
       captured = []
-      @vm.on_unhandled_rejection = ->(err) { captured << err }
+      @vm.on_unhandled_rejection { |err| captured << err }
       @vm.eval_code("void Promise.reject('just-a-string');")
 
       _(captured.first).must_be_kind_of Quickjs::RuntimeError
       _(captured.first.message).must_match(/just-a-string/)
     end
 
-    it "accepts nil to clear a previously set callback" do
-      @vm.on_unhandled_rejection = ->(err) {}
-      @vm.on_unhandled_rejection = nil
-      _(@vm.on_unhandled_rejection).must_be_nil
+    it "replaces the previously registered block on a second call" do
+      first = []
+      second = []
+      @vm.on_unhandled_rejection { |err| first << err }
+      @vm.on_unhandled_rejection { |err| second << err }
+      @vm.eval_code("void Promise.reject(new Error('boom'));")
+
+      _(first).must_be_empty
+      _(second.size).must_equal 1
     end
 
-    it "rejects non-Proc, non-nil values" do
-      _ { @vm.on_unhandled_rejection = 'not a proc' }.must_raise TypeError
+    it "raises LocalJumpError when called without a block" do
+      _ { @vm.on_unhandled_rejection }.must_raise LocalJumpError
     end
 
-    it "swallows exceptions raised inside the callback" do
+    it "swallows exceptions raised inside the block" do
       called = false
-      @vm.on_unhandled_rejection = ->(_) { called = true; raise 'callback boom' }
+      @vm.on_unhandled_rejection { |_| called = true; raise 'callback boom' }
       @vm.eval_code("void Promise.reject(new Error('x'));")
 
       _(called).must_equal true

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -219,6 +219,31 @@ describe Quickjs do
       _(err.js_name).must_be_nil
     end
 
+    it "exposes the JS Error.stack as the Ruby exception's backtrace" do
+      err = _ {
+        ::Quickjs.eval_code(<<~JS, filename: 'demo.js')
+          function inner() { throw new TypeError('boom'); }
+          function outer() { inner(); }
+          outer();
+        JS
+      }.must_raise Quickjs::TypeError
+
+      _(err.backtrace).wont_be_nil
+      joined = err.backtrace.join("\n")
+      _(joined).must_match(/inner.*demo\.js/)
+      _(joined).must_match(/outer.*demo\.js/)
+    end
+
+    it "leaves the Ruby default backtrace in place for non-Error throws (no JS stack to surface)" do
+      err = _ {
+        ::Quickjs.eval_code("throw 'bare string';", filename: 'demo.js')
+      }.must_raise Quickjs::RuntimeError
+
+      # A bare throw has no .stack property, so no JS frame ever lands in
+      # the backtrace — Ruby's default is left in place.
+      _(err.backtrace.any? {|line| line.include?('demo.js') }).must_equal false
+    end
+
     it "throws an exception if promise instance is returned" do
       err = _ {
         ::Quickjs.eval_code("const promise = new Promise((res) => { res('awaited yo') });promise")
@@ -905,6 +930,23 @@ describe Quickjs::VM do
 
       _(captured.first).must_be_kind_of Quickjs::RuntimeError
       _(captured.first.message).must_match(/just-a-string/)
+    end
+
+    it "exposes the JS Error.stack as the captured exception's backtrace" do
+      captured = []
+      @vm.on_unhandled_rejection { |err| captured << err }
+      @vm.eval_code(<<~JS, filename: 'rej.js')
+        function detonate() { throw new TypeError('rejection-stack-test'); }
+        function trigger() {
+          try { detonate(); } catch (e) { void Promise.reject(e); }
+        }
+        trigger();
+      JS
+
+      _(captured.first.backtrace).wont_be_nil
+      joined = captured.first.backtrace.join("\n")
+      _(joined).must_match(/detonate.*rej\.js/)
+      _(joined).must_match(/trigger.*rej\.js/)
     end
 
     it "replaces the previously registered block on a second call" do


### PR DESCRIPTION
## Summary

`Quickjs::*Error` raised from JS land previously carried only Ruby's call-site backtrace, so when JS code threw — especially deep inside a rejected promise chain — the actual JS site was invisible. This PR reads the JS `Error.stack` property, splits it into lines, and feeds them to `Exception#set_backtrace`. The JS frames then show up directly when you log, inspect, or re-raise.

Before:

```rb
begin
  vm.eval_code(<<~JS, filename: 'app.js')
    function inner() { throw new TypeError('boom'); }
    function outer() { inner(); }
    outer();
  JS
rescue Quickjs::TypeError => e
  puts e.backtrace
end
#=> ./my_script.rb:42:in '<main>'
#   (no JS site, even though the throw happened inside outer/inner)
```

After:

```
at inner (app.js:1:39)
at outer (app.js:2:25)
at <eval> (app.js:3:6)
```

Applies to both paths in this codebase:

1. **Synchronous eval / call** — `to_rb_value_inner`'s `JS_TAG_EXCEPTION` branch
2. **Unhandled promise rejection tracker** (introduced in this same PR series) — `r_exception_from_js_reason`

The frames keep QuickJS's native `at func (file:line:col)` format. `Exception#set_backtrace` accepts arbitrary strings, and reshaping into `file:line:in 'method'` would lose the column information for no real win — mini_racer does the same.

Bare throws (`throw 'string'`, `throw 42`) have no `.stack` property, so the Ruby default backtrace is left in place for those.

## Drive-by fix

Found a use-after-free in `to_rb_value_inner`: `errorClassName` was being passed to `rb_str_new2` _after_ being freed via `JS_FreeCString`. The refactor naturally fixes it by capturing all the Ruby string copies first, then freeing C-side allocations.

## Dependency

This builds on top of #42 (Promise rejection tracker) — the rejection-path fix touches `r_exception_from_js_reason`, which is introduced there. Easiest review order: merge #42 first, then this. The base branch is `main`, so once #42 lands the diff here should collapse to just the new stack-handling code.

## Test plan

- [x] `bundle exec rake` (435 runs, 634 assertions, 0 failures)
- [x] Sync eval: nested JS functions throwing produce a backtrace with each frame and the filename passed to `eval_code`
- [x] Bare `throw 'string'`: Ruby default backtrace preserved (no JS frames)
- [x] Rejection tracker: captured exception's backtrace contains the JS frames from the throw site

🤖 Generated with [Claude Code](https://claude.com/claude-code)