### PR TITLE
Support globals in Quickjs.eval_code

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Quickjs.eval_code('const fn = (n, pow) => n ** pow; fn(2,8);') # => 256
 Quickjs.eval_code('const fn = (name) => `Hi, ${name}!`; fn("Itadori");') # => "Hi, Itadori!"
 Quickjs.eval_code("[1,2,3]") #=> [1, 2, 3]
 Quickjs.eval_code("({ a: '1', b: 1 })") #=> { 'a' => '1', 'b' => 1 }
+Quickjs.eval_code('a + b', globals: { a: 1, b: 2 }) #=> 3
 ```
 
 <details>
@@ -45,6 +46,14 @@ Quickjs.eval_code(code,
 ```rb
 # Label shown in JS stack traces (default: "<code>")
 Quickjs.eval_code(code, filename: 'my_script.js')
+```
+
+#### Globals
+
+Ruby values can be exposed as JavaScript globals without interpolating them into the source:
+
+```rb
+Quickjs.eval_code('user.name', globals: { user: { name: 'Itadori' } }) #=> "Itadori"
 ```
 
 #### Timeout

--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -1145,6 +1145,7 @@ static VALUE vm_m_initialize(int argc, VALUE *argv, VALUE r_self)
   VALUE r_timeout_msec = rb_hash_aref(r_opts, ID2SYM(rb_intern("timeout_msec")));
   if (NIL_P(r_timeout_msec))
     r_timeout_msec = UINT2NUM(100);
+  VALUE r_globals = rb_hash_aref(r_opts, ID2SYM(rb_intern("globals")));
 
   VMData *data;
   TypedData_Get_Struct(r_self, VMData, &vm_type, data);
@@ -1159,6 +1160,10 @@ static VALUE vm_m_initialize(int argc, VALUE *argv, VALUE r_self)
   register_module_loader_funcs(data);
   JS_SetHostPromiseRejectionTracker(runtime, quickjsrb_promise_rejection_tracker, NULL);
   js_std_init_handlers(runtime);
+
+  // Validate after handler initialization so a TypeError can safely unwind through vm_free.
+  if (!NIL_P(r_globals))
+    Check_Type(r_globals, T_HASH);
 
   JSValue j_global = JS_GetGlobalObject(data->context);
 
@@ -1238,6 +1243,13 @@ static VALUE vm_m_initialize(int argc, VALUE *argv, VALUE r_self)
       JS_NewCFunction(data->context, js_console_error, "error", 1));
 
   JS_SetPropertyStr(data->context, j_global, "console", j_console);
+
+  if (!NIL_P(r_globals))
+  {
+    RbHashToJsArg globals = {data->context, j_global};
+    rb_hash_foreach(r_globals, rb_hash_entry_to_js, (VALUE)&globals);
+  }
+
   JS_FreeValue(data->context, j_global);
 
   return r_self;

--- a/sig/quickjs.rbs
+++ b/sig/quickjs.rbs
@@ -21,7 +21,7 @@ module Quickjs
   end
 
   class VM
-    def initialize: (?features: Array[Symbol], ?memory_limit: Integer, ?max_stack_size: Integer, ?timeout_msec: Integer) -> void
+    def initialize: (?features: Array[Symbol], ?memory_limit: Integer, ?max_stack_size: Integer, ?timeout_msec: Integer, ?globals: Hash[String | Symbol, untyped]) -> void
 
     def eval_code: (String code, ?async: bool, ?filename: String) -> untyped
 

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -287,6 +287,27 @@ describe Quickjs do
     end
   end
 
+  describe "EvalGlobals" do
+    it "exposes globals to evaluated code" do
+      result = ::Quickjs.eval_code("a + b", globals: { a: 1, b: 2 })
+
+      _(result).must_equal 3
+    end
+
+    it "converts nested Ruby values" do
+      result = ::Quickjs.eval_code(
+        "user.name + ': ' + tags.join(', ')",
+        globals: { user: { name: "Itadori" }, tags: ["strong", "kind"] }
+      )
+
+      _(result).must_equal "Itadori: strong, kind"
+    end
+
+    it "rejects globals that are not a Hash" do
+      _ { ::Quickjs.eval_code("1", globals: [1, 2]) }.must_raise TypeError
+    end
+  end
+
   describe "SyncEval" do
     it "evaluates synchronously when async: false" do
       vm = Quickjs::VM.new


### PR DESCRIPTION
## Summary

- add a `globals:` option to `Quickjs.eval_code` and `Quickjs::VM.new`
- expose supplied Ruby values as JavaScript globals through QuickJS's native C API
- reuse the existing Ruby-to-JavaScript converter for primitives, arrays, and hashes
- document the API and add focused coverage for conversion and invalid input

## Why

Callers currently need to interpolate values into JavaScript source. Native variable injection provides a concise API without generating a JavaScript wrapper or changing QuickJS core:

```ruby
Quickjs.eval_code("a + b", globals: { a: 1, b: 2 }) # => 3
```

The values are installed on the new VM's global object during native initialization, before the code is evaluated.

## Validation

- `bundle exec rake`
- 500 tests, 775 assertions, 0 failures, 1 existing skip
- RBS validation passes
