### PR TITLE
Ignore compiled *.so next to *.bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ build-iPhoneSimulator/
 # Used by RuboCop. Remote config files pulled in from inherit_from directive.
 # .rubocop-https?--*
 *.bundle
+*.so
 
 *.local.json
 


### PR DESCRIPTION
`rake compile` installs the extension as `lib/quickjs/quickjsrb.so` on Linux, but only the macOS `*.bundle` form is ignored — every Linux checkout carries the built artifact as a dangling untracked file (and one `git add -A` away from being committed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)