### PR TITLE
Eagerly dispose temporary VMs created by _with_vm

### DIFF
--- a/lib/quickjs.rb
+++ b/lib/quickjs.rb
@@ -43,12 +43,16 @@ module Quickjs
     when Quickjs::VM
       yield on
     when nil
-      yield Quickjs::VM.new
+      vm = Quickjs::VM.new
+      yield vm
     when Hash
-      yield Quickjs::VM.new(**on)
+      vm = Quickjs::VM.new(**on)
+      yield vm
     else
       raise ArgumentError, 'on: must be a Quickjs::VM, a Hash of VM options, or nil'
     end
+  ensure
+    vm&.dispose!
   end
   module_function :_with_vm
 

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -942,6 +942,23 @@ describe Quickjs::VM do
       @vm.eval_code("capture(() => 1)")
       _ { received.call(on: "bad") }.must_raise ArgumentError
     end
+
+    it "call with no on: disposes the temporary VM after execution" do
+      received = nil
+      @vm.define_function("capture") { |fn| received = fn }
+      @vm.eval_code("capture(() => 42)")
+      _(received.call).must_equal 42
+    end
+
+    it "call with on: vm does not dispose the external VM" do
+      received = nil
+      @vm.define_function("capture") { |fn| received = fn }
+      @vm.eval_code("capture(() => 1)")
+      other_vm = Quickjs::VM.new
+      received.call(on: other_vm)
+      _(other_vm.disposed?).must_equal false
+      other_vm.dispose!
+    end
   end
 
   describe "Import" do
@@ -1356,6 +1373,19 @@ describe Quickjs::VM do
       runnable = @vm.compile('while (true) {}')
       vm = Quickjs::VM.new(timeout_msec: 50)
       _ { runnable.run(on: vm) }.must_raise Quickjs::InterruptedError
+    end
+
+    it "run with no on: disposes the temporary VM after execution" do
+      runnable = @vm.compile('40 + 2')
+      _(runnable.run).must_equal 42
+    end
+
+    it "run(on: vm) does not dispose the external VM" do
+      runnable = @vm.compile('1 + 1')
+      other_vm = Quickjs::VM.new
+      runnable.run(on: other_vm)
+      _(other_vm.disposed?).must_equal false
+      other_vm.dispose!
     end
   end
 


### PR DESCRIPTION
## Summary

- `Function#call` and `Runnable#run` share `_with_vm` to create a temporary VM when `on:` is `nil` or a Hash option bag
- Previously the temporary VM was left for Ruby GC; now `_with_vm` disposes it in an `ensure` block so the QuickJS heap is freed immediately
- External VMs passed via `on: vm` are never disposed — the `when Quickjs::VM` branch never assigns the local `vm` variable, so `vm&.dispose!` is a no-op

## Test plan

- Added tests confirming the temporary-VM path still returns correct results after disposal
- Added tests confirming an externally passed VM is not disposed after `Function#call` / `Runnable#run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)