### PR TITLE
Release GVL during registered polyfill bytecode loading

### DIFF
--- a/benchmark/threading.rb
+++ b/benchmark/threading.rb
@@ -9,18 +9,12 @@ end
 
 require 'etc'
 require_relative '../lib/quickjs'
+require_relative '../test/support/cpu_workload'
 
-# CPU-bound JS workload: a tight loop with non-trivial arithmetic.
-# Large enough that any GVL contention dominates over fixed overheads.
-WORKLOAD = <<~JS
-  (() => {
-    let acc = 0;
-    for (let i = 0; i < 200000; i++) {
-      acc = (acc + Math.sqrt(i) * Math.sin(i)) % 1e9;
-    }
-    return acc;
-  })();
-JS
+# CPU-bound JS workload: a tight loop with non-trivial arithmetic, shared
+# with the parallelism tests so this benchmark measures the exact
+# workload `assert_run_in_parallel` asserts on.
+WORKLOAD = QuickjsCpuWorkload.cpu_workload_js
 
 THREAD_COUNTS = [1, 2, 4, 8]
 ITERATIONS_PER_THREAD = 20

--- a/benchmark/threading.rb
+++ b/benchmark/threading.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require 'bundler/inline'
+
+gemfile(true, quiet: true) do
+  source 'https://rubygems.org'
+  gem 'benchmark'
+end
+
+require 'etc'
+require_relative '../lib/quickjs'
+
+# CPU-bound JS workload: a tight loop with non-trivial arithmetic.
+# Large enough that any GVL contention dominates over fixed overheads.
+WORKLOAD = <<~JS
+  (() => {
+    let acc = 0;
+    for (let i = 0; i < 200000; i++) {
+      acc = (acc + Math.sqrt(i) * Math.sin(i)) % 1e9;
+    }
+    return acc;
+  })();
+JS
+
+THREAD_COUNTS = [1, 2, 4, 8]
+ITERATIONS_PER_THREAD = 20
+TRIALS = 5
+
+def run(thread_count, iterations_per_thread)
+  threads = Array.new(thread_count) {
+    Thread.new {
+      vm = Quickjs::VM.new
+
+      begin
+        iterations_per_thread.times { vm.eval_code(WORKLOAD) }
+      ensure
+        vm.dispose!
+      end
+    }
+  }
+  threads.each(&:join)
+end
+
+def median(values)
+  sorted = values.sort
+  mid    = sorted.length / 2
+  sorted.length.odd? ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2.0
+end
+
+# Subtract the heredoc's trailing newline so a 6-line JS body reports as 6.
+js_line_count = WORKLOAD.lines.count - (WORKLOAD.end_with?("\n") ? 1 : 0)
+
+puts "Ruby #{RUBY_VERSION} / quickjs.rb #{Quickjs::VERSION}"
+puts "Workload: #{js_line_count} lines of CPU-bound JS, #{ITERATIONS_PER_THREAD} iterations/thread, median of #{TRIALS} trials"
+puts "Cores reported: #{Etc.nprocessors}"
+puts
+
+# Warm up: load the extension, JIT caches, etc.
+run(1, 1)
+
+label_width = 'N threads'.length
+
+per_iter_ms_by_n = {}
+Benchmark.bm(label_width) do |x|
+  THREAD_COUNTS.each do |n|
+    label = "#{n} threads"
+    trial_per_iter_ms = []
+    x.report(label) {
+      TRIALS.times {
+        elapsed = Benchmark.realtime { run(n, ITERATIONS_PER_THREAD) }
+        trial_per_iter_ms << elapsed / (n * ITERATIONS_PER_THREAD) * 1000
+      }
+    }
+    per_iter_ms_by_n[n] = median(trial_per_iter_ms)
+  end
+end
+
+puts
+puts 'Per-iteration wall-clock (lower is better; flat across thread counts ⇒ serial; halving as N doubles ⇒ parallel):'
+baseline_per_iter = per_iter_ms_by_n[THREAD_COUNTS.first]
+THREAD_COUNTS.each do |n|
+  per_iter_ms = per_iter_ms_by_n[n]
+  speedup = n == THREAD_COUNTS.first ? 'baseline' : format('%.2fx vs 1 thread', baseline_per_iter / per_iter_ms)
+  puts "#{"#{n} threads".ljust(label_width)}  #{format('%6.2f', per_iter_ms)} ms/iter  (#{speedup})"
+end

--- a/benchmark/threading.rb
+++ b/benchmark/threading.rb
@@ -47,11 +47,8 @@ def median(values)
   sorted.length.odd? ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2.0
 end
 
-# Subtract the heredoc's trailing newline so a 6-line JS body reports as 6.
-js_line_count = WORKLOAD.lines.count - (WORKLOAD.end_with?("\n") ? 1 : 0)
-
 puts "Ruby #{RUBY_VERSION} / quickjs.rb #{Quickjs::VERSION}"
-puts "Workload: #{js_line_count} lines of CPU-bound JS, #{ITERATIONS_PER_THREAD} iterations/thread, median of #{TRIALS} trials"
+puts "Workload: #{WORKLOAD.lines.count} lines of CPU-bound JS, #{ITERATIONS_PER_THREAD} iterations/thread, median of #{TRIALS} trials"
 puts "Cores reported: #{Etc.nprocessors}"
 puts
 

--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -1249,7 +1249,7 @@ static bool can_eval_gvl_free(VMData *data)
       && !data->has_native_ruby_bridge;
 }
 
-struct eval_code_no_gvl_args
+struct eval_code_no_gvl_body_args
 {
   JSContext *ctx;
   const char *code;
@@ -1260,9 +1260,12 @@ struct eval_code_no_gvl_args
   JSValue result;
 };
 
-static void *eval_code_no_gvl(void *p)
+// Worker body passed to rb_thread_call_without_gvl. Runs JS_Eval (+ js_std_await
+// for async) on the calling thread with the GVL released. MUST NOT touch the
+// Ruby VM directly — see js_quickjsrb_log's dispatcher for the re-acquire pattern.
+static void *eval_code_no_gvl_body(void *p)
 {
-  struct eval_code_no_gvl_args *args = p;
+  struct eval_code_no_gvl_body_args *args = p;
   JSValue j_codeResult = JS_Eval(args->ctx, args->code, args->code_len, args->filename, args->eval_flags);
   if (args->async_mode)
   {
@@ -1299,7 +1302,7 @@ static VALUE eval_code_release_gvl(VMData *data, VALUE r_code, const char *filen
     rb_raise(rb_eNoMemError, "failed to allocate eval filename buffer");
   }
 
-  struct eval_code_no_gvl_args args = {
+  struct eval_code_no_gvl_body_args args = {
       .ctx = data->context,
       .code = code_buf,
       .code_len = code_len,
@@ -1310,7 +1313,7 @@ static VALUE eval_code_release_gvl(VMData *data, VALUE r_code, const char *filen
   };
 
   data->gvl_released_eval = true;
-  rb_thread_call_without_gvl(eval_code_no_gvl, &args, NULL, NULL);
+  rb_thread_call_without_gvl(eval_code_no_gvl_body, &args, NULL, NULL);
   data->gvl_released_eval = false;
 
   free(code_buf);

--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -1696,6 +1696,15 @@ static VALUE vm_m_loadPolyfillBytecode(VALUE r_self, VALUE r_bytecode)
   check_oom_poisoned(data);
   StringValue(r_bytecode);
 
+  // "Unbudgeted" needs enforcing, not just skipping arm_eval_timer: the
+  // interrupt handler installed by a previous eval stays armed with that
+  // eval's started_at, so a load after the budget lapsed would be
+  // interrupted on its first check — and because the bytecode is
+  // async-wrapped, the interruption surfaces as a rejected promise the
+  // old code never looked at: the load "succeeded" with the polyfill
+  // silently missing. Disarm for the load; the next eval re-arms.
+  JS_SetInterruptHandler(JS_GetRuntime(data->context), NULL, NULL);
+
   size_t buf_len = (size_t)RSTRING_LEN(r_bytecode);
   JSValue j_result;
   if (can_eval_gvl_free(data))
@@ -1729,6 +1738,20 @@ static VALUE vm_m_loadPolyfillBytecode(VALUE r_self, VALUE r_bytecode)
 
   if (JS_IsException(j_result))
     return to_rb_value(data->context, j_result); // raises
+
+  // The compiled bytecode is async-wrapped (JS_EVAL_FLAG_ASYNC), so a
+  // top-level throw doesn't come back as JS_EXCEPTION — it comes back as
+  // a rejected promise. Surface it instead of silently shipping a VM
+  // whose polyfill half-ran.
+  if (JS_PromiseState(data->context, j_result) == JS_PROMISE_REJECTED)
+  {
+    JSValue j_reason = JS_PromiseResult(data->context, j_result);
+    JS_FreeValue(data->context, j_result);
+    VALUE r_error = r_exception_from_js_reason(data->context, j_reason);
+    JS_FreeValue(data->context, j_reason);
+    rb_exc_raise(r_error);
+  }
+
   JS_FreeValue(data->context, j_result);
   return Qnil;
 }

--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -1116,12 +1116,13 @@ static void *bytecode_load_job_run(void *p)
   return NULL;
 }
 
-// owned_buf: pass the malloc'd storage backing buf (ownership transfers to
-// the release region), or NULL when buf points at static bytecode.
-static JSValue load_polyfill_bytecode(VMData *data, const uint8_t *buf, size_t buf_len, uint8_t *owned_buf)
+// take_ownership: true when buf is malloc'd storage that the release region
+// should free on every exit path (including async-interrupt unwinds); false
+// when buf points at static bytecode.
+static JSValue load_polyfill_bytecode(VMData *data, const uint8_t *buf, size_t buf_len, bool take_ownership)
 {
   struct bytecode_load_job job = {data->context, buf, buf_len, JS_UNDEFINED};
-  run_gvl_release_region(data, bytecode_load_job_run, &job, &job.result, owned_buf, NULL);
+  run_gvl_release_region(data, bytecode_load_job_run, &job, &job.result, take_ownership ? (uint8_t *)buf : NULL, NULL);
   return job.result;
 }
 
@@ -1191,7 +1192,7 @@ static VALUE vm_m_initialize(int argc, VALUE *argv, VALUE r_self)
 
   if (RTEST(rb_funcall(r_features, rb_intern("include?"), 1, QUICKJSRB_SYM(featurePolyfillFileId))))
   {
-    JSValue j_polyfillFileResult = load_polyfill_bytecode(data, &qjsc_polyfill_file_min, qjsc_polyfill_file_min_size, NULL);
+    JSValue j_polyfillFileResult = load_polyfill_bytecode(data, &qjsc_polyfill_file_min, qjsc_polyfill_file_min_size, false);
     JS_FreeValue(data->context, j_polyfillFileResult);
 
     quickjsrb_init_file_proxy(data);
@@ -1199,13 +1200,13 @@ static VALUE vm_m_initialize(int argc, VALUE *argv, VALUE r_self)
 
   if (RTEST(rb_funcall(r_features, rb_intern("include?"), 1, QUICKJSRB_SYM(featurePolyfillEncodingId))))
   {
-    JSValue j_polyfillEncodingResult = load_polyfill_bytecode(data, &qjsc_polyfill_encoding_min, qjsc_polyfill_encoding_min_size, NULL);
+    JSValue j_polyfillEncodingResult = load_polyfill_bytecode(data, &qjsc_polyfill_encoding_min, qjsc_polyfill_encoding_min_size, false);
     JS_FreeValue(data->context, j_polyfillEncodingResult);
   }
 
   if (RTEST(rb_funcall(r_features, rb_intern("include?"), 1, QUICKJSRB_SYM(featurePolyfillUrlId))))
   {
-    JSValue j_polyfillUrlResult = load_polyfill_bytecode(data, &qjsc_polyfill_url_min, qjsc_polyfill_url_min_size, NULL);
+    JSValue j_polyfillUrlResult = load_polyfill_bytecode(data, &qjsc_polyfill_url_min, qjsc_polyfill_url_min_size, false);
     JS_FreeValue(data->context, j_polyfillUrlResult);
   }
 
@@ -1518,20 +1519,36 @@ static VALUE bytecode_eval_await_body(VALUE p)
   return Qnil;
 }
 
+// Copy a Ruby String to a malloc'd buffer that outlives a GVL release —
+// RSTRING_PTR is GC-movable, so a released region must not read the
+// String's own storage. Ownership passes to the caller (the release
+// regions free it on every exit path). nul_terminate preserves the
+// sentinel NUL QuickJS's parser reads past the length: Ruby strings carry
+// one past RSTRING_LEN, so GVL-held paths get it for free, and a copy
+// must add it back. Allocates at least one byte either way — malloc(0)
+// may return NULL on success, and an empty String (e.g. empty bytecode)
+// must still reach the JS-level diagnostic instead of a spurious
+// NoMemError.
+static char *copy_rstring_to_owned_buffer(VALUE r_str, size_t *out_len, bool nul_terminate)
+{
+  size_t len = (size_t)RSTRING_LEN(r_str);
+  char *buf = malloc(nul_terminate ? len + 1 : (len > 0 ? len : 1));
+  if (buf == NULL)
+    rb_raise(rb_eNoMemError, "failed to allocate a GVL-release copy of a Ruby String");
+  memcpy(buf, RSTRING_PTR(r_str), len);
+  if (nul_terminate)
+    buf[len] = '\0';
+  *out_len = len;
+  return buf;
+}
+
 // Run the eval core without the GVL. Inputs are copied to malloc'd buffers
 // because RSTRING_PTR can be invalidated by GC compaction while we're
-// released — see feedback memory on RSTRING_PTR + GVL release.
+// released.
 static VALUE eval_code_release_gvl(VMData *data, VALUE r_code, const char *filename, bool async_mode)
 {
-  size_t code_len = (size_t)RSTRING_LEN(r_code);
-  // QuickJS's parser reads code_len bytes plus a sentinel NUL; Ruby strings
-  // are always NUL-terminated past RSTRING_LEN, so the original GVL-held path
-  // works by accident. Our malloc'd copy must preserve that invariant.
-  char *code_buf = malloc(code_len + 1);
-  if (code_buf == NULL)
-    rb_raise(rb_eNoMemError, "failed to allocate eval code buffer");
-  memcpy(code_buf, RSTRING_PTR(r_code), code_len);
-  code_buf[code_len] = '\0';
+  size_t code_len;
+  char *code_buf = copy_rstring_to_owned_buffer(r_code, &code_len, true);
 
   char *filename_buf = strdup(filename);
   if (filename_buf == NULL)
@@ -1709,17 +1726,8 @@ static VALUE vm_m_loadPolyfillBytecode(VALUE r_self, VALUE r_bytecode)
   JSValue j_result;
   if (can_eval_gvl_free(data))
   {
-    // malloc(0) may return NULL on success; ask for one byte so an empty
-    // bytecode String still reaches JS_ReadObject's own diagnostic instead
-    // of a spurious NoMemError.
-    uint8_t *buf = malloc(buf_len > 0 ? buf_len : 1);
-    if (buf == NULL)
-      rb_raise(rb_eNoMemError, "failed to allocate polyfill bytecode buffer");
-    memcpy(buf, RSTRING_PTR(r_bytecode), buf_len);
-
-    // buf ownership transfers to the release region, which frees it even
-    // if an async interrupt unwinds past this frame.
-    j_result = load_polyfill_bytecode(data, buf, buf_len, buf);
+    uint8_t *buf = (uint8_t *)copy_rstring_to_owned_buffer(r_bytecode, &buf_len, false);
+    j_result = load_polyfill_bytecode(data, buf, buf_len, true);
   }
   else
   {

--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -1709,9 +1709,13 @@ static VALUE vm_m_loadPolyfillBytecode(VALUE r_self, VALUE r_bytecode)
   VMData *data;
   TypedData_Get_Struct(r_self, VMData, &vm_type, data);
 
+  // StringValue can invoke a non-String argument's to_str, which may
+  // yield the GVL — run it before the disposed check so nothing below
+  // touches a context freed by a concurrent dispose! in that window.
+  StringValue(r_bytecode);
+
   check_disposed(data);
   check_oom_poisoned(data);
-  StringValue(r_bytecode);
 
   // "Unbudgeted" needs enforcing, not just skipping arm_eval_timer: the
   // interrupt handler installed by a previous eval stays armed with that
@@ -1719,8 +1723,12 @@ static VALUE vm_m_loadPolyfillBytecode(VALUE r_self, VALUE r_bytecode)
   // interrupted on its first check — and because the bytecode is
   // async-wrapped, the interruption surfaces as a rejected promise the
   // old code never looked at: the load "succeeded" with the polyfill
-  // silently missing. Disarm for the load; the next eval re-arms.
-  JS_SetInterruptHandler(JS_GetRuntime(data->context), NULL, NULL);
+  // silently missing. Disarm for the load; the next eval re-arms. Only
+  // when this load is the outermost JS activity, though: a load issued
+  // from inside a bridge callback (e.g. an on_log listener) must stay
+  // under the in-flight eval's budget, not erase it.
+  if (data->evals_in_flight == 0)
+    JS_SetInterruptHandler(JS_GetRuntime(data->context), NULL, NULL);
 
   size_t buf_len = (size_t)RSTRING_LEN(r_bytecode);
   JSValue j_result;
@@ -1750,14 +1758,16 @@ static VALUE vm_m_loadPolyfillBytecode(VALUE r_self, VALUE r_bytecode)
   // The compiled bytecode is async-wrapped (JS_EVAL_FLAG_ASYNC), so a
   // top-level throw doesn't come back as JS_EXCEPTION — it comes back as
   // a rejected promise. Surface it instead of silently shipping a VM
-  // whose polyfill half-ran.
+  // whose polyfill half-ran. Re-throwing the reason routes it through
+  // to_rb_value's standard exception path, so interrupted/OOM mapping,
+  // oom_poisoned latching, and the on_log error dispatch all behave
+  // exactly as for a synchronous throw.
   if (JS_PromiseState(data->context, j_result) == JS_PROMISE_REJECTED)
   {
     JSValue j_reason = JS_PromiseResult(data->context, j_result);
     JS_FreeValue(data->context, j_result);
-    VALUE r_error = r_exception_from_js_reason(data->context, j_reason);
-    JS_FreeValue(data->context, j_reason);
-    rb_exc_raise(r_error);
+    JS_Throw(data->context, j_reason); // consumes j_reason
+    return to_rb_value(data->context, JS_EXCEPTION); // raises
   }
 
   JS_FreeValue(data->context, j_result);
@@ -1822,6 +1832,10 @@ static VALUE vm_m_defineGlobalFunction(int argc, VALUE *argv, VALUE r_self)
     {
       VALUE r_first_str = rb_funcall(RARRAY_AREF(r_name, 0), rb_intern("to_s"), 0);
       const char *first_seg = StringValueCStr(r_first_str);
+      // This lookup eval runs under whatever interrupt handler the
+      // previous eval left armed; refresh the clock so a lapsed budget
+      // can't misfire here and masquerade as "'%s' is not an object".
+      arm_eval_timer(data);
       j_parent = JS_Eval(data->context, first_seg, strlen(first_seg), vmInternalFilename, JS_EVAL_TYPE_GLOBAL);
 
       if (JS_IsException(j_parent) || !JS_IsObject(j_parent))
@@ -2192,6 +2206,12 @@ static VALUE vm_m_import(int argc, VALUE *argv, VALUE r_self)
 
   check_disposed(data);
   check_oom_poisoned(data);
+
+  // Module top-level code is user JS like any eval — budget it. Without
+  // this, import ran under whatever handler the previous entry point
+  // left behind: a lapsed armed one (spurious interrupt) or none at all
+  // after a polyfill load's disarm (unbounded).
+  arm_eval_timer(data);
 
   // Like vm_m_callGlobalFunction: the body registers a module in the
   // context and then runs Ruby code (_build_import, StringValueCStr on

--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -25,6 +25,8 @@ const char *native_errors[] = {
 const int num_native_errors = sizeof(native_errors) / sizeof(native_errors[0]);
 
 static int dispatch_log(VMData *data, const char *severity, VALUE r_row);
+static void check_disposed(VMData *data);
+static void run_gvl_release_region(VMData *data, void *(*job_run)(void *), void *job, JSValue *j_result, void *owned_buf0, void *owned_buf1);
 
 JSValue to_js_value(JSContext *ctx, VALUE r_value);
 VALUE to_rb_value(JSContext *ctx, JSValue j_val);
@@ -919,7 +921,7 @@ struct quickjsrb_log_call
 // array), allocation failure, or the user's on_log listener — can longjmp
 // through QuickJS's interpreter frames, or, on the pure path (where this
 // runs inside rb_thread_call_with_gvl), across the rb_thread_call_without_gvl
-// region — which would leak its buffers and leave gvl_released_eval stuck.
+// region — which would leak its buffers and leave gvl_released_js stuck.
 static VALUE r_build_and_dispatch_log(VALUE r_call)
 {
   struct quickjsrb_log_call *call = (struct quickjsrb_log_call *)r_call;
@@ -1003,10 +1005,10 @@ static void *quickjsrb_log_with_gvl(void *p)
   // the GVL, which MRI aborts on. A plain save/restore pair suffices: the
   // listener can't longjmp out (js_quickjsrb_log_inner rb_protects
   // everything it runs).
-  bool prev = data->gvl_released_eval;
-  data->gvl_released_eval = false;
+  bool prev = data->gvl_released_js;
+  data->gvl_released_js = false;
   c->result = js_quickjsrb_log_inner(c->ctx, c->argc, c->argv, c->severity);
-  data->gvl_released_eval = prev;
+  data->gvl_released_js = prev;
   return NULL;
 }
 
@@ -1029,7 +1031,7 @@ static JSValue js_quickjsrb_log(JSContext *ctx, int argc, JSValueConst *argv, co
   // (which itself requires the GVL) at worst drops this one row.
   if (NIL_P(data->log_listener))
     return JS_UNDEFINED;
-  if (data->gvl_released_eval)
+  if (data->gvl_released_js)
   {
     struct quickjsrb_log_call c = {ctx, argc, argv, severity, JS_UNDEFINED};
     rb_thread_call_with_gvl(quickjsrb_log_with_gvl, &c);
@@ -1062,19 +1064,32 @@ static JSValue js_console_error(JSContext *ctx, JSValueConst this, int argc, JSV
 // warmer thread can populate a VM pool in parallel with the main thread
 // on multi-core hosts.
 //
-// Two bridges can already be live when these loads run in
-// vm_m_initialize — setTimeout (FEATURE_TIMEOUT) and the File proxy
-// (POLYFILL_FILE registers it ahead of the encoding/url loads) — so
-// releasing the GVL is safe not because nothing is registered, but
-// because a load never runs bridge code: js_quickjsrb_set_timeout only
-// enqueues (pure C; the Ruby-calling js_delay_and_eval_job runs later,
-// under a GVL-held drain/await), a load never drains the job queue, and
-// the bundled polyfill top-levels (file / encoding / url, built from
-// polyfills/src in this repo) don't call the File proxy. That audit is
-// the invariant to preserve when rebuilding bundles or reordering
-// vm_m_initialize. Arbitrary user bytecode must not come through here —
-// vm_m_loadPolyfillBytecode keeps the GVL for that.
-struct polyfill_load_args
+// Two call sites use this helper:
+//
+//   1. vm_m_initialize — pre-built bytecode (file / encoding / url) embedded
+//      as static C constants. setTimeout (FEATURE_TIMEOUT) and the File
+//      proxy (POLYFILL_FILE, registered ahead of the encoding/url loads)
+//      can already be live here, so the release is safe not because
+//      nothing is registered, but because a load never runs bridge code:
+//      js_quickjsrb_set_timeout only enqueues (pure C; the Ruby-calling
+//      js_delay_and_eval_job runs later, under a GVL-held drain/await), a
+//      load never drains the job queue, and the bundled polyfill
+//      top-levels (built from polyfills/src in this repo) don't call the
+//      File proxy. That audit is the invariant to preserve when rebuilding
+//      bundles or reordering vm_m_initialize.
+//
+//   2. vm_m_loadPolyfillBytecode — bytecode from a Ruby String, copied to a
+//      malloc'd buffer first so the buffer survives a GC compact. This
+//      bytecode is arbitrary (registered by companion gems), so no audit
+//      applies: the caller gates the release on can_eval_gvl_free() to
+//      bail whenever a direct-rb_funcall bridge (File proxy, crypto, …)
+//      is installed; console.log is covered by js_quickjsrb_log's
+//      gvl_released_js re-acquire either way.
+//
+// load_polyfill_bytecode delegates to the shared GVL-release region (see
+// run_gvl_release_region) so every caller inherits the re-acquire safety,
+// the dispose! handshake, and interrupt-proof cleanup automatically.
+struct bytecode_load_job
 {
   JSContext *ctx;
   const uint8_t *buf;
@@ -1082,19 +1097,32 @@ struct polyfill_load_args
   JSValue result;
 };
 
-static void *polyfill_load_no_gvl(void *p)
+// Shared bytecode read + eval core — pure C over JSValues, MUST NOT touch
+// the Ruby VM (the polyfill release path runs it without the GVL; the
+// GVL-held call sites invoke it directly).
+static void *bytecode_load_job_run(void *p)
 {
-  struct polyfill_load_args *args = p;
-  JSValue obj = JS_ReadObject(args->ctx, args->buf, args->buf_len, JS_READ_OBJ_BYTECODE);
-  args->result = JS_EvalFunction(args->ctx, obj); // frees obj
+  struct bytecode_load_job *job = p;
+  JSValue obj = JS_ReadObject(job->ctx, job->buf, job->buf_len, JS_READ_OBJ_BYTECODE);
+  // JS_EvalFunction on a JS_EXCEPTION input replaces the pending exception
+  // with a generic "bytecode function expected" TypeError, losing the actual
+  // deserialization diagnostic from JS_ReadObject. Short-circuit instead.
+  if (JS_IsException(obj))
+  {
+    job->result = obj;
+    return NULL;
+  }
+  job->result = JS_EvalFunction(job->ctx, obj); // frees obj
   return NULL;
 }
 
-static JSValue load_polyfill_bytecode(JSContext *ctx, const uint8_t *buf, size_t buf_len)
+// owned_buf: pass the malloc'd storage backing buf (ownership transfers to
+// the release region), or NULL when buf points at static bytecode.
+static JSValue load_polyfill_bytecode(VMData *data, const uint8_t *buf, size_t buf_len, uint8_t *owned_buf)
 {
-  struct polyfill_load_args args = {ctx, buf, buf_len, JS_UNDEFINED};
-  rb_thread_call_without_gvl(polyfill_load_no_gvl, &args, NULL, NULL);
-  return args.result;
+  struct bytecode_load_job job = {data->context, buf, buf_len, JS_UNDEFINED};
+  run_gvl_release_region(data, bytecode_load_job_run, &job, &job.result, owned_buf, NULL);
+  return job.result;
 }
 
 static VALUE vm_m_initialize(int argc, VALUE *argv, VALUE r_self)
@@ -1163,7 +1191,7 @@ static VALUE vm_m_initialize(int argc, VALUE *argv, VALUE r_self)
 
   if (RTEST(rb_funcall(r_features, rb_intern("include?"), 1, QUICKJSRB_SYM(featurePolyfillFileId))))
   {
-    JSValue j_polyfillFileResult = load_polyfill_bytecode(data->context, &qjsc_polyfill_file_min, qjsc_polyfill_file_min_size);
+    JSValue j_polyfillFileResult = load_polyfill_bytecode(data, &qjsc_polyfill_file_min, qjsc_polyfill_file_min_size, NULL);
     JS_FreeValue(data->context, j_polyfillFileResult);
 
     quickjsrb_init_file_proxy(data);
@@ -1171,13 +1199,13 @@ static VALUE vm_m_initialize(int argc, VALUE *argv, VALUE r_self)
 
   if (RTEST(rb_funcall(r_features, rb_intern("include?"), 1, QUICKJSRB_SYM(featurePolyfillEncodingId))))
   {
-    JSValue j_polyfillEncodingResult = load_polyfill_bytecode(data->context, &qjsc_polyfill_encoding_min, qjsc_polyfill_encoding_min_size);
+    JSValue j_polyfillEncodingResult = load_polyfill_bytecode(data, &qjsc_polyfill_encoding_min, qjsc_polyfill_encoding_min_size, NULL);
     JS_FreeValue(data->context, j_polyfillEncodingResult);
   }
 
   if (RTEST(rb_funcall(r_features, rb_intern("include?"), 1, QUICKJSRB_SYM(featurePolyfillUrlId))))
   {
-    JSValue j_polyfillUrlResult = load_polyfill_bytecode(data->context, &qjsc_polyfill_url_min, qjsc_polyfill_url_min_size);
+    JSValue j_polyfillUrlResult = load_polyfill_bytecode(data, &qjsc_polyfill_url_min, qjsc_polyfill_url_min_size, NULL);
     JS_FreeValue(data->context, j_polyfillUrlResult);
   }
 
@@ -1283,11 +1311,11 @@ static void arm_eval_timer(VMData *data)
 
 // Pure-path predicate: true when no JS→Ruby bridge can fire during eval
 // other than console.log (which is handled by js_quickjsrb_log's
-// gvl_released_eval re-acquire). When true, eval can safely run with the
+// gvl_released_js re-acquire). When true, eval can safely run with the
 // GVL released so other Ruby threads make progress on different cores.
 // C-function bridges registered via quickjsrb_new_ruby_bridge (crypto.*,
 // File proxy, setTimeout) call rb_funcall directly — those would need to
-// learn the gvl_released_eval pattern before they can run under a released
+// learn the gvl_released_js pattern before they can run under a released
 // GVL, so we hold the GVL when any of them is installed.
 //
 // :feature_std / :feature_os intentionally pass: quickjs-libc never calls
@@ -1341,7 +1369,7 @@ static void *eval_code_job_run(void *p)
 
 // A GVL-release region — the one place that owns the handshake required to
 // run a pure-C QuickJS job with the GVL released: the save/restore of
-// gvl_released_eval (restore, not clear, so a region nested through an
+// gvl_released_js (restore, not clear, so a region nested through an
 // on_log listener doesn't flip the outer region's console.log back to the
 // inline path), the evals_in_flight increment that makes dispose! refuse,
 // the stale-dispose re-check, and an rb_ensure cleanup that keeps all of
@@ -1374,7 +1402,7 @@ static VALUE gvl_release_region_cleanup(VALUE p)
 {
   struct gvl_release_region *region = (struct gvl_release_region *)p;
   VMData *data = region->data;
-  data->gvl_released_eval = region->prev_gvl_released;
+  data->gvl_released_js = region->prev_gvl_released;
   data->evals_in_flight--;
   data->gvl_release_regions--;
   free(region->owned_bufs[0]);
@@ -1411,13 +1439,13 @@ static void run_gvl_release_region(VMData *data, void *(*job_run)(void *), void 
       .job = job,
       .j_result = j_result,
       .owned_bufs = {owned_buf0, owned_buf1},
-      .prev_gvl_released = data->gvl_released_eval,
+      .prev_gvl_released = data->gvl_released_js,
       .completed = false,
   };
 
   data->evals_in_flight++;
   data->gvl_release_regions++;
-  data->gvl_released_eval = true;
+  data->gvl_released_js = true;
   rb_ensure(gvl_release_region_run, (VALUE)&region, gvl_release_region_cleanup, (VALUE)&region);
 }
 
@@ -1468,18 +1496,25 @@ static VALUE eval_code_job_run_body(VALUE p)
   return Qnil;
 }
 
-struct eval_function_job
+// rb_ensure bodies over the shared bytecode core, for the GVL-held call
+// sites: vm_m_loadPolyfillBytecode's held fallback loads without awaiting
+// (matching its release path), vm_m_evalBytecode awaits the result. These
+// can take RSTRING_PTR without a copy: JS_ReadObject consumes the buffer
+// before any bridge can fire, so the GVL is provably held (no compaction)
+// for as long as the pointer is read.
+static VALUE bytecode_load_body(VALUE p)
 {
-  JSContext *ctx;
-  JSValue j_func;
-  JSValue j_awaited;
-};
+  bytecode_load_job_run((struct bytecode_load_job *)p);
+  return Qnil;
+}
 
-static VALUE eval_function_job_run_body(VALUE p)
+static VALUE bytecode_eval_await_body(VALUE p)
 {
-  struct eval_function_job *job = (struct eval_function_job *)p;
-  JSValue j_codeResult = JS_EvalFunction(job->ctx, job->j_func); // frees j_func
-  job->j_awaited = js_std_await(job->ctx, j_codeResult);
+  struct bytecode_load_job *job = (struct bytecode_load_job *)p;
+  bytecode_load_job_run(job);
+  // js_std_await passes a non-promise — including an exception preserved by
+  // the JS_ReadObject short-circuit — through untouched.
+  job->result = js_std_await(job->ctx, job->result);
   return Qnil;
 }
 
@@ -1620,19 +1655,16 @@ static VALUE vm_m_evalBytecode(VALUE r_self, VALUE r_bytecode)
   // here with the same can_eval_gvl_free gate + buffer copy eval_code
   // uses — left GVL-held deliberately until bytecode eval shows up as a
   // parallelism bottleneck.
-  JSValue j_func = JS_ReadObject(data->context,
-                                 (const uint8_t *)RSTRING_PTR(r_bytecode),
-                                 (size_t)RSTRING_LEN(r_bytecode),
-                                 JS_READ_OBJ_BYTECODE);
-  if (JS_IsException(j_func))
-  {
-    return to_rb_value(data->context, j_func); // raises
-  }
+  struct bytecode_load_job job = {data->context,
+                                  (const uint8_t *)RSTRING_PTR(r_bytecode),
+                                  (size_t)RSTRING_LEN(r_bytecode),
+                                  JS_UNDEFINED};
+  run_held_js_entry(data, bytecode_eval_await_body, (VALUE)&job);
+  if (JS_IsException(job.result))
+    return to_rb_value(data->context, job.result); // raises
 
-  struct eval_function_job job = {data->context, j_func, JS_UNDEFINED};
-  run_held_js_entry(data, eval_function_job_run_body, (VALUE)&job);
-  JSValue j_returnedValue = JS_GetPropertyStr(data->context, job.j_awaited, "value");
-  JS_FreeValue(data->context, job.j_awaited);
+  JSValue j_returnedValue = JS_GetPropertyStr(data->context, job.result, "value");
+  JS_FreeValue(data->context, job.result);
   return to_rb_return_value(data->context, j_returnedValue);
 }
 
@@ -1640,11 +1672,21 @@ static VALUE vm_m_evalBytecode(VALUE r_self, VALUE r_bytecode)
 // The user's `timeout_msec` is a budget for *their* code; running a
 // multi-MB polyfill bundle (e.g. the companion `quickjs-polyfill-intl`
 // gem registered via Quickjs.register_polyfill) under that budget would
-// interrupt the load on tight defaults. Unlike load_polyfill_bytecode
-// above we hold the GVL through JS_ReadObject + JS_EvalFunction: the
-// bytecode buffer is a Ruby String, so releasing would let GC compact
-// the backing storage out from under us. The static-symbol path can
-// release safely; this path cannot.
+// interrupt the load on tight defaults.
+//
+// Picks the GVL-released or GVL-held path based on can_eval_gvl_free
+// (same gate vm_m_evalCode uses): if POLYFILL_FILE / POLYFILL_CRYPTO is
+// enabled, the polyfill's top-level code could reach a Ruby-bridged C
+// function that calls rb_funcall directly — those bridges don't honor
+// gvl_released_js, so we must keep the GVL. Otherwise, csim and similar
+// warmer-thread VM pools recover multi-core scaling: without the release
+// every warmer's polyfill load serializes through the GVL, collapsing
+// 4-way warmer parallelism to 1.
+//
+// The GVL-released path copies the Ruby String to a malloc'd buffer
+// because RSTRING_PTR can be invalidated by GC compaction while the GVL
+// is released. The memcpy cost is microseconds vs hundreds of ms of
+// bytecode eval, so it's negligible.
 static VALUE vm_m_loadPolyfillBytecode(VALUE r_self, VALUE r_bytecode)
 {
   VMData *data;
@@ -1654,14 +1696,37 @@ static VALUE vm_m_loadPolyfillBytecode(VALUE r_self, VALUE r_bytecode)
   check_oom_poisoned(data);
   StringValue(r_bytecode);
 
-  JSValue j_func = JS_ReadObject(data->context,
-                                 (const uint8_t *)RSTRING_PTR(r_bytecode),
-                                 (size_t)RSTRING_LEN(r_bytecode),
-                                 JS_READ_OBJ_BYTECODE);
-  if (JS_IsException(j_func))
-    return to_rb_value(data->context, j_func); // raises
+  size_t buf_len = (size_t)RSTRING_LEN(r_bytecode);
+  JSValue j_result;
+  if (can_eval_gvl_free(data))
+  {
+    // malloc(0) may return NULL on success; ask for one byte so an empty
+    // bytecode String still reaches JS_ReadObject's own diagnostic instead
+    // of a spurious NoMemError.
+    uint8_t *buf = malloc(buf_len > 0 ? buf_len : 1);
+    if (buf == NULL)
+      rb_raise(rb_eNoMemError, "failed to allocate polyfill bytecode buffer");
+    memcpy(buf, RSTRING_PTR(r_bytecode), buf_len);
 
-  JSValue j_result = JS_EvalFunction(data->context, j_func); // frees j_func
+    // buf ownership transfers to the release region, which frees it even
+    // if an async interrupt unwinds past this frame.
+    j_result = load_polyfill_bytecode(data, buf, buf_len, buf);
+  }
+  else
+  {
+    // This branch runs exactly when a Ruby bridge (crypto, File, …) is
+    // installed, and every rb_funcall inside one is an interrupt
+    // checkpoint — run_held_js_entry keeps the counter unwind (and the
+    // stale-dispose re-check the released branch gets from its region)
+    // on this path too.
+    struct bytecode_load_job job = {data->context,
+                                    (const uint8_t *)RSTRING_PTR(r_bytecode),
+                                    buf_len,
+                                    JS_UNDEFINED};
+    run_held_js_entry(data, bytecode_load_body, (VALUE)&job);
+    j_result = job.result;
+  }
+
   if (JS_IsException(j_result))
     return to_rb_value(data->context, j_result); // raises
   JS_FreeValue(data->context, j_result);

--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -902,7 +902,7 @@ static VALUE vm_m_on_log(VALUE r_self)
   return Qnil;
 }
 
-static JSValue js_quickjsrb_log(JSContext *ctx, JSValueConst _this, int argc, JSValueConst *argv, const char *severity)
+static JSValue js_quickjsrb_log_inner(JSContext *ctx, JSValueConst _this, int argc, JSValueConst *argv, const char *severity)
 {
   VMData *data = JS_GetContextOpaque(ctx);
   VALUE r_row = rb_ary_new();
@@ -960,6 +960,40 @@ static JSValue js_quickjsrb_log(JSContext *ctx, JSValueConst _this, int argc, JS
     return JS_Throw(ctx, j_error);
   }
   return JS_UNDEFINED;
+}
+
+// Dispatcher: when the caller released the GVL around JS_Eval (see
+// vm_m_evalCode pure-path), Ruby APIs can't be touched directly. Re-acquire
+// the GVL via rb_thread_call_with_gvl before running the row-building body.
+// When the GVL is already held, call the body inline to avoid the re-acquire
+// overhead.
+struct quickjsrb_log_call
+{
+  JSContext *ctx;
+  JSValueConst this_val;
+  int argc;
+  JSValueConst *argv;
+  const char *severity;
+  JSValue result;
+};
+
+static void *quickjsrb_log_with_gvl(void *p)
+{
+  struct quickjsrb_log_call *c = p;
+  c->result = js_quickjsrb_log_inner(c->ctx, c->this_val, c->argc, c->argv, c->severity);
+  return NULL;
+}
+
+static JSValue js_quickjsrb_log(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv, const char *severity)
+{
+  VMData *data = JS_GetContextOpaque(ctx);
+  if (data->gvl_released_eval)
+  {
+    struct quickjsrb_log_call c = {ctx, this_val, argc, argv, severity, JS_UNDEFINED};
+    rb_thread_call_with_gvl(quickjsrb_log_with_gvl, &c);
+    return c.result;
+  }
+  return js_quickjsrb_log_inner(ctx, this_val, argc, argv, severity);
 }
 
 static JSValue js_console_info(JSContext *ctx, JSValueConst this, int argc, JSValueConst *argv)
@@ -1073,6 +1107,10 @@ static VALUE vm_m_initialize(int argc, VALUE *argv, VALUE r_self)
     JS_SetPropertyStr(
         data->context, j_global, "setTimeout",
         JS_NewCFunction(data->context, js_quickjsrb_set_timeout, "setTimeout", 2));
+    // js_delay_and_eval_job (the actual setTimeout callback) calls rb_funcall
+    // and rb_thread_wait_for synchronously, so eval must keep the GVL while
+    // js_std_await is draining the job queue.
+    data->has_native_ruby_bridge = true;
   }
 
   if (RTEST(rb_funcall(r_features, rb_intern("include?"), 1, QUICKJSRB_SYM(featurePolyfillFileId))))
@@ -1081,6 +1119,7 @@ static VALUE vm_m_initialize(int argc, VALUE *argv, VALUE r_self)
     JS_FreeValue(data->context, j_polyfillFileResult);
 
     quickjsrb_init_file_proxy(data);
+    data->has_native_ruby_bridge = true;
   }
 
   if (RTEST(rb_funcall(r_features, rb_intern("include?"), 1, QUICKJSRB_SYM(featurePolyfillEncodingId))))
@@ -1098,6 +1137,7 @@ static VALUE vm_m_initialize(int argc, VALUE *argv, VALUE r_self)
   if (RTEST(rb_funcall(r_features, rb_intern("include?"), 1, QUICKJSRB_SYM(featurePolyfillCryptoId))))
   {
     quickjsrb_init_crypto(data->context, j_global);
+    data->has_native_ruby_bridge = true;
   }
 
   // Host callbacks (console, setTimeout, Ruby-bridged functions) are
@@ -1194,6 +1234,91 @@ static void arm_eval_timer(VMData *data)
   JS_SetInterruptHandler(JS_GetRuntime(data->context), interrupt_handler, data->eval_time);
 }
 
+// Pure-path predicate: true when no JS→Ruby bridge can fire during eval
+// other than console.log (which is handled by js_quickjsrb_log's
+// gvl_released_eval re-acquire). When true, eval can safely run with the
+// GVL released so other Ruby threads make progress on different cores.
+// POLYFILL_FILE / POLYFILL_CRYPTO install C functions that call rb_funcall
+// directly — those would need to learn the gvl_released_eval pattern before
+// they can run under a released GVL, so we hold the GVL when they're loaded.
+static bool can_eval_gvl_free(VMData *data)
+{
+  return RHASH_SIZE(data->defined_functions) == 0
+      && NIL_P(data->module_loader)
+      && NIL_P(data->on_unhandled_rejection)
+      && !data->has_native_ruby_bridge;
+}
+
+struct eval_code_no_gvl_args
+{
+  JSContext *ctx;
+  const char *code;
+  size_t code_len;
+  const char *filename;
+  int eval_flags;
+  bool async_mode;
+  JSValue result;
+};
+
+static void *eval_code_no_gvl(void *p)
+{
+  struct eval_code_no_gvl_args *args = p;
+  JSValue j_codeResult = JS_Eval(args->ctx, args->code, args->code_len, args->filename, args->eval_flags);
+  if (args->async_mode)
+  {
+    JSValue j_awaitedResult = js_std_await(args->ctx, j_codeResult); // frees j_codeResult
+    args->result = JS_GetPropertyStr(args->ctx, j_awaitedResult, "value");
+    JS_FreeValue(args->ctx, j_awaitedResult);
+  }
+  else
+  {
+    args->result = j_codeResult;
+  }
+  return NULL;
+}
+
+// Run JS_Eval (+ js_std_await for async) without the GVL. Inputs are copied
+// to malloc'd buffers because RSTRING_PTR can be invalidated by GC compaction
+// while we're released — see feedback memory on RSTRING_PTR + GVL release.
+static VALUE eval_code_release_gvl(VMData *data, VALUE r_code, const char *filename, bool async_mode)
+{
+  size_t code_len = (size_t)RSTRING_LEN(r_code);
+  // QuickJS's parser reads code_len bytes plus a sentinel NUL; Ruby strings
+  // are always NUL-terminated past RSTRING_LEN, so the original GVL-held path
+  // works by accident. Our malloc'd copy must preserve that invariant.
+  char *code_buf = malloc(code_len + 1);
+  if (code_buf == NULL)
+    rb_raise(rb_eNoMemError, "failed to allocate eval code buffer");
+  memcpy(code_buf, RSTRING_PTR(r_code), code_len);
+  code_buf[code_len] = '\0';
+
+  char *filename_buf = strdup(filename);
+  if (filename_buf == NULL)
+  {
+    free(code_buf);
+    rb_raise(rb_eNoMemError, "failed to allocate eval filename buffer");
+  }
+
+  struct eval_code_no_gvl_args args = {
+      .ctx = data->context,
+      .code = code_buf,
+      .code_len = code_len,
+      .filename = filename_buf,
+      .eval_flags = async_mode ? (JS_EVAL_TYPE_GLOBAL | JS_EVAL_FLAG_ASYNC) : JS_EVAL_TYPE_GLOBAL,
+      .async_mode = async_mode,
+      .result = JS_UNDEFINED,
+  };
+
+  data->gvl_released_eval = true;
+  rb_thread_call_without_gvl(eval_code_no_gvl, &args, NULL, NULL);
+  data->gvl_released_eval = false;
+
+  free(code_buf);
+  free(filename_buf);
+
+  return to_rb_return_value(data->context, args.result);
+}
+
 static VALUE vm_m_evalCode(int argc, VALUE *argv, VALUE r_self)
 {
   VMData *data;
@@ -1217,6 +1342,9 @@ static VALUE vm_m_evalCode(int argc, VALUE *argv, VALUE r_self)
   arm_eval_timer(data);
 
   StringValue(r_code);
+
+  if (can_eval_gvl_free(data))
+    return eval_code_release_gvl(data, r_code, filename, async_mode);
 
   if (!async_mode)
   {

--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -987,7 +987,7 @@ static void *quickjsrb_log_with_gvl(void *p)
 static JSValue js_quickjsrb_log(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv, const char *severity)
 {
   VMData *data = JS_GetContextOpaque(ctx);
-  if (data->gvl_released_eval)
+  if (data->gvl_released_js)
   {
     struct quickjsrb_log_call c = {ctx, this_val, argc, argv, severity, JS_UNDEFINED};
     rb_thread_call_with_gvl(quickjsrb_log_with_gvl, &c);
@@ -1020,12 +1020,27 @@ static JSValue js_console_error(JSContext *ctx, JSValueConst this, int argc, JSV
 // warmer thread can populate a VM pool in parallel with the main thread
 // on multi-core hosts.
 //
-// Releasing the GVL here is only safe because the bundled polyfills are
-// pure JS (file / encoding / url) and no Ruby-bridged callbacks have
-// been registered on globalThis yet at this point in vm_m_initialize.
-// If the order ever changes — e.g. moving define_function setup ahead of
-// the polyfill loads — the polyfill bytecode could re-enter Ruby without
-// the GVL held. Keep host callback registration after polyfill loading.
+// Two call sites use this helper:
+//
+//   1. vm_m_initialize — pre-built bytecode (file / encoding / url) embedded
+//      as static C constants. Safe because no Ruby-bridged callbacks
+//      (console / setTimeout / define_function) have been registered on
+//      globalThis at this point, so polyfill top-level code can't re-enter
+//      Ruby. (gvl_released_js is still toggled — harmless, since nothing
+//      reads it yet.)
+//
+//   2. vm_m_loadPolyfillBytecode — bytecode from a Ruby String, copied to a
+//      malloc'd buffer first so the buffer survives a GC compact. Console /
+//      define_function bridges ARE registered by this point; safety for
+//      console.log relies on js_quickjsrb_log's gvl_released_js re-acquire,
+//      and the caller gates the release on can_eval_gvl_free() to bail when
+//      POLYFILL_FILE / POLYFILL_CRYPTO bridges (which still call rb_funcall
+//      directly) are loaded.
+//
+// load_polyfill_bytecode owns the gvl_released_js toggle so every caller
+// inherits the re-acquire safety automatically. Without that, a future
+// load_polyfill_bytecode caller could forget to set the flag and silently
+// run console.log against Ruby without holding the GVL.
 struct polyfill_load_args
 {
   JSContext *ctx;
@@ -1038,15 +1053,38 @@ static void *polyfill_load_no_gvl(void *p)
 {
   struct polyfill_load_args *args = p;
   JSValue obj = JS_ReadObject(args->ctx, args->buf, args->buf_len, JS_READ_OBJ_BYTECODE);
+  // JS_EvalFunction on a JS_EXCEPTION input replaces the pending exception
+  // with a generic "bytecode function expected" TypeError, losing the actual
+  // deserialization diagnostic from JS_ReadObject. Short-circuit instead.
+  if (JS_IsException(obj))
+  {
+    args->result = obj;
+    return NULL;
+  }
   args->result = JS_EvalFunction(args->ctx, obj); // frees obj
   return NULL;
 }
 
 static JSValue load_polyfill_bytecode(JSContext *ctx, const uint8_t *buf, size_t buf_len)
 {
+  VMData *data = JS_GetContextOpaque(ctx);
   struct polyfill_load_args args = {ctx, buf, buf_len, JS_UNDEFINED};
+  data->gvl_released_js = true;
   rb_thread_call_without_gvl(polyfill_load_no_gvl, &args, NULL, NULL);
+  data->gvl_released_js = false;
   return args.result;
+}
+
+// GVL-held variant for callers that can't release safely (e.g. when
+// POLYFILL_FILE / POLYFILL_CRYPTO bridges are live and might be invoked
+// from the polyfill's top-level code via rb_funcall — those bridges
+// don't honor gvl_released_js).
+static JSValue load_polyfill_bytecode_gvl_held(JSContext *ctx, const uint8_t *buf, size_t buf_len)
+{
+  JSValue obj = JS_ReadObject(ctx, buf, buf_len, JS_READ_OBJ_BYTECODE);
+  if (JS_IsException(obj))
+    return obj;
+  return JS_EvalFunction(ctx, obj); // frees obj
 }
 
 static VALUE vm_m_initialize(int argc, VALUE *argv, VALUE r_self)
@@ -1236,10 +1274,10 @@ static void arm_eval_timer(VMData *data)
 
 // Pure-path predicate: true when no JS→Ruby bridge can fire during eval
 // other than console.log (which is handled by js_quickjsrb_log's
-// gvl_released_eval re-acquire). When true, eval can safely run with the
+// gvl_released_js re-acquire). When true, eval can safely run with the
 // GVL released so other Ruby threads make progress on different cores.
 // POLYFILL_FILE / POLYFILL_CRYPTO install C functions that call rb_funcall
-// directly — those would need to learn the gvl_released_eval pattern before
+// directly — those would need to learn the gvl_released_js pattern before
 // they can run under a released GVL, so we hold the GVL when they're loaded.
 static bool can_eval_gvl_free(VMData *data)
 {
@@ -1312,9 +1350,9 @@ static VALUE eval_code_release_gvl(VMData *data, VALUE r_code, const char *filen
       .result = JS_UNDEFINED,
   };
 
-  data->gvl_released_eval = true;
+  data->gvl_released_js = true;
   rb_thread_call_without_gvl(eval_code_no_gvl_body, &args, NULL, NULL);
-  data->gvl_released_eval = false;
+  data->gvl_released_js = false;
 
   free(code_buf);
   free(filename_buf);
@@ -1440,11 +1478,21 @@ static VALUE vm_m_evalBytecode(VALUE r_self, VALUE r_bytecode)
 // The user's `timeout_msec` is a budget for *their* code; running a
 // multi-MB polyfill bundle (e.g. the companion `quickjs-polyfill-intl`
 // gem registered via Quickjs.register_polyfill) under that budget would
-// interrupt the load on tight defaults. Unlike load_polyfill_bytecode
-// above we hold the GVL through JS_ReadObject + JS_EvalFunction: the
-// bytecode buffer is a Ruby String, so releasing would let GC compact
-// the backing storage out from under us. The static-symbol path can
-// release safely; this path cannot.
+// interrupt the load on tight defaults.
+//
+// Picks the GVL-released or GVL-held path based on can_eval_gvl_free
+// (same gate vm_m_evalCode uses): if POLYFILL_FILE / POLYFILL_CRYPTO is
+// enabled, the polyfill's top-level code could reach a Ruby-bridged C
+// function that calls rb_funcall directly — those bridges don't honor
+// gvl_released_js, so we must keep the GVL. Otherwise, csim and similar
+// warmer-thread VM pools recover multi-core scaling: without the release
+// every warmer's polyfill load serializes through the GVL, collapsing
+// 4-way warmer parallelism to 1.
+//
+// The GVL-released path copies the Ruby String to a malloc'd buffer
+// because RSTRING_PTR can be invalidated by GC compaction while the GVL
+// is released. The memcpy cost is microseconds vs hundreds of ms of
+// bytecode eval, so it's negligible.
 static VALUE vm_m_loadPolyfillBytecode(VALUE r_self, VALUE r_bytecode)
 {
   VMData *data;
@@ -1453,14 +1501,26 @@ static VALUE vm_m_loadPolyfillBytecode(VALUE r_self, VALUE r_bytecode)
   check_disposed(data);
   StringValue(r_bytecode);
 
-  JSValue j_func = JS_ReadObject(data->context,
-                                 (const uint8_t *)RSTRING_PTR(r_bytecode),
-                                 (size_t)RSTRING_LEN(r_bytecode),
-                                 JS_READ_OBJ_BYTECODE);
-  if (JS_IsException(j_func))
-    return to_rb_value(data->context, j_func); // raises
+  size_t buf_len = (size_t)RSTRING_LEN(r_bytecode);
+  JSValue j_result;
+  if (can_eval_gvl_free(data))
+  {
+    uint8_t *buf = malloc(buf_len);
+    if (buf == NULL)
+      rb_raise(rb_eNoMemError, "failed to allocate polyfill bytecode buffer");
+    memcpy(buf, RSTRING_PTR(r_bytecode), buf_len);
 
-  JSValue j_result = JS_EvalFunction(data->context, j_func); // frees j_func
+    j_result = load_polyfill_bytecode(data->context, buf, buf_len);
+
+    free(buf);
+  }
+  else
+  {
+    j_result = load_polyfill_bytecode_gvl_held(data->context,
+                                               (const uint8_t *)RSTRING_PTR(r_bytecode),
+                                               buf_len);
+  }
+
   if (JS_IsException(j_result))
     return to_rb_value(data->context, j_result); // raises
   JS_FreeValue(data->context, j_result);

--- a/ext/quickjsrb/quickjsrb.h
+++ b/ext/quickjsrb/quickjsrb.h
@@ -75,21 +75,23 @@ typedef struct VMData
   // enough pressure to collect the wrapper. Doubles as a double-free guard
   // for the dfree handler.
   bool disposed;
-  // Set while eval is running with the GVL released so JS→Ruby bridges
+  // Set while JS is executing with the GVL released so JS→Ruby bridges
   // (currently js_quickjsrb_log) can re-acquire the GVL before touching
-  // Ruby APIs. Reset before to_rb_return_value runs under the GVL.
-  // Saved/restored (not blindly cleared) so an eval nested through an
-  // on_log listener doesn't clear the outer eval's flag.
-  bool gvl_released_eval;
+  // Ruby APIs. Covers both vm_m_evalCode and vm_m_loadPolyfillBytecode;
+  // reset before to_rb_return_value or other Ruby-touching code runs.
+  // Saved/restored (not blindly cleared) so a region nested through an
+  // on_log listener doesn't clear the outer region's flag.
+  bool gvl_released_js;
   // Number of JS executions currently in flight on this VM — eval_code
   // (both the GVL-released and GVL-held paths), call, bytecode runs,
-  // import, and job drains. vm_m_dispose refuses (ThreadError) while
-  // nonzero: freeing the runtime under live JS is a use-after-free, and
-  // both the GVL release and GVL-yielding bridge callbacks (setTimeout's
-  // rb_thread_wait_for, define_function procs, on_log listeners) make
-  // that overlap reachable — e.g. the README's `Thread.new { vm.dispose! }`
-  // pattern, or a listener calling dispose! mid-eval. Only mutated while
-  // holding the GVL, so plain int accesses are race-free.
+  // polyfill bytecode loads, import, and job drains. vm_m_dispose refuses
+  // (ThreadError) while nonzero: freeing the runtime under live JS is a
+  // use-after-free, and both the GVL release and GVL-yielding bridge
+  // callbacks (setTimeout's rb_thread_wait_for, define_function procs,
+  // on_log listeners) make that overlap reachable — e.g. the README's
+  // `Thread.new { vm.dispose! }` pattern, or a listener calling dispose!
+  // mid-eval. Only mutated while holding the GVL, so plain int accesses
+  // are race-free.
   int evals_in_flight;
   // Number of GVL-release regions currently open on this VM (a subset of
   // evals_in_flight). Bridge-registration APIs (define_function,
@@ -102,7 +104,7 @@ typedef struct VMData
   int gvl_release_regions;
   // Latched by quickjsrb_new_ruby_bridge whenever a C function that calls
   // into Ruby synchronously (rb_funcall & friends) WITHOUT honoring
-  // gvl_released_eval is installed into this context. While true,
+  // gvl_released_js is installed into this context. While true,
   // can_eval_gvl_free fails and eval keeps the GVL held. Register every
   // such function through that helper — a bridge registered with plain
   // JS_NewCFunction would run against Ruby under a released GVL and
@@ -111,7 +113,7 @@ typedef struct VMData
 } VMData;
 
 // Drop-in replacement for JS_NewCFunction for C functions that call into
-// Ruby synchronously without honoring gvl_released_eval (crypto.*, File
+// Ruby synchronously without honoring gvl_released_js (crypto.*, File
 // proxy helpers, setTimeout's job). Latching has_native_ruby_bridge here
 // makes the "keep the GVL held" contract structural instead of relying on
 // each feature-init site to remember a flag assignment. Requires
@@ -218,7 +220,7 @@ static VALUE vm_alloc(VALUE r_self)
   data->j_file_proxy_creator = JS_UNDEFINED;
   data->oom_poisoned = false;
   data->disposed = false;
-  data->gvl_released_eval = false;
+  data->gvl_released_js = false;
   data->evals_in_flight = 0;
   data->gvl_release_regions = 0;
   data->has_native_ruby_bridge = false;

--- a/ext/quickjsrb/quickjsrb.h
+++ b/ext/quickjsrb/quickjsrb.h
@@ -75,6 +75,16 @@ typedef struct VMData
   // enough pressure to collect the wrapper. Doubles as a double-free guard
   // for the dfree handler.
   bool disposed;
+  // Set while eval is running with the GVL released so JS→Ruby bridges
+  // (currently js_quickjsrb_log) can re-acquire the GVL before touching
+  // Ruby APIs. Reset before to_rb_return_value runs under the GVL.
+  bool gvl_released_eval;
+  // Set when POLYFILL_FILE or POLYFILL_CRYPTO is enabled — those install
+  // C functions that call rb_funcall synchronously (e.g. crypto.subtle.*,
+  // File proxy). Until those bridges learn to re-acquire the GVL through
+  // gvl_released_eval, vm_m_evalCode must keep the GVL held when this flag
+  // is true.
+  bool has_native_ruby_bridge;
 } VMData;
 
 static void vm_teardown_context(JSContext *ctx)
@@ -168,6 +178,8 @@ static VALUE vm_alloc(VALUE r_self)
   data->j_file_proxy_creator = JS_UNDEFINED;
   data->oom_poisoned = false;
   data->disposed = false;
+  data->gvl_released_eval = false;
+  data->has_native_ruby_bridge = false;
 
   EvalTime *eval_time = malloc(sizeof(EvalTime));
   data->eval_time = eval_time;

--- a/ext/quickjsrb/quickjsrb.h
+++ b/ext/quickjsrb/quickjsrb.h
@@ -75,14 +75,15 @@ typedef struct VMData
   // enough pressure to collect the wrapper. Doubles as a double-free guard
   // for the dfree handler.
   bool disposed;
-  // Set while eval is running with the GVL released so JS→Ruby bridges
+  // Set while JS is executing with the GVL released so JS→Ruby bridges
   // (currently js_quickjsrb_log) can re-acquire the GVL before touching
-  // Ruby APIs. Reset before to_rb_return_value runs under the GVL.
-  bool gvl_released_eval;
+  // Ruby APIs. Covers both vm_m_evalCode and vm_m_loadPolyfillBytecode.
+  // Reset before to_rb_return_value or other Ruby-touching code runs.
+  bool gvl_released_js;
   // Set when POLYFILL_FILE or POLYFILL_CRYPTO is enabled — those install
   // C functions that call rb_funcall synchronously (e.g. crypto.subtle.*,
   // File proxy). Until those bridges learn to re-acquire the GVL through
-  // gvl_released_eval, vm_m_evalCode must keep the GVL held when this flag
+  // gvl_released_js, vm_m_evalCode must keep the GVL held when this flag
   // is true.
   bool has_native_ruby_bridge;
 } VMData;
@@ -178,7 +179,7 @@ static VALUE vm_alloc(VALUE r_self)
   data->j_file_proxy_creator = JS_UNDEFINED;
   data->oom_poisoned = false;
   data->disposed = false;
-  data->gvl_released_eval = false;
+  data->gvl_released_js = false;
   data->has_native_ruby_bridge = false;
 
   EvalTime *eval_time = malloc(sizeof(EvalTime));

--- a/lib/quickjs/polyfills.rb
+++ b/lib/quickjs/polyfills.rb
@@ -14,7 +14,7 @@ module Quickjs
     raise ::TypeError, "source: must be a String or Proc, got #{source.class}" unless source.is_a?(String) || source.is_a?(Proc)
     raise ::TypeError, "init: must be a String or nil, got #{init.class}" unless init.nil? || init.is_a?(String)
 
-    @_polyfills[name] = {source: source, init: init&.freeze, bytecode: nil}
+    @_polyfills[name] = {source: source, init: init&.freeze, bytecode: nil, mutex: Mutex.new}
     nil
   end
 
@@ -30,15 +30,24 @@ module Quickjs
   def self._apply_registered_polyfills(vm, features)
     features.each do |feature|
       next unless (entry = @_polyfills[feature])
-      # `||=` isn't atomic — `_precompile_polyfill` releases the GVL inside
-      # `Quickjs.compile`, so two threads racing to construct VMs with the
-      # same polyfill can both see nil and both compile. The bytecode write
-      # is harmless because both threads produce identical bytes; the only
-      # observable cost is wasted compile work, and (for `source: Proc`) a
-      # second Proc invocation — so register Procs that are safe to call
-      # more than once.
-      entry[:bytecode] ||= _precompile_polyfill(entry, feature)
-      vm.send(:_load_polyfill_bytecode, entry[:bytecode])
+      # The per-entry mutex makes first-use compilation happen exactly once
+      # even when threads race to construct VMs with the same polyfill —
+      # `||=` alone isn't atomic (`_precompile_polyfill` yields the GVL
+      # inside `Quickjs.compile`), and a losing thread could otherwise
+      # double-compile or read entry[:source] after the winner cleared it.
+      # A compile failure leaves bytecode nil and source intact, so a later
+      # attempt can retry.
+      bytecode = entry[:mutex].synchronize {
+        entry[:bytecode] ||= begin
+          compiled = _precompile_polyfill(entry, feature)
+          # The Proc / String source isn't needed again once the bytecode
+          # is cached — drop it so its captured scope can be GC'd.
+          entry[:source] = nil
+          entry[:init]   = nil
+          compiled
+        end
+      }
+      vm.send(:_load_polyfill_bytecode, bytecode)
     end
   end
 

--- a/lib/quickjs/polyfills.rb
+++ b/lib/quickjs/polyfills.rb
@@ -8,13 +8,20 @@ module Quickjs
   # `source:` accepts either a `String` (eager) or a `Proc` returning one
   # (lazy). The lazy form lets a companion gem call `register_polyfill`
   # at require time without paying the file-read cost unless a VM
-  # actually opts into the feature.
+  # actually opts into the feature. The Proc must not itself construct a
+  # VM with the same feature: compilation is locked per entry, so that
+  # recursion raises ThreadError instead of deadlocking silently.
   def self.register_polyfill(name, source:, init: nil)
     raise ::TypeError, "name must be a Symbol, got #{name.class}" unless name.is_a?(Symbol)
     raise ::TypeError, "source: must be a String or Proc, got #{source.class}" unless source.is_a?(String) || source.is_a?(Proc)
     raise ::TypeError, "init: must be a String or nil, got #{init.class}" unless init.nil? || init.is_a?(String)
 
-    @_polyfills[name] = {source: source, init: init&.freeze, bytecode: nil, mutex: Mutex.new}
+    # Re-registration keeps the entry's Mutex: a thread mid-compile under
+    # the old entry and a thread arriving via the new one must serialize
+    # on the same lock, or the two would compile concurrently and break
+    # the exactly-once guarantee below.
+    mutex = @_polyfills[name]&.fetch(:mutex) || Mutex.new
+    @_polyfills[name] = {source: source, init: init&.freeze, bytecode: nil, mutex: mutex}
     nil
   end
 
@@ -36,8 +43,10 @@ module Quickjs
       # inside `Quickjs.compile`), and a losing thread could otherwise
       # double-compile or read entry[:source] after the winner cleared it.
       # A compile failure leaves bytecode nil and source intact, so a later
-      # attempt can retry.
-      bytecode = entry[:mutex].synchronize {
+      # attempt can retry. The unlocked first read keeps the post-compile
+      # hot path (warmer pools constructing VMs concurrently) off the lock;
+      # a stale nil just falls into the synchronize.
+      bytecode = entry[:bytecode] || entry[:mutex].synchronize {
         entry[:bytecode] ||= begin
           compiled = _precompile_polyfill(entry, feature)
           # The Proc / String source isn't needed again once the bytecode

--- a/lib/quickjs/polyfills.rb
+++ b/lib/quickjs/polyfills.rb
@@ -11,17 +11,18 @@ module Quickjs
   # actually opts into the feature. The Proc must not itself construct a
   # VM with the same feature: compilation is locked per entry, so that
   # recursion raises ThreadError instead of deadlocking silently.
+  #
+  # Re-registering a name replaces the entry wholesale, lock included: a
+  # VM construction already compiling under the old entry finishes
+  # against it (and loads the old bytecode) while the first construction
+  # under the new entry compiles the new source independently. Each
+  # registration compiles at most once; the two compiles can overlap.
   def self.register_polyfill(name, source:, init: nil)
     raise ::TypeError, "name must be a Symbol, got #{name.class}" unless name.is_a?(Symbol)
     raise ::TypeError, "source: must be a String or Proc, got #{source.class}" unless source.is_a?(String) || source.is_a?(Proc)
     raise ::TypeError, "init: must be a String or nil, got #{init.class}" unless init.nil? || init.is_a?(String)
 
-    # Re-registration keeps the entry's Mutex: a thread mid-compile under
-    # the old entry and a thread arriving via the new one must serialize
-    # on the same lock, or the two would compile concurrently and break
-    # the exactly-once guarantee below.
-    mutex = @_polyfills[name]&.fetch(:mutex) || Mutex.new
-    @_polyfills[name] = {source: source, init: init&.freeze, bytecode: nil, mutex: mutex}
+    @_polyfills[name] = {source: source, init: init&.freeze, bytecode: nil, mutex: Mutex.new}
     nil
   end
 

--- a/lib/quickjs/polyfills.rb
+++ b/lib/quickjs/polyfills.rb
@@ -37,7 +37,15 @@ module Quickjs
       # observable cost is wasted compile work, and (for `source: Proc`) a
       # second Proc invocation — so register Procs that are safe to call
       # more than once.
-      entry[:bytecode] ||= _precompile_polyfill(entry, feature)
+      if entry[:bytecode].nil?
+        entry[:bytecode] = _precompile_polyfill(entry, feature)
+        # The Proc / String source isn't needed again once bytecode is
+        # cached — drop it so its captured scope can be GC'd. A racing
+        # second thread will already have called the Proc before reaching
+        # here (see comment above) so this is safe.
+        entry[:source] = nil
+        entry[:init]   = nil
+      end
       vm.send(:_load_polyfill_bytecode, entry[:bytecode])
     end
   end

--- a/test/quickjs_register_polyfill_test.rb
+++ b/test/quickjs_register_polyfill_test.rb
@@ -94,6 +94,42 @@ describe "Quickjs.register_polyfill" do
     _(vm.eval_code('installed', async: false)).must_equal true
   end
 
+  # Skipping arm_eval_timer isn't enough to keep loads unbudgeted: the
+  # interrupt handler a previous eval armed stays installed with that
+  # eval's deadline, so a load after the budget lapsed used to be
+  # interrupted at its first check — and because compiled polyfills are
+  # async-wrapped, the interruption surfaced as a rejected promise nobody
+  # checked: the load "succeeded" with the polyfill silently missing.
+  # _load_polyfill_bytecode now disarms the handler for the load.
+  it 'loads fully even when a prior eval left a lapsed timer armed' do
+    Quickjs.register_polyfill(@feature, source: cpu_workload_js)
+    Quickjs::VM.new(features: [@feature]).dispose! # populate the bytecode cache
+    bytecode = Quickjs._polyfill_for(@feature)[:bytecode]
+
+    vm = Quickjs::VM.new(timeout_msec: 50)
+    vm.eval_code('1 + 1') # arms the interrupt timer with this eval's deadline
+    sleep 0.1 # let the budget lapse so a stale handler would fire mid-load
+    vm.send(:_load_polyfill_bytecode, bytecode)
+
+    _(vm.eval_code('typeof workloadAcc', async: false)).must_equal 'number'
+
+    # Disarming for the load must not disable the user's budget — the
+    # next eval re-arms it.
+    _ { vm.eval_code('while (true) {}') }.must_raise Quickjs::InterruptedError
+  ensure
+    vm&.dispose!
+  end
+
+  # Same root cause, second symptom: a top-level throw in the polyfill
+  # also comes back as a rejected promise rather than JS_EXCEPTION, so
+  # VM.new used to succeed with a half-applied polyfill.
+  it "raises when the polyfill's top level throws" do
+    Quickjs.register_polyfill(@feature, source: 'throw new TypeError("polyfill exploded");')
+
+    err = _ { Quickjs::VM.new(features: [@feature]) }.must_raise Quickjs::TypeError
+    _(err.message).must_match(/polyfill exploded/)
+  end
+
   # Mirrors the GVL-release pattern from VM#eval_code: _load_polyfill_bytecode
   # copies the Ruby String to a malloc'd buffer and releases the GVL during
   # JS_ReadObject + JS_EvalFunction. Without that, csim-style warmer-thread VM

--- a/test/quickjs_register_polyfill_test.rb
+++ b/test/quickjs_register_polyfill_test.rb
@@ -102,9 +102,7 @@ describe "Quickjs.register_polyfill" do
   # checked: the load "succeeded" with the polyfill silently missing.
   # _load_polyfill_bytecode now disarms the handler for the load.
   it 'loads fully even when a prior eval left a lapsed timer armed' do
-    Quickjs.register_polyfill(@feature, source: cpu_workload_js)
-    Quickjs::VM.new(features: [@feature]).dispose! # populate the bytecode cache
-    bytecode = Quickjs._polyfill_for(@feature)[:bytecode]
+    bytecode = Quickjs.compile(cpu_workload_js).to_s
 
     vm = Quickjs::VM.new(timeout_msec: 50)
     vm.eval_code('1 + 1') # arms the interrupt timer with this eval's deadline

--- a/test/quickjs_register_polyfill_test.rb
+++ b/test/quickjs_register_polyfill_test.rb
@@ -170,6 +170,21 @@ describe "Quickjs.register_polyfill" do
     vm&.dispose!
   end
 
+  # Same assertion on the GVL-held path (crypto latches a Ruby bridge, so
+  # can_eval_gvl_free bails): the short-circuit lives in the shared core,
+  # but only a test on each branch keeps it that way.
+  it "preserves the JS_ReadObject error for corrupt bytecode on the GVL-held path" do
+    vm = Quickjs::VM.new(features: [Quickjs::POLYFILL_CRYPTO])
+
+    err = _ {
+      vm.send(:_load_polyfill_bytecode, 'this is not valid bytecode')
+    }.must_raise Quickjs::SyntaxError
+
+    _(err.message).wont_match(/bytecode function expected/)
+  ensure
+    vm&.dispose!
+  end
+
   # vm_m_loadPolyfillBytecode gates on can_eval_gvl_free: when POLYFILL_CRYPTO
   # is enabled, the polyfill's top-level code can reach crypto.getRandomValues
   # (a C bridge that calls rb_funcall directly without honoring gvl_released_js).

--- a/test/quickjs_register_polyfill_test.rb
+++ b/test/quickjs_register_polyfill_test.rb
@@ -93,4 +93,61 @@ describe "Quickjs.register_polyfill" do
 
     _(vm.eval_code('installed', async: false)).must_equal true
   end
+
+  # Mirrors the GVL-release pattern from VM#eval_code: _load_polyfill_bytecode
+  # copies the Ruby String to a malloc'd buffer and releases the GVL during
+  # JS_ReadObject + JS_EvalFunction. Without that, csim-style warmer-thread VM
+  # pools serialize all polyfill loads through the GVL and lose multi-core
+  # scaling — the original motivation for this code path. The workload calls
+  # _load_polyfill_bytecode directly on a bare VM so the timing isolates the
+  # bytecode-load step from VM construction (which would otherwise release the
+  # GVL itself if any bundled polyfill features were enabled).
+  it "loads polyfill bytecode in parallel across VMs (GVL released)" do
+    Quickjs.register_polyfill(@feature, source: cpu_workload_js)
+
+    Quickjs::VM.new(features: [@feature]).dispose! # populate the bytecode cache
+    bytecode = Quickjs._polyfill_for(@feature)[:bytecode]
+
+    assert_run_in_parallel do |iterations|
+      iterations.times do
+        vm = Quickjs::VM.new
+        vm.send(:_load_polyfill_bytecode, bytecode)
+        vm.dispose!
+      end
+    end
+  end
+
+  # JS_EvalFunction on a JS_EXCEPTION input replaces the pending exception
+  # with a generic "bytecode function expected" TypeError, losing the actual
+  # deserialization diagnostic. bytecode_load_job_run (shared by the released
+  # and GVL-held paths) short-circuits on JS_IsException to preserve the
+  # original error.
+  it "preserves the original JS_ReadObject error for corrupt bytecode" do
+    vm = Quickjs::VM.new
+
+    err = _ {
+      vm.send(:_load_polyfill_bytecode, 'this is not valid bytecode')
+    }.must_raise Quickjs::SyntaxError
+
+    _(err.message).wont_match(/bytecode function expected/)
+  ensure
+    vm&.dispose!
+  end
+
+  # vm_m_loadPolyfillBytecode gates on can_eval_gvl_free: when POLYFILL_CRYPTO
+  # is enabled, the polyfill's top-level code can reach crypto.getRandomValues
+  # (a C bridge that calls rb_funcall directly without honoring gvl_released_js).
+  # Releasing the GVL would crash; the gate keeps it held. This test exercises
+  # the combo to prove the gate is wired — without it, the crypto bridge runs
+  # off-GVL and segfaults under MRI.
+  it "loads with GVL held when a Ruby-bridged feature is also enabled" do
+    Quickjs.register_polyfill(@feature, source: <<~JS)
+      globalThis.fromPolyfill = crypto.getRandomValues(new Uint8Array(4)).length;
+    JS
+    vm = Quickjs::VM.new(features: [Quickjs::POLYFILL_CRYPTO, @feature])
+
+    _(vm.eval_code('fromPolyfill')).must_equal 4
+  ensure
+    vm&.dispose!
+  end
 end

--- a/test/quickjs_register_polyfill_test.rb
+++ b/test/quickjs_register_polyfill_test.rb
@@ -93,4 +93,68 @@ describe "Quickjs.register_polyfill" do
 
     _(vm.eval_code('installed', async: false)).must_equal true
   end
+
+  # Mirrors the GVL-release pattern from VM#eval_code: _load_polyfill_bytecode
+  # copies the Ruby String to a malloc'd buffer and releases the GVL during
+  # JS_ReadObject + JS_EvalFunction. Without that, csim-style warmer-thread VM
+  # pools serialize all polyfill loads through the GVL and lose multi-core
+  # scaling — the original motivation for this code path. The workload calls
+  # _load_polyfill_bytecode directly on a bare VM so the timing isolates the
+  # bytecode-load step from VM construction (which would otherwise release the
+  # GVL itself if any bundled polyfill features were enabled).
+  it "loads polyfill bytecode in parallel across VMs (GVL released)" do
+    Quickjs.register_polyfill(@feature, source: <<~JS)
+      (() => {
+        let acc = 0;
+        for (let i = 0; i < 200000; i++) {
+          acc = (acc + Math.sqrt(i) * Math.sin(i)) % 1e9;
+        }
+        globalThis.polyfillAcc = acc;
+      })();
+    JS
+
+    Quickjs::VM.new(features: [@feature]).dispose! # populate the bytecode cache
+    bytecode = Quickjs._polyfill_for(@feature)[:bytecode]
+
+    assert_run_in_parallel do |iterations|
+      iterations.times do
+        vm = Quickjs::VM.new
+        vm.send(:_load_polyfill_bytecode, bytecode)
+        vm.dispose!
+      end
+    end
+  end
+
+  # JS_EvalFunction on a JS_EXCEPTION input replaces the pending exception
+  # with a generic "bytecode function expected" TypeError, losing the actual
+  # deserialization diagnostic. polyfill_load_no_gvl / the GVL-held variant
+  # both short-circuit on JS_IsException to preserve the original error.
+  it "preserves the original JS_ReadObject error for corrupt bytecode" do
+    vm = Quickjs::VM.new
+
+    err = _ {
+      vm.send(:_load_polyfill_bytecode, 'this is not valid bytecode')
+    }.must_raise Quickjs::SyntaxError
+
+    _(err.message).wont_match(/bytecode function expected/)
+  ensure
+    vm&.dispose!
+  end
+
+  # vm_m_loadPolyfillBytecode gates on can_eval_gvl_free: when POLYFILL_CRYPTO
+  # is enabled, the polyfill's top-level code can reach crypto.getRandomValues
+  # (a C bridge that calls rb_funcall directly without honoring gvl_released_js).
+  # Releasing the GVL would crash; the gate keeps it held. This test exercises
+  # the combo to prove the gate is wired — without it, the crypto bridge runs
+  # off-GVL and segfaults under MRI.
+  it "loads with GVL held when a Ruby-bridged feature is also enabled" do
+    Quickjs.register_polyfill(@feature, source: <<~JS)
+      globalThis.fromPolyfill = crypto.getRandomValues(new Uint8Array(4)).length;
+    JS
+    vm = Quickjs::VM.new(features: [Quickjs::POLYFILL_CRYPTO, @feature])
+
+    _(vm.eval_code('fromPolyfill')).must_equal 4
+  ensure
+    vm&.dispose!
+  end
 end

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "test_helper"
+require 'etc'
 
 describe Quickjs do
   it "VERSION" do
@@ -1648,6 +1649,46 @@ describe "Quickjs::Blocking" do
     skip('unresolved stack overflow on Ubuntu of GitHub Actions') unless RUBY_PLATFORM.match(/darwin/)
   end
 
+  # Asserts the block runs in parallel across Ruby threads, by comparing
+  # wall-clock for the same total amount of work done serially in one thread
+  # vs split across two threads. If the work releases the GVL during its hot
+  # section, the 2-thread run finishes in ~half the wall clock; if it holds
+  # the GVL, both runs take roughly the same time. The 2/3 threshold cleanly
+  # distinguishes the two while leaving headroom for thread scheduling jitter.
+  #
+  # The block receives an iteration count and is expected to do that many
+  # units of the operation under test (e.g. eval_code calls). Each thread
+  # creates its own VM internally, because QuickJS records the runtime's
+  # stack base at construction time — using a VM from a thread other than
+  # its creator trips a (false) stack-overflow guard.
+  def assert_run_in_parallel(trials: 5, total_evals: 8, &workload)
+    skip 'requires 2+ cores' if Etc.nprocessors < 2
+
+    measure = ->(&block) {
+      start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      block.call
+      Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
+    }
+
+    workload.call(1) # warmup: load JIT / page in caches before timing
+
+    single = trials.times.map {
+      measure.call { workload.call(total_evals) }
+    }.min
+
+    parallel = trials.times.map {
+      measure.call {
+        threads = Array.new(2) {
+          Thread.new { workload.call(total_evals / 2) }
+        }
+        threads.each(&:join)
+      }
+    }.min
+
+    assert_operator parallel, :<=, single * 2.0 / 3,
+      "parallel wall clock #{(parallel * 1000).round(1)}ms not ≤ 2/3 × single #{(single * 1000).round(1)}ms — work may not be releasing the GVL"
+  end
+
   describe "ProcessBlocking" do
     before do
       @vm = Quickjs::VM.new(timeout_msec: 500, features: [::Quickjs::MODULE_OS])
@@ -1752,6 +1793,48 @@ describe "Quickjs::Blocking" do
       }
       results = threads.map(&:value)
       _(results.flatten.uniq).must_equal [expected]
+    end
+
+    it "evaluates pure JS concurrently with measurable speedup" do
+      timing_workload = <<~JS
+        (() => {
+          let acc = 0;
+          for (let i = 0; i < 200000; i++) {
+            acc = (acc + Math.sqrt(i) * Math.sin(i)) % 1e9;
+          }
+          return acc;
+        })();
+      JS
+
+      assert_run_in_parallel do |iterations|
+        vm = Quickjs::VM.new
+        begin
+          iterations.times { vm.eval_code(timing_workload) }
+        ensure
+          vm.dispose!
+        end
+      end
+    end
+
+    # The pure-eval fast path releases the GVL, so console.log inside that
+    # eval reaches js_quickjsrb_log without holding it. The dispatcher must
+    # re-acquire the GVL via rb_thread_call_with_gvl before invoking the
+    # on_log block — otherwise touching Ruby APIs from the released thread
+    # crashes the interpreter. This test exercises that re-acquire path.
+    it "delivers console.log to on_log during a GVL-released eval" do
+      vm       = Quickjs::VM.new
+      received = []
+      vm.on_log {|log| received << log }
+
+      begin
+        vm.eval_code('console.log("hello"); console.log(42, "world"); 1 + 1')
+
+        _(received.size).must_equal 2
+        _(received[0].to_s).must_equal 'hello'
+        _(received[1].to_s).must_equal '42 world'
+      ensure
+        vm.dispose!
+      end
     end
 
     # Regression test: setTimeout enqueues js_delay_and_eval_job which calls

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -1644,10 +1644,6 @@ describe "Quickjs::Blocking" do
     _(run_threads(&block)).must_equal %w(t1 t1 t1 t2)
   end
 
-  def refute_sleep_a_sec_within_thread(&block)
-    _(run_threads(&block)).wont_equal %w(t1 t1 t1 t2)
-  end
-
   def pend_on_ubuntu
     skip('unresolved stack overflow on Ubuntu of GitHub Actions') unless RUBY_PLATFORM.match(/darwin/)
   end
@@ -1678,30 +1674,33 @@ describe "Quickjs::Blocking" do
       end
     end
 
-    it "os sleep messes" do
+    # The GVL is released during VM#eval_code on the pure path, so these
+    # blocking-looking calls (os.sleep, os.setTimeout, os.sleepAsync) no
+    # longer hold up sibling Ruby threads.
+    it "os.sleep does not block other threads" do
       pend_on_ubuntu
-      refute_sleep_a_sec_within_thread do
+      assert_sleep_a_sec_within_thread do
         @vm.eval_code('os.sleep(200);')
       end
     end
 
-    it "awaiting os.setTimeout messes" do
+    it "awaiting os.setTimeout does not block other threads" do
       pend_on_ubuntu
-      refute_sleep_a_sec_within_thread do
+      assert_sleep_a_sec_within_thread do
         @vm.eval_code('await new Promise(resolve => os.setTimeout(resolve, 200));')
       end
     end
 
-    it "awaiting async function which wraps os.setTimeout messes" do
+    it "awaiting async function which wraps os.setTimeout does not block other threads" do
       pend_on_ubuntu
-      refute_sleep_a_sec_within_thread do
+      assert_sleep_a_sec_within_thread do
         @vm.eval_code('async function top () { await new Promise(resolve => os.setTimeout(resolve, 200)); } await top();')
       end
     end
 
-    it "awaiting os.sleepAsync messes" do
+    it "awaiting os.sleepAsync does not block other threads" do
       pend_on_ubuntu
-      refute_sleep_a_sec_within_thread do
+      assert_sleep_a_sec_within_thread do
         @vm.eval_code('async function top () { await os.sleepAsync(200); } await top();')
       end
     end
@@ -1716,6 +1715,57 @@ describe "Quickjs::Blocking" do
       pend_on_ubuntu
       assert_sleep_a_sec_within_thread do
         @vm.eval_code('await new Promise(resolve => setTimeout(resolve, 200));')
+      end
+    end
+  end
+
+  describe "ParallelEval" do
+    # Smoke test for VM#eval_code releasing the GVL: N threads each running
+    # a CPU-bound JS workload on their own VM should all complete with the
+    # expected result. Regressions in the pure-eval fast path (lost work,
+    # corrupted state, missing GVL re-acquire) surface as crashes or wrong
+    # return values here, even without measuring wall-clock scaling.
+    def cpu_workload
+      <<~JS
+        (() => {
+          let acc = 0;
+          for (let i = 0; i < 5000; i++) {
+            acc = (acc + i) % 1e9;
+          }
+          return acc;
+        })();
+      JS
+    end
+
+    it "runs eval_code in parallel across multiple VMs without crashing" do
+      expected = (0...5000).sum % 1_000_000_000
+      threads  = Array.new(4) {
+        Thread.new {
+          vm = Quickjs::VM.new
+
+          begin
+            5.times.map { vm.eval_code(cpu_workload) }
+          ensure
+            vm.dispose!
+          end
+        }
+      }
+      results = threads.map(&:value)
+      _(results.flatten.uniq).must_equal [expected]
+    end
+
+    # Regression test: setTimeout enqueues js_delay_and_eval_job which calls
+    # rb_funcall and rb_thread_wait_for synchronously. The pure-eval fast
+    # path must keep the GVL held when FEATURE_TIMEOUT is enabled, otherwise
+    # those Ruby APIs run without the GVL and crash.
+    it "tolerates setTimeout in JS without crashing the interpreter" do
+      pend_on_ubuntu
+      vm = Quickjs::VM.new(features: [::Quickjs::FEATURE_TIMEOUT])
+
+      begin
+        _(vm.eval_code('await new Promise(resolve => setTimeout(() => resolve(42), 10));')).must_equal 42
+      ensure
+        vm.dispose!
       end
     end
   end

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -1941,7 +1941,11 @@ describe "Quickjs::Blocking" do
       timing_workload = cpu_workload_js
 
       assert_run_in_parallel do |iterations|
-        vm = Quickjs::VM.new
+        # The eval budget is wall-clock, so a scheduling stall on a busy CI
+        # runner can push one ~10ms eval past the 100ms default and error
+        # the test with InterruptedError. Parallelism is what's asserted
+        # here, not the budget — make the timeout a non-factor.
+        vm = Quickjs::VM.new(timeout_msec: 10_000)
         begin
           iterations.times { vm.eval_code(timing_workload) }
         ensure

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require_relative "test_helper"
-require 'etc'
 
 describe Quickjs do
   it "VERSION" do
@@ -1822,49 +1821,6 @@ describe "Quickjs::Blocking" do
     skip('unresolved stack overflow on Ubuntu of GitHub Actions') unless RUBY_PLATFORM.match(/darwin/)
   end
 
-  # Asserts the block runs in parallel across Ruby threads, by comparing
-  # wall-clock for the same total amount of work done serially in one thread
-  # vs split across two threads. If the work releases the GVL during its hot
-  # section, the 2-thread run finishes in ~half the wall clock; if it holds
-  # the GVL, both runs take roughly the same time (ratio ≈ 1.0 plus thread
-  # overhead). The 0.8 threshold cleanly distinguishes the two: GitHub's
-  # 3-core macOS runners have been observed topping out around 1.5x
-  # speedup (ratio ~0.67), so demanding better than 1.25x keeps margin on
-  # both sides without flapping.
-  #
-  # The block receives an iteration count and is expected to do that many
-  # units of the operation under test (e.g. eval_code calls). Each thread
-  # creates its own VM internally, because QuickJS records the runtime's
-  # stack base at construction time — using a VM from a thread other than
-  # its creator trips a (false) stack-overflow guard.
-  def assert_run_in_parallel(trials: 5, total_evals: 8, &workload)
-    skip 'requires 2+ cores' if Etc.nprocessors < 2
-
-    measure = ->(&block) {
-      start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-      block.call
-      Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
-    }
-
-    workload.call(1) # warmup: load JIT / page in caches before timing
-
-    single = trials.times.map {
-      measure.call { workload.call(total_evals) }
-    }.min
-
-    parallel = trials.times.map {
-      measure.call {
-        threads = Array.new(2) {
-          Thread.new { workload.call(total_evals / 2) }
-        }
-        threads.each(&:join)
-      }
-    }.min
-
-    assert_operator parallel, :<=, single * 0.8,
-      "parallel wall clock #{(parallel * 1000).round(1)}ms not ≤ 0.8 × single #{(single * 1000).round(1)}ms — work may not be releasing the GVL"
-  end
-
   describe "ProcessBlocking" do
     before do
       @vm = Quickjs::VM.new(timeout_msec: 500, features: [::Quickjs::MODULE_OS])
@@ -1972,15 +1928,7 @@ describe "Quickjs::Blocking" do
     end
 
     it "evaluates pure JS concurrently with measurable speedup" do
-      timing_workload = <<~JS
-        (() => {
-          let acc = 0;
-          for (let i = 0; i < 200000; i++) {
-            acc = (acc + Math.sqrt(i) * Math.sin(i)) % 1e9;
-          }
-          return acc;
-        })();
-      JS
+      timing_workload = cpu_workload_js
 
       assert_run_in_parallel do |iterations|
         vm = Quickjs::VM.new

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -1135,6 +1135,16 @@ describe Quickjs::VM do
       _(err.message).must_match(/top-level boom/)
     end
 
+    it "applies timeout_msec to module top-level code" do
+      vm = Quickjs::VM.new(timeout_msec: 50)
+
+      _ {
+        vm.import('* as x', from: 'while (true) {}; export const x = 1;')
+      }.must_raise Quickjs::InterruptedError
+    ensure
+      vm&.dispose!
+    end
+
     it "raises when the loader-resolved module throws synchronously" do
       @vm.module_loader = ->(name) {
         "export const x = 1; throw new RangeError('loader-throw');" if name == 'bad'

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require_relative "test_helper"
-require 'etc'
 
 describe Quickjs do
   it "VERSION" do
@@ -1647,46 +1646,6 @@ describe "Quickjs::Blocking" do
 
   def pend_on_ubuntu
     skip('unresolved stack overflow on Ubuntu of GitHub Actions') unless RUBY_PLATFORM.match(/darwin/)
-  end
-
-  # Asserts the block runs in parallel across Ruby threads, by comparing
-  # wall-clock for the same total amount of work done serially in one thread
-  # vs split across two threads. If the work releases the GVL during its hot
-  # section, the 2-thread run finishes in ~half the wall clock; if it holds
-  # the GVL, both runs take roughly the same time. The 2/3 threshold cleanly
-  # distinguishes the two while leaving headroom for thread scheduling jitter.
-  #
-  # The block receives an iteration count and is expected to do that many
-  # units of the operation under test (e.g. eval_code calls). Each thread
-  # creates its own VM internally, because QuickJS records the runtime's
-  # stack base at construction time — using a VM from a thread other than
-  # its creator trips a (false) stack-overflow guard.
-  def assert_run_in_parallel(trials: 5, total_evals: 8, &workload)
-    skip 'requires 2+ cores' if Etc.nprocessors < 2
-
-    measure = ->(&block) {
-      start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-      block.call
-      Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
-    }
-
-    workload.call(1) # warmup: load JIT / page in caches before timing
-
-    single = trials.times.map {
-      measure.call { workload.call(total_evals) }
-    }.min
-
-    parallel = trials.times.map {
-      measure.call {
-        threads = Array.new(2) {
-          Thread.new { workload.call(total_evals / 2) }
-        }
-        threads.each(&:join)
-      }
-    }.min
-
-    assert_operator parallel, :<=, single * 2.0 / 3,
-      "parallel wall clock #{(parallel * 1000).round(1)}ms not ≤ 2/3 × single #{(single * 1000).round(1)}ms — work may not be releasing the GVL"
   end
 
   describe "ProcessBlocking" do

--- a/test/support/cpu_workload.rb
+++ b/test/support/cpu_workload.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# CPU-bound JS heavy enough (~10ms at the default iteration count) that
+# eval time dominates threading overhead when measuring GVL-release
+# parallelism. Shared between `assert_run_in_parallel` tests
+# (test_helper.rb) and benchmark/threading.rb so both measure the
+# identical workload — minitest-free on purpose so the benchmark can
+# require it too.
+module QuickjsCpuWorkload
+  def cpu_workload_js(iterations: 200_000)
+    <<~JS
+      (() => {
+        let acc = 0;
+        for (let i = 0; i < #{iterations}; i++) {
+          acc = (acc + Math.sqrt(i) * Math.sin(i)) % 1e9;
+        }
+        globalThis.workloadAcc = acc;
+        return acc;
+      })();
+    JS
+  end
+  module_function :cpu_workload_js
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,8 +4,11 @@ $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require "quickjs"
 require "minitest/autorun"
 require 'etc'
+require_relative 'support/cpu_workload'
 
 module QuickjsTestHelpers
+  include QuickjsCpuWorkload
+
   # Asserts the block runs in parallel across Ruby threads, by comparing
   # wall-clock for the same total amount of work done serially in one thread
   # vs split across two threads. If the work releases the GVL during its hot
@@ -47,22 +50,6 @@ module QuickjsTestHelpers
 
     assert_operator parallel, :<=, single * 0.8,
       "parallel wall clock #{(parallel * 1000).round(1)}ms not ≤ 0.8 × single #{(single * 1000).round(1)}ms — work may not be releasing the GVL"
-  end
-
-  # CPU-bound JS heavy enough (~10ms at the default iteration count) that
-  # eval time dominates threading overhead in assert_run_in_parallel.
-  # benchmark/threading.rb keeps its own copy of this loop — benchmarks
-  # don't load minitest helpers — so retune both if the size ever changes.
-  def cpu_workload_js(iterations: 200_000)
-    <<~JS
-      (() => {
-        let acc = 0;
-        for (let i = 0; i < #{iterations}; i++) {
-          acc = (acc + Math.sqrt(i) * Math.sin(i)) % 1e9;
-        }
-        globalThis.workloadAcc = acc;
-      })();
-    JS
   end
 end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,3 +3,67 @@
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require "quickjs"
 require "minitest/autorun"
+require 'etc'
+
+module QuickjsTestHelpers
+  # Asserts the block runs in parallel across Ruby threads, by comparing
+  # wall-clock for the same total amount of work done serially in one thread
+  # vs split across two threads. If the work releases the GVL during its hot
+  # section, the 2-thread run finishes in ~half the wall clock; if it holds
+  # the GVL, both runs take roughly the same time (ratio ≈ 1.0 plus thread
+  # overhead). The 0.8 threshold cleanly distinguishes the two: GitHub's
+  # 3-core macOS runners have been observed topping out around 1.5x
+  # speedup (ratio ~0.67), so demanding better than 1.25x keeps margin on
+  # both sides without flapping.
+  #
+  # The block receives an iteration count and is expected to do that many
+  # units of the operation under test (e.g. eval_code calls, VM constructions).
+  # Each thread should create its own VM internally, because QuickJS records
+  # the runtime's stack base at construction time — using a VM from a thread
+  # other than its creator trips a (false) stack-overflow guard.
+  def assert_run_in_parallel(trials: 5, total_iterations: 8, &workload)
+    skip 'requires 2+ cores' if Etc.nprocessors < 2
+
+    measure = ->(&block) {
+      start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      block.call
+      Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
+    }
+
+    workload.call(1) # warmup: load JIT / page in caches before timing
+
+    single = trials.times.map {
+      measure.call { workload.call(total_iterations) }
+    }.min
+
+    parallel = trials.times.map {
+      measure.call {
+        threads = Array.new(2) {
+          Thread.new { workload.call(total_iterations / 2) }
+        }
+        threads.each(&:join)
+      }
+    }.min
+
+    assert_operator parallel, :<=, single * 0.8,
+      "parallel wall clock #{(parallel * 1000).round(1)}ms not ≤ 0.8 × single #{(single * 1000).round(1)}ms — work may not be releasing the GVL"
+  end
+
+  # CPU-bound JS heavy enough (~10ms at the default iteration count) that
+  # eval time dominates threading overhead in assert_run_in_parallel.
+  # benchmark/threading.rb keeps its own copy of this loop — benchmarks
+  # don't load minitest helpers — so retune both if the size ever changes.
+  def cpu_workload_js(iterations: 200_000)
+    <<~JS
+      (() => {
+        let acc = 0;
+        for (let i = 0; i < #{iterations}; i++) {
+          acc = (acc + Math.sqrt(i) * Math.sin(i)) % 1e9;
+        }
+        globalThis.workloadAcc = acc;
+      })();
+    JS
+  end
+end
+
+Minitest::Spec.include(QuickjsTestHelpers)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,3 +3,48 @@
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require "quickjs"
 require "minitest/autorun"
+require 'etc'
+
+module QuickjsTestHelpers
+  # Asserts the block runs in parallel across Ruby threads, by comparing
+  # wall-clock for the same total amount of work done serially in one thread
+  # vs split across two threads. If the work releases the GVL during its hot
+  # section, the 2-thread run finishes in ~half the wall clock; if it holds
+  # the GVL, both runs take roughly the same time. The 2/3 threshold cleanly
+  # distinguishes the two while leaving headroom for thread scheduling jitter.
+  #
+  # The block receives an iteration count and is expected to do that many
+  # units of the operation under test (e.g. eval_code calls, VM constructions).
+  # Each thread should create its own VM internally, because QuickJS records
+  # the runtime's stack base at construction time — using a VM from a thread
+  # other than its creator trips a (false) stack-overflow guard.
+  def assert_run_in_parallel(trials: 5, total_iterations: 8, &workload)
+    skip 'requires 2+ cores' if Etc.nprocessors < 2
+
+    measure = ->(&block) {
+      start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      block.call
+      Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
+    }
+
+    workload.call(1) # warmup: load JIT / page in caches before timing
+
+    single = trials.times.map {
+      measure.call { workload.call(total_iterations) }
+    }.min
+
+    parallel = trials.times.map {
+      measure.call {
+        threads = Array.new(2) {
+          Thread.new { workload.call(total_iterations / 2) }
+        }
+        threads.each(&:join)
+      }
+    }.min
+
+    assert_operator parallel, :<=, single * 2.0 / 3,
+      "parallel wall clock #{(parallel * 1000).round(1)}ms not ≤ 2/3 × single #{(single * 1000).round(1)}ms — work may not be releasing the GVL"
+  end
+end
+
+Minitest::Spec.include(QuickjsTestHelpers)


### PR DESCRIPTION
## Summary

Extends #56's GVL-released JS pattern to `Quickjs::VM#_load_polyfill_bytecode` so warmer-thread VM pools (e.g. capybara-simulated) recover multi-core scaling when an Intl polyfill is registered via the companion `quickjs-polyfill-intl` gem.

Stacked on top of #56 — the first 2 commits are #56's; this PR's commit is the last one. Diff will collapse cleanly once #56 lands.

## Motivation

Reported on capybara-simulated CI: the QuickJS suite went from ~13 min on quickjs.rb 0.18 (bundled Intl) to ~32 min on 0.19 (companion gem). Root cause: the bundled polyfill loaded via the GVL-released static-symbol path, but the registered-polyfill path held the GVL through `JS_ReadObject` + `JS_EvalFunction` — collapsing 4-way warmer parallelism to serial. The QuickJS submodule itself is unchanged between 0.18 and 0.19, so this is purely a binding-side regression.

Benchmark on a 32-core box with the full Intl chain (getcanonicallocales + locale + pluralrules + numberformat + datetimeformat):

```
single thread:  177 ms / VM
4 threads:       48 ms / VM   (3.7x speedup)
```

## Changes

**Core fix** — `vm_m_loadPolyfillBytecode` copies the Ruby String into a malloc'd buffer (so GC compaction can't move the backing storage out from under `JS_ReadObject`) and releases the GVL via the same `load_polyfill_bytecode` helper the static-symbol path uses. memcpy cost is microseconds vs. ~ms of bytecode eval.

**Safety gate** — release is gated on `can_eval_gvl_free(data)` (same gate `vm_m_evalCode` uses). With `POLYFILL_FILE` / `POLYFILL_CRYPTO` enabled, the polyfill's top-level can reach C bridges that call `rb_funcall` directly without honoring `gvl_released_js` — those combinations fall back to a held-GVL load path.

**Robustness** — `polyfill_load_no_gvl` short-circuits when `JS_ReadObject` returns an exception. Without this, `JS_EvalFunction` replaces the actual diagnostic (e.g. \`\"invalid version (116 expected=5)\"\`) with a generic \`\"bytecode function expected\"\` TypeError, hiding the real reason from users feeding corrupt or version-mismatched bytecode.

**Hygiene** — moved the `gvl_released_js` toggle into `load_polyfill_bytecode` itself so callers can't forget it; renamed `gvl_released_eval` → `gvl_released_js` since the flag now covers both eval and polyfill load; cleared `entry[:source]` / `entry[:init]` in `@_polyfills` after caching bytecode to release closure scope.

## Test plan

- [x] All 478 tests pass locally (475 prior + 3 new: parallelism, corrupt-bytecode error preservation, POLYFILL_CRYPTO + registered-polyfill combo)
- [x] Benchmark with real Intl chain confirms 3.7x speedup with 4 threads
- [ ] CI green on Ruby 3.2 / 3.3 / 3.4 / 4.0 × Ubuntu / macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)