### PR TITLE
Rename drain_microtasks! to drain_jobs!

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,22 @@ vm.eval_code('1 + 1') # raises Quickjs::RuntimeError "VM has been disposed"
 Thread.new { vm.dispose! }
 ```
 
+#### `Quickjs::VM#drain_microtasks!`: 🌀 Run pending microtasks to completion
+
+QuickJS does not automatically drain the microtask queue at the end of a synchronous `eval_code` / `call`. Continuations scheduled via `Promise.resolve().then(...)`, `queueMicrotask`-style patterns, or `JS_EnqueueJob` stay pending until something explicitly pumps them — `await` inside JS does, but a sync return path does not.
+
+```rb
+vm = Quickjs::VM.new
+vm.eval_code('globalThis.x = 0; Promise.resolve().then(() => { x = 1 })')
+vm.eval_code('x')      #=> 0  (the .then() callback hasn't run yet)
+vm.drain_microtasks!   #=> 1  (number of jobs executed)
+vm.eval_code('x')      #=> 1
+```
+
+`drain_microtasks!` keeps pumping until the queue empties, so microtasks that schedule further microtasks all run in a single call. The drain is bounded by the VM's `timeout_msec`, and any exception that escapes a job is raised as a `Quickjs::RuntimeError`.
+
+Useful when porting JS that assumed V8's implicit-drain semantics — V8 (and therefore [mini_racer](https://github.com/rubyjs/mini_racer)) flushes microtasks at every eval boundary, so `eval_code` already sees `.then()` continuations run by the time it returns. QuickJS doesn't. Patterns like `Promise.resolve().then(() => { ... })`, `queueMicrotask`-style chains, and Stimulus/Hotwire callbacks that assume "the next microtask tick" silently fall through unless you call `drain_microtasks!` explicitly.
+
 ### Value Conversion
 
 | JavaScript | | Ruby | Note |

--- a/README.md
+++ b/README.md
@@ -317,21 +317,21 @@ vm.eval_code('1 + 1') # raises Quickjs::RuntimeError "VM has been disposed"
 Thread.new { vm.dispose! }
 ```
 
-#### `Quickjs::VM#drain_microtasks!`: 🌀 Run pending microtasks to completion
+#### `Quickjs::VM#drain_jobs!`: Run pending JS jobs to completion
 
-QuickJS does not automatically drain the microtask queue at the end of a synchronous `eval_code` / `call`. Continuations scheduled via `Promise.resolve().then(...)`, `queueMicrotask`-style patterns, or `JS_EnqueueJob` stay pending until something explicitly pumps them — `await` inside JS does, but a sync return path does not.
+QuickJS does not automatically drain the job queue at the end of a synchronous `eval_code` / `call`. Continuations scheduled via `Promise.resolve().then(...)` or `JS_EnqueueJob` stay pending until something explicitly runs them — `await` inside JS does, but a sync return path does not.
 
 ```rb
 vm = Quickjs::VM.new
-vm.eval_code('globalThis.x = 0; Promise.resolve().then(() => { x = 1 })')
-vm.eval_code('x')      #=> 0  (the .then() callback hasn't run yet)
-vm.drain_microtasks!   #=> 1  (number of jobs executed)
-vm.eval_code('x')      #=> 1
+vm.eval_code('globalThis.x = 0; Promise.resolve().then(() => { x = 1 }); void 0')
+vm.eval_code('x')    #=> 0  (the .then() callback hasn't run yet)
+vm.drain_jobs!       #=> 1  (number of jobs executed)
+vm.eval_code('x')   #=> 1
 ```
 
-`drain_microtasks!` keeps pumping until the queue empties, so microtasks that schedule further microtasks all run in a single call. The drain is bounded by the VM's `timeout_msec`, and any exception that escapes a job is raised as a `Quickjs::RuntimeError`.
+`drain_jobs!` keeps running until the queue empties, so jobs that schedule further jobs all run in a single call. The drain is bounded by the VM's `timeout_msec`; exceeding it raises `Quickjs::InterruptedError`.
 
-Useful when porting JS that assumed V8's implicit-drain semantics — V8 (and therefore [mini_racer](https://github.com/rubyjs/mini_racer)) flushes microtasks at every eval boundary, so `eval_code` already sees `.then()` continuations run by the time it returns. QuickJS doesn't. Patterns like `Promise.resolve().then(() => { ... })`, `queueMicrotask`-style chains, and Stimulus/Hotwire callbacks that assume "the next microtask tick" silently fall through unless you call `drain_microtasks!` explicitly.
+Useful when porting JS that assumed V8's implicit-drain semantics — V8 (and therefore [mini_racer](https://github.com/rubyjs/mini_racer)) flushes pending jobs at every eval boundary, so `eval_code` already sees `.then()` continuations run by the time it returns. QuickJS doesn't. Patterns like `Promise.resolve().then(() => { ... })` and Stimulus/Hotwire callbacks that assume "the next microtask tick" silently fall through unless you call `drain_jobs!` explicitly.
 
 ### Value Conversion
 

--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -34,7 +34,7 @@ static VALUE vm_m_runGC(VALUE r_self);
 static VALUE vm_m_memoryPoisoned(VALUE r_self);
 static VALUE vm_m_dispose(VALUE r_self);
 static VALUE vm_m_disposed(VALUE r_self);
-static VALUE vm_m_drainMicrotasks(VALUE r_self);
+static VALUE vm_m_drainJobs(VALUE r_self);
 
 JSValue j_error_from_ruby_error(JSContext *ctx, VALUE r_error)
 {
@@ -1604,7 +1604,7 @@ RUBY_FUNC_EXPORTED void Init_quickjsrb(void)
   rb_define_method(r_class_vm, "memory_poisoned?", vm_m_memoryPoisoned, 0);
   rb_define_method(r_class_vm, "dispose!", vm_m_dispose, 0);
   rb_define_method(r_class_vm, "disposed?", vm_m_disposed, 0);
-  rb_define_method(r_class_vm, "drain_microtasks!", vm_m_drainMicrotasks, 0);
+  rb_define_method(r_class_vm, "drain_jobs!", vm_m_drainJobs, 0);
   r_define_log_class(r_class_vm);
 }
 
@@ -1640,7 +1640,7 @@ static VALUE vm_m_runGC(VALUE r_self)
   return Qnil;
 }
 
-static VALUE vm_m_drainMicrotasks(VALUE r_self)
+static VALUE vm_m_drainJobs(VALUE r_self)
 {
   VMData *data;
   TypedData_Get_Struct(r_self, VMData, &vm_type, data);

--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -34,6 +34,7 @@ static VALUE vm_m_runGC(VALUE r_self);
 static VALUE vm_m_memoryPoisoned(VALUE r_self);
 static VALUE vm_m_dispose(VALUE r_self);
 static VALUE vm_m_disposed(VALUE r_self);
+static VALUE vm_m_drainMicrotasks(VALUE r_self);
 
 JSValue j_error_from_ruby_error(JSContext *ctx, VALUE r_error)
 {
@@ -1603,6 +1604,7 @@ RUBY_FUNC_EXPORTED void Init_quickjsrb(void)
   rb_define_method(r_class_vm, "memory_poisoned?", vm_m_memoryPoisoned, 0);
   rb_define_method(r_class_vm, "dispose!", vm_m_dispose, 0);
   rb_define_method(r_class_vm, "disposed?", vm_m_disposed, 0);
+  rb_define_method(r_class_vm, "drain_microtasks!", vm_m_drainMicrotasks, 0);
   r_define_log_class(r_class_vm);
 }
 
@@ -1636,6 +1638,32 @@ static VALUE vm_m_runGC(VALUE r_self)
   check_disposed(data);
   JS_RunGC(JS_GetRuntime(data->context));
   return Qnil;
+}
+
+static VALUE vm_m_drainMicrotasks(VALUE r_self)
+{
+  VMData *data;
+  TypedData_Get_Struct(r_self, VMData, &vm_type, data);
+
+  check_oom_poisoned(data);
+
+  JSRuntime *runtime = JS_GetRuntime(data->context);
+  if (!JS_IsJobPending(runtime))
+    return INT2NUM(0);
+
+  arm_eval_timer(data);
+
+  int executed = 0;
+  for (;;)
+  {
+    int err = JS_ExecutePendingJob(runtime, NULL);
+    if (err == 0)
+      break;
+    if (err < 0)
+      return to_rb_value(data->context, JS_EXCEPTION); // raises
+    executed++;
+  }
+  return INT2NUM(executed);
 }
 
 static VALUE vm_m_memoryPoisoned(VALUE r_self)

--- a/sig/quickjs.rbs
+++ b/sig/quickjs.rbs
@@ -51,6 +51,8 @@ module Quickjs
 
     def disposed?: () -> bool
 
+    def drain_microtasks!: () -> Integer
+
     class Log
       attr_reader severity: Symbol
 

--- a/sig/quickjs.rbs
+++ b/sig/quickjs.rbs
@@ -51,7 +51,7 @@ module Quickjs
 
     def disposed?: () -> bool
 
-    def drain_microtasks!: () -> Integer
+    def drain_jobs!: () -> Integer
 
     class Log
       attr_reader severity: Symbol

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -450,6 +450,81 @@ describe Quickjs::VM do
     _ { vm.eval_code("await longProcess()") }.must_raise Quickjs::InterruptedError
   end
 
+  describe "DrainMicrotasks" do
+    before do
+      @vm = Quickjs::VM.new
+    end
+
+    it "returns 0 when no microtasks are pending" do
+      _(@vm.drain_microtasks!).must_equal 0
+    end
+
+    it "runs a Promise.resolve().then() callback that eval_code leaves pending" do
+      @vm.eval_code('globalThis.x = 0; Promise.resolve().then(() => { x = 1 }); void 0')
+      _(@vm.eval_code('x')).must_equal 0
+      _(@vm.drain_microtasks!).must_equal 1
+      _(@vm.eval_code('x')).must_equal 1
+    end
+
+    it "drains chained then() across multiple ticks" do
+      @vm.eval_code(<<~JS)
+        globalThis.log = []
+        Promise.resolve()
+          .then(() => log.push('a'))
+          .then(() => log.push('b'))
+          .then(() => log.push('c'))
+        void 0
+      JS
+      _(@vm.drain_microtasks!).must_equal 3
+      _(@vm.eval_code('log.join(",")')).must_equal 'a,b,c'
+    end
+
+    it "drains microtasks scheduled from within other microtasks" do
+      @vm.eval_code(<<~JS)
+        globalThis.depth = 0
+        function schedule(n) {
+          if (n === 0) return
+          Promise.resolve().then(() => { depth++; schedule(n - 1) })
+        }
+        schedule(5)
+        void 0
+      JS
+      _(@vm.drain_microtasks!).must_equal 5
+      _(@vm.eval_code('depth')).must_equal 5
+    end
+
+    it "leaves the queue empty after draining" do
+      @vm.eval_code('Promise.resolve().then(() => {}); void 0')
+      _(@vm.drain_microtasks!).must_equal 1
+      _(@vm.drain_microtasks!).must_equal 0
+    end
+
+    it "respects timeout_msec while draining" do
+      vm = Quickjs::VM.new(timeout_msec: 100)
+      vm.eval_code(<<~JS)
+        function loop() { Promise.resolve().then(loop) }
+        loop()
+        void 0
+      JS
+
+      started = Time.now.to_f * 1000
+      vm.drain_microtasks!
+      elapsed = Time.now.to_f * 1000 - started
+      # The interrupt check has some inherent slack vs. the wall clock — CI
+      # has been observed firing ~0.6ms before the 100ms timeout. Widen both
+      # bounds enough to absorb realistic noise while still catching
+      # "returns instantly" (lower) and "hangs forever" (upper).
+      assert_operator elapsed, :>=, 50
+      assert_operator elapsed, :<, 300
+    end
+
+    it "raises Quickjs::RuntimeError after the VM is OOM-poisoned" do
+      vm = Quickjs::VM.new(memory_limit: 1024 * 1024)
+      _ { vm.eval_code('new Array(2_000_000).fill(0); void 0') }.must_raise Quickjs::RuntimeError
+      _ { vm.drain_microtasks! }.must_raise Quickjs::RuntimeError
+    end
+  end
+
   describe "GlobalFunction" do
     before do
       @vm = Quickjs::VM.new

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -450,19 +450,19 @@ describe Quickjs::VM do
     _ { vm.eval_code("await longProcess()") }.must_raise Quickjs::InterruptedError
   end
 
-  describe "DrainMicrotasks" do
+  describe "DrainJobs" do
     before do
       @vm = Quickjs::VM.new
     end
 
-    it "returns 0 when no microtasks are pending" do
-      _(@vm.drain_microtasks!).must_equal 0
+    it "returns 0 when no jobs are pending" do
+      _(@vm.drain_jobs!).must_equal 0
     end
 
     it "runs a Promise.resolve().then() callback that eval_code leaves pending" do
       @vm.eval_code('globalThis.x = 0; Promise.resolve().then(() => { x = 1 }); void 0')
       _(@vm.eval_code('x')).must_equal 0
-      _(@vm.drain_microtasks!).must_equal 1
+      _(@vm.drain_jobs!).must_equal 1
       _(@vm.eval_code('x')).must_equal 1
     end
 
@@ -475,11 +475,11 @@ describe Quickjs::VM do
           .then(() => log.push('c'))
         void 0
       JS
-      _(@vm.drain_microtasks!).must_equal 3
+      _(@vm.drain_jobs!).must_equal 3
       _(@vm.eval_code('log.join(",")')).must_equal 'a,b,c'
     end
 
-    it "drains microtasks scheduled from within other microtasks" do
+    it "drains jobs scheduled from within other jobs" do
       @vm.eval_code(<<~JS)
         globalThis.depth = 0
         function schedule(n) {
@@ -489,14 +489,14 @@ describe Quickjs::VM do
         schedule(5)
         void 0
       JS
-      _(@vm.drain_microtasks!).must_equal 5
+      _(@vm.drain_jobs!).must_equal 5
       _(@vm.eval_code('depth')).must_equal 5
     end
 
     it "leaves the queue empty after draining" do
       @vm.eval_code('Promise.resolve().then(() => {}); void 0')
-      _(@vm.drain_microtasks!).must_equal 1
-      _(@vm.drain_microtasks!).must_equal 0
+      _(@vm.drain_jobs!).must_equal 1
+      _(@vm.drain_jobs!).must_equal 0
     end
 
     it "respects timeout_msec while draining" do
@@ -508,12 +508,8 @@ describe Quickjs::VM do
       JS
 
       started = Time.now.to_f * 1000
-      vm.drain_microtasks!
+      vm.drain_jobs!
       elapsed = Time.now.to_f * 1000 - started
-      # The interrupt check has some inherent slack vs. the wall clock — CI
-      # has been observed firing ~0.6ms before the 100ms timeout. Widen both
-      # bounds enough to absorb realistic noise while still catching
-      # "returns instantly" (lower) and "hangs forever" (upper).
       assert_operator elapsed, :>=, 50
       assert_operator elapsed, :<, 300
     end
@@ -521,7 +517,7 @@ describe Quickjs::VM do
     it "raises Quickjs::RuntimeError after the VM is OOM-poisoned" do
       vm = Quickjs::VM.new(memory_limit: 1024 * 1024)
       _ { vm.eval_code('new Array(2_000_000).fill(0); void 0') }.must_raise Quickjs::RuntimeError
-      _ { vm.drain_microtasks! }.must_raise Quickjs::RuntimeError
+      _ { vm.drain_jobs! }.must_raise Quickjs::RuntimeError
     end
   end
 


### PR DESCRIPTION
## Summary

Renames `drain_microtasks!` (proposed in #40) to `drain_jobs!` before merging.

- **Terminology**: QuickJS never uses the word "microtask" — its API is `JS_ExecutePendingJob` / `JS_IsJobPending`. `drain_jobs!` stays consistent with the engine's own vocabulary.
- **README fix**: example now uses `; void 0` so async eval doesn't inadvertently drain the queue via `js_std_await`, which would make the demo incorrect.
- **README fix**: documents that timeout raises `Quickjs::InterruptedError` (not `RuntimeError`).

This is based on #40 (Keita Urashima's work), squashed into a single commit with attribution, plus the rename on top.

Closes #40.