### PR TITLE
Require registered polyfill top levels to settle synchronously

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,6 +430,8 @@ Quickjs.register_polyfill(
 
 The first VM with a given polyfill pays the parse cost (the source is compiled to QuickJS bytecode on a disposable VM with a generous timeout); subsequent VMs reuse the cached bytecode. The polyfill body runs without consuming the user VM's `timeout_msec` budget — that's reserved for user code.
 
+The polyfill's top level must settle synchronously — no top-level `await`. `VM.new(features:)` guarantees a usable polyfill on return, but loads don't drain the job queue, so nothing past the first `await` would have run by then. A polyfill left pending (and any top-level throw) raises a `Quickjs::RuntimeError` naming the feature at construction, rather than handing back a VM with the polyfill silently half-applied.
+
 Intl APIs (Collator, DateTimeFormat, NumberFormat, PluralRules, Locale, etc.) live in a separate companion gem: [`quickjs-polyfill-intl`](https://github.com/hmsk/quickjs-polyfill-intl). Granular, dependency-aware, opt-in per API.
 
 ## Acknowledgements

--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -1126,6 +1126,43 @@ static JSValue load_polyfill_bytecode(VMData *data, const uint8_t *buf, size_t b
   return job.result;
 }
 
+// Shared settle check for every polyfill load's result, bundled or
+// registered. The compiled bytecode is async-wrapped (JS_EVAL_FLAG_ASYNC),
+// so a top-level throw comes back as a rejected promise, not JS_EXCEPTION;
+// re-throwing the reason routes it through to_rb_value's standard
+// exception path (interrupted/OOM mapping, oom_poisoned latching, on_log
+// dispatch). And a top level that awaits is still pending: loads never
+// drain the job queue, so nothing past the first await has run — refuse
+// loudly instead of shipping a silently half-applied VM; polyfill top
+// levels must settle synchronously (the register_polyfill contract).
+// Frees j_result on every path.
+static void finish_polyfill_load(VMData *data, JSValue j_result)
+{
+  if (JS_IsException(j_result))
+  {
+    to_rb_value(data->context, j_result); // raises
+    return;
+  }
+
+  JSPromiseStateEnum state = JS_PromiseState(data->context, j_result);
+  if (state == JS_PROMISE_REJECTED)
+  {
+    JSValue j_reason = JS_PromiseResult(data->context, j_result);
+    JS_FreeValue(data->context, j_result);
+    JS_Throw(data->context, j_reason); // consumes j_reason
+    to_rb_value(data->context, JS_EXCEPTION); // raises
+    return;
+  }
+  if (state == JS_PROMISE_PENDING)
+  {
+    JS_FreeValue(data->context, j_result);
+    VALUE r_msg = rb_str_new2("polyfill top level must settle synchronously: top-level await leaves the load pending and the polyfill silently half-applied");
+    rb_exc_raise(rb_funcall(QUICKJSRB_ERROR_FOR(QUICKJSRB_ROOT_RUNTIME_ERROR), rb_intern("new"), 2, r_msg, Qnil));
+  }
+
+  JS_FreeValue(data->context, j_result);
+}
+
 static VALUE vm_m_initialize(int argc, VALUE *argv, VALUE r_self)
 {
   VALUE r_opts;
@@ -1192,22 +1229,19 @@ static VALUE vm_m_initialize(int argc, VALUE *argv, VALUE r_self)
 
   if (RTEST(rb_funcall(r_features, rb_intern("include?"), 1, QUICKJSRB_SYM(featurePolyfillFileId))))
   {
-    JSValue j_polyfillFileResult = load_polyfill_bytecode(data, &qjsc_polyfill_file_min, qjsc_polyfill_file_min_size, false);
-    JS_FreeValue(data->context, j_polyfillFileResult);
+    finish_polyfill_load(data, load_polyfill_bytecode(data, &qjsc_polyfill_file_min, qjsc_polyfill_file_min_size, false));
 
     quickjsrb_init_file_proxy(data);
   }
 
   if (RTEST(rb_funcall(r_features, rb_intern("include?"), 1, QUICKJSRB_SYM(featurePolyfillEncodingId))))
   {
-    JSValue j_polyfillEncodingResult = load_polyfill_bytecode(data, &qjsc_polyfill_encoding_min, qjsc_polyfill_encoding_min_size, false);
-    JS_FreeValue(data->context, j_polyfillEncodingResult);
+    finish_polyfill_load(data, load_polyfill_bytecode(data, &qjsc_polyfill_encoding_min, qjsc_polyfill_encoding_min_size, false));
   }
 
   if (RTEST(rb_funcall(r_features, rb_intern("include?"), 1, QUICKJSRB_SYM(featurePolyfillUrlId))))
   {
-    JSValue j_polyfillUrlResult = load_polyfill_bytecode(data, &qjsc_polyfill_url_min, qjsc_polyfill_url_min_size, false);
-    JS_FreeValue(data->context, j_polyfillUrlResult);
+    finish_polyfill_load(data, load_polyfill_bytecode(data, &qjsc_polyfill_url_min, qjsc_polyfill_url_min_size, false));
   }
 
   if (RTEST(rb_funcall(r_features, rb_intern("include?"), 1, QUICKJSRB_SYM(featurePolyfillCryptoId))))
@@ -1752,25 +1786,7 @@ static VALUE vm_m_loadPolyfillBytecode(VALUE r_self, VALUE r_bytecode)
     j_result = job.result;
   }
 
-  if (JS_IsException(j_result))
-    return to_rb_value(data->context, j_result); // raises
-
-  // The compiled bytecode is async-wrapped (JS_EVAL_FLAG_ASYNC), so a
-  // top-level throw doesn't come back as JS_EXCEPTION — it comes back as
-  // a rejected promise. Surface it instead of silently shipping a VM
-  // whose polyfill half-ran. Re-throwing the reason routes it through
-  // to_rb_value's standard exception path, so interrupted/OOM mapping,
-  // oom_poisoned latching, and the on_log error dispatch all behave
-  // exactly as for a synchronous throw.
-  if (JS_PromiseState(data->context, j_result) == JS_PROMISE_REJECTED)
-  {
-    JSValue j_reason = JS_PromiseResult(data->context, j_result);
-    JS_FreeValue(data->context, j_result);
-    JS_Throw(data->context, j_reason); // consumes j_reason
-    return to_rb_value(data->context, JS_EXCEPTION); // raises
-  }
-
-  JS_FreeValue(data->context, j_result);
+  finish_polyfill_load(data, j_result); // raises unless settled fulfilled
   return Qnil;
 }
 

--- a/lib/quickjs/polyfills.rb
+++ b/lib/quickjs/polyfills.rb
@@ -12,6 +12,12 @@ module Quickjs
   # VM with the same feature: compilation is locked per entry, so that
   # recursion raises ThreadError instead of deadlocking silently.
   #
+  # The polyfill's top level must settle synchronously — no top-level
+  # await. `VM.new(features:)` promises a usable polyfill on return, but
+  # loads never drain the job queue, so nothing past the first await
+  # would have run by then; a pending load raises Quickjs::RuntimeError
+  # instead of handing back a silently half-applied VM.
+  #
   # Re-registering a name replaces the entry wholesale, lock included: a
   # VM construction already compiling under the old entry finishes
   # against it (and loads the old bytecode) while the first construction
@@ -57,7 +63,15 @@ module Quickjs
           compiled
         end
       }
-      vm.send(:_load_polyfill_bytecode, bytecode)
+      begin
+        vm.send(:_load_polyfill_bytecode, bytecode)
+      rescue Quickjs::RuntimeError => e
+        # The C layer only sees bytecode; name the registration so a VM
+        # with several polyfill features points at the one that failed.
+        # `raise e, msg` clones — class, js_name, and any JS backtrace
+        # already set on the original all survive.
+        raise e, "#{feature}: #{e.message}"
+      end
     end
   end
 

--- a/test/quickjs_register_polyfill_test.rb
+++ b/test/quickjs_register_polyfill_test.rb
@@ -128,6 +128,19 @@ describe "Quickjs.register_polyfill" do
     _(err.message).must_match(/polyfill exploded/)
   end
 
+  # Loads never drain the job queue, so nothing past a top-level await has
+  # run when VM.new returns — the load used to report success with the
+  # polyfill's globals missing (and a throw behind the await, the same
+  # PENDING shape at load time, was swallowed outright). PENDING is now an
+  # error: registered polyfill top-levels must settle synchronously. The
+  # message names the offending feature, since a VM can enable several.
+  it 'raises when the polyfill uses top-level await' do
+    Quickjs.register_polyfill(@feature, source: 'await 0; throw new TypeError("never surfaces");')
+
+    err = _ { Quickjs::VM.new(features: [@feature]) }.must_raise Quickjs::RuntimeError
+    _(err.message).must_match(/#{@feature}.*settle synchronously/)
+  end
+
   # Mirrors the GVL-release pattern from VM#eval_code: _load_polyfill_bytecode
   # copies the Ruby String to a malloc'd buffer and releases the GVL during
   # JS_ReadObject + JS_EvalFunction. Without that, csim-style warmer-thread VM


### PR DESCRIPTION
The follow-up you called for in the #59 approval — option (b) for the top-level-await gap.

**The contract.** A registered polyfill whose top level awaits is still `JS_PROMISE_PENDING` when the load returns: loads never drain the job queue, so nothing past the first `await` has run, the polyfill's globals aren't installed, and a rejection behind the await was swallowed outright. A pending load now raises `Quickjs::RuntimeError`, and "polyfill top levels must settle synchronously" is documented on `register_polyfill` and in the README's registering-polyfills section.

**Placement.** The settle check landed as a `finish_polyfill_load` tail shared by all four load sites, not just `_load_polyfill_bytecode`. That also closes a pre-existing gap you may want to eyeball: the bundled file/encoding/url loads in `vm_m_initialize` freed their results completely unchecked — an OOM or interrupt mid-load rejected the async-wrapped promise silently and `VM.new` shipped with e.g. `Blob` missing, the exact failure mode #59 eliminated for registered polyfills. The bundles can't hit the PENDING branch (they're synchronous by construction, audited at `rake polyfills:build` time), but the rejection surfacing now covers them identically.

**Error ergonomics.** The raise from `_apply_registered_polyfills` is re-raised as `"#{feature}: #{message}"` — the C layer only sees bytecode, and a VM enabling several polyfill features shouldn't force a bisection to find the offender. `raise e, msg` clones, so the class, `js_name`, and any JS backtrace survive.

One deeper alternative considered and left on the table: compiling polyfill sources without `JS_EVAL_FLAG_ASYNC` would turn top-level `await` into a `SyntaxError` at registration (the gem author's test suite) instead of a `RuntimeError` at every consumer's `VM.new`, and would collapse the promise-state checks entirely. It needs an `async:` knob on the compile path, so it grows the C surface — flagging it rather than doing it.

Local: full suite green (498 runs / 767 assertions / 0 failures), the new test verified to fail without the C change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)