### PR TITLE
Add Quickjs.compile convenience method

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,15 @@ runnable.run(on: { features: [::Quickjs::POLYFILL_INTL] }) # ad-hoc VM with opti
 
 `Runnable#to_s` returns the underlying bytecode as a frozen ASCII-8BIT `String`, suitable for caching to memory or disk. `Quickjs::Runnable.new(bytecode_string)` reconstructs a `Runnable` from that blob — validation happens lazily at `run` time, so a corrupt or wrong-build blob surfaces as `Quickjs::RuntimeError` when executed. The bytecode format is tied to the QuickJS build, so include the gem version in your cache key if you persist across upgrades.
 
+`Quickjs.compile` is a one-shot convenience that creates and immediately disposes a throwaway VM:
+
+```rb
+runnable = Quickjs.compile(File.read('big_bundle.js'), filename: 'big_bundle.js')
+runnable.run  # execute on a fresh VM, no parse cost
+```
+
+Accepts `filename:` and the same VM options as `Quickjs.eval_code` (`memory_limit:`, `timeout_msec:`, etc.) — useful when compiling large bundles that exceed the default limits.
+
 #### `Quickjs::VM#call`: ⚡ Call a JS function directly with Ruby arguments
 
 ```rb

--- a/lib/quickjs.rb
+++ b/lib/quickjs.rb
@@ -29,6 +29,16 @@ module Quickjs
   end
   module_function :eval_code
 
+  def compile(source, **opts)
+    compile_opts = {}
+    compile_opts[:filename] = opts.delete(:filename) if opts.key?(:filename)
+    vm = Quickjs::VM.new(**opts)
+    vm.compile(source, **compile_opts)
+  ensure
+    vm&.dispose!
+  end
+  module_function :compile
+
   def _with_timeout(msec, proc, args)
     Timeout.timeout(msec / 1_000.0) { proc.call(*args) }
   rescue Timeout::Error

--- a/sig/quickjs.rbs
+++ b/sig/quickjs.rbs
@@ -12,6 +12,7 @@ module Quickjs
   POLYFILL_CRYPTO: Symbol
 
   def self.eval_code: (String code, ?Hash[Symbol, untyped] overwrite_opts) -> untyped
+  def self.compile: (String source, ?filename: String, **untyped) -> Quickjs::Runnable
 
   class Value
     UNDEFINED: Symbol

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -1274,6 +1274,20 @@ describe Quickjs::VM do
     end
   end
 
+  describe "Quickjs.compile" do
+    it "returns a Quickjs::Runnable" do
+      _(::Quickjs.compile('1 + 1')).must_be_instance_of Quickjs::Runnable
+    end
+
+    it "the Runnable runs correctly" do
+      _(::Quickjs.compile('40 + 2').run).must_equal 42
+    end
+
+    it "supports filename: option" do
+      _ { ::Quickjs.compile('}{', filename: 'app.js') }.must_raise Quickjs::SyntaxError
+    end
+  end
+
   describe "Runnable" do
     before do
       @vm = Quickjs::VM.new


### PR DESCRIPTION
## Summary

Adds `Quickjs.compile` as a module-level convenience, mirroring `Quickjs.eval_code`.

```rb
runnable = Quickjs.compile('40 + 2')
runnable.run  #=> 42
```

Creates a throwaway VM internally, compiles the source to a `Runnable`, then disposes the VM eagerly via `ensure` — so QuickJS runtime memory is freed immediately rather than waiting for GC.

`VM#compile` remains the right API when you want to compile and run against a shared persistent VM. `Quickjs.compile` is for one-shot compilation where the context doesn't matter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)