### PR TITLE
Dispose VM eagerly in Quickjs.eval_code

### DIFF
--- a/lib/quickjs.rb
+++ b/lib/quickjs.rb
@@ -23,9 +23,9 @@ module Quickjs
     eval_opts[:filename] = overwrite_opts.delete(:filename) if overwrite_opts.key?(:filename)
     eval_opts[:async] = overwrite_opts.delete(:async) if overwrite_opts.key?(:async)
     vm = Quickjs::VM.new(**overwrite_opts)
-    res = vm.eval_code(code, **eval_opts)
-    vm = nil
-    res
+    vm.eval_code(code, **eval_opts)
+  ensure
+    vm&.dispose!
   end
   module_function :eval_code
 


### PR DESCRIPTION
## Summary

Replaces `vm = nil` with `vm.dispose!` in an `ensure` block in `Quickjs.eval_code`.

`vm = nil` only removes the Ruby reference, leaving the QuickJS runtime (JSContext + JSRuntime + atom table) in memory until GC decides to collect it. `dispose!` calls `rb_thread_call_without_gvl` to free the runtime immediately, releasing the GVL during cleanup so other Ruby threads can run concurrently.

The `ensure` also means the VM is disposed even when `eval_code` raises — previously the `vm = nil` line was never reached on exception.

🤖 Generated with [Claude Code](https://claude.com/claude-code)