### PR TITLE
Fix crypto.subtle AES-GCM IV handling and error propagation

### DIFF
--- a/ext/quickjsrb/quickjsrb_crypto_subtle.c
+++ b/ext/quickjsrb/quickjsrb_crypto_subtle.c
@@ -65,6 +65,7 @@ static VALUE js_usages_to_ruby_array(JSContext *ctx, JSValueConst j_usages)
 static void js_reject_with_ruby_error(JSContext *ctx, JSValueConst *resolving_funcs)
 {
   VALUE r_error = rb_errinfo();
+  rb_set_errinfo(Qnil);
   VALUE r_message = rb_funcall(r_error, rb_intern("message"), 0);
   JSValue j_err = JS_NewError(ctx);
   JS_SetPropertyStr(ctx, j_err, "message", JS_NewString(ctx, StringValueCStr(r_message)));

--- a/lib/quickjs/subtle_crypto.rb
+++ b/lib/quickjs/subtle_crypto.rb
@@ -367,6 +367,9 @@ module Quickjs
       additional_data = params[:additional_data]
 
       tag_bytes = tag_length / 8
+      if data.bytesize < tag_bytes
+        raise ArgumentError, "SubtleCrypto: AES-GCM data is shorter than the #{tag_bytes}-byte authentication tag"
+      end
       ciphertext = data[0, data.bytesize - tag_bytes]
       tag = data[-tag_bytes, tag_bytes]
 

--- a/lib/quickjs/subtle_crypto.rb
+++ b/lib/quickjs/subtle_crypto.rb
@@ -351,6 +351,8 @@ module Quickjs
       cipher = OpenSSL::Cipher.new("aes-#{key.algorithm["length"]}-gcm")
       cipher.encrypt
       cipher.key = key.key_data
+      # WebCrypto allows any nonzero IV length for AES-GCM; OpenSSL defaults to 12 bytes
+      cipher.iv_len = iv.bytesize
       cipher.iv = iv
       cipher.auth_data = additional_data || ""
       ciphertext = cipher.update(data) + cipher.final
@@ -371,6 +373,7 @@ module Quickjs
       decipher = OpenSSL::Cipher.new("aes-#{key.algorithm["length"]}-gcm")
       decipher.decrypt
       decipher.key = key.key_data
+      decipher.iv_len = iv.bytesize
       decipher.iv = iv
       decipher.auth_tag = tag
       decipher.auth_data = additional_data || ""

--- a/test/quickjs_crypto_subtle_aes_gcm_test.rb
+++ b/test/quickjs_crypto_subtle_aes_gcm_test.rb
@@ -71,6 +71,18 @@ describe "crypto.subtle AES-GCM encrypt/decrypt" do
     _(::Quickjs.eval_code(code, @options)).must_equal "10,20,30"
   end
 
+  it "supports non-default IV lengths (e.g. 16 bytes)" do
+    code = <<~JS
+      const key = await crypto.subtle.generateKey({name: "AES-GCM", length: 256}, false, ["encrypt", "decrypt"]);
+      const iv = crypto.getRandomValues(new Uint8Array(16));
+      const plaintext = new TextEncoder().encode("hello world");
+      const ciphertext = await crypto.subtle.encrypt({name: "AES-GCM", iv}, key, plaintext);
+      const decrypted = await crypto.subtle.decrypt({name: "AES-GCM", iv}, key, ciphertext);
+      new TextDecoder().decode(decrypted)
+    JS
+    _(::Quickjs.eval_code(code, { features: [::Quickjs::POLYFILL_CRYPTO, ::Quickjs::POLYFILL_ENCODING] })).must_equal "hello world"
+  end
+
   it "fails to decrypt with wrong iv" do
     code = <<~JS
       const rawKey = new Uint8Array(32);

--- a/test/quickjs_crypto_subtle_aes_gcm_test.rb
+++ b/test/quickjs_crypto_subtle_aes_gcm_test.rb
@@ -95,6 +95,20 @@ describe "crypto.subtle AES-GCM encrypt/decrypt" do
     _ { ::Quickjs.eval_code(code, @options) }.must_raise Quickjs::RuntimeError
   end
 
+  it "rejects data shorter than the authentication tag" do
+    code = <<~JS
+      const rawKey = new Uint8Array(32);
+      const key = await crypto.subtle.importKey("raw", rawKey, {name: "AES-GCM"}, false, ["decrypt"]);
+      try {
+        await crypto.subtle.decrypt({name: "AES-GCM", iv: new Uint8Array(12)}, key, new Uint8Array(5));
+        "no error"
+      } catch (e) {
+        e.message
+      }
+    JS
+    _(::Quickjs.eval_code(code, @options)).must_match(/shorter than the 16-byte authentication tag/)
+  end
+
   it "rejects unsupported algorithm" do
     code = <<~JS
       const rawKey = new Uint8Array(32);

--- a/test/quickjs_crypto_subtle_test.rb
+++ b/test/quickjs_crypto_subtle_test.rb
@@ -11,6 +11,17 @@ describe "crypto.subtle" do
     _ { ::Quickjs.eval_code("crypto.subtle.digest('SHA-256', new Uint8Array([1,2,3]))") }.must_raise Quickjs::ReferenceError
   end
 
+  it "does not leave the Ruby exception in $! after a rejection caught in JS" do
+    code = <<~JS
+      try {
+        await crypto.subtle.digest('SHA-999', new Uint8Array([1]));
+      } catch (e) {}
+      "done"
+    JS
+    _(::Quickjs.eval_code(code, @options)).must_equal "done"
+    _($!).must_be_nil
+  end
+
   describe "digest" do
     it "returns an ArrayBuffer" do
       code = "const buf = await crypto.subtle.digest('SHA-256', new Uint8Array([1,2,3])); buf.byteLength"


### PR DESCRIPTION
## Summary

`crypto.subtle.decrypt` rejected with a Ruby-layer `ArgumentError` ("iv must be 12 bytes") for JS code that works in browsers and Node. Root-causing that surfaced two adjacent bugs, each fixed in its own commit with a test:

- **Accept arbitrary IV lengths for AES-GCM.** The WebCrypto spec allows any nonzero IV length, but `OpenSSL::Cipher` defaults GCM to 12 bytes and `#iv=` rejects everything else. Set `iv_len` from the provided IV so e.g. 16-byte-IV ciphertext produced elsewhere decrypts correctly.
- **Reject AES-GCM decrypt input shorter than the authentication tag.** Slicing the tag off too-short data produced a `nil` tag, surfacing as `no implicit conversion of nil into String`; now it rejects with a descriptive message.
- **Clear `errinfo` after capturing a Ruby error for promise rejection.** `js_reject_with_ruby_error` left the exception in `$!` after `eval_code` returned — even when JS caught the rejection — and Ruby dumped its backtrace at process exit. Reset it like the module-loader path already does.

## Test plan

- New tests: 16-byte IV round-trip, short-input rejection message, `$!` is nil after a JS-caught rejection
- Full suite: 490 runs, 0 failures (1 pre-existing unrelated skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)