### PR TITLE
Preload ES modules as bytecode across VMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,37 @@ When `module_loader=` is set, pass `filename:` to `import` instead of `from:` to
 
 `import` awaits the module's top-level evaluation — top-level `await`, synchronous body execution, and any chained dynamic `import()`. The call blocks until the module's settle promise resolves. A top-level throw, a failed dynamic `import()`, or a rejected top-level `await` propagates back to Ruby as the matching `Quickjs::*Error` instead of being silently dropped.
 
+#### `Quickjs.register_module`: 📦 Preload ES modules as bytecode
+
+A module resolved through `module_loader` is parsed again by every VM that imports it. `register_module` parses it once per process and hands each VM the compiled bytecode instead, which is the same trick `compile` plays for classic scripts. On a 220KB module that takes importing from ~10.7ms to ~1.8ms per VM.
+
+```rb
+Quickjs.register_module('lib', source: File.read('lib.js'))
+
+vm = Quickjs::VM.new(preload_modules: ['lib'])
+vm.import(['call'], filename: 'lib')
+vm.eval_code('call(1, 2)')
+```
+
+Registration is process-wide, `preload_modules:` is per VM. Registering only makes a module available; each VM says which ones it wants. That split is deliberate: reading a module into a VM costs about 1.26ms per 220KB whether or not it ends up being imported, so a registry that every VM read wholesale would be slower than plain source loading as soon as a VM used only part of it. It is the same reason browsers ask for `<link rel="modulepreload">` per document rather than preloading everything they know about.
+
+`source:` also accepts a `Proc` returning a `String`, so a gem can register at `require` time without paying the file-read cost unless a VM actually preloads it:
+
+```rb
+Quickjs.register_module('lib', source: -> { File.read('lib.js') })
+```
+
+The first VM to preload a given module pays the compile cost (on a disposable VM with a generous timeout, so it doesn't consume the user VM's `timeout_msec`); later VMs reuse the cached bytecode. Each VM still gets its own instance of the module, with its own module-level state.
+
+**`name` is the canonical name, not a label.** It is the string JS writes in its `import` statement, the name QuickJS keys its module map by, and it is baked into the compiled bytecode. If your `module_loader` resolves specifiers to absolute paths, register under the resolved path (`/vendor/lodash.js`), not the bare specifier your JS happens to write (`lodash`). A loader that maps a specifier onto a preloaded canonical via `as:` still lands on the preloaded module, so importmap-style scoping keeps working.
+
+Two consequences worth knowing:
+
+- **A preloaded module wins over `module_loader`, which is never asked for that name.** The module is already in the VM's module map, exactly as if it had been imported earlier, so resolution finds it before any loader runs.
+- **A preloaded module's own imports are not preloaded.** They resolve through `module_loader` on first import like any other specifier, so register each module you want cached. This differs from HTML's `modulepreload`, which walks the dependency graph.
+
+Preloading a name that isn't registered raises `ArgumentError`; names must be `String`s (a `Symbol` raises `TypeError`). `Quickjs._unregister_module(name)` removes an entry, which is mostly useful for keeping tests isolated.
+
 #### `Quickjs::VM#on_unhandled_rejection`: 🚨 Catch promise rejections that have no handler
 
 Register a block to be notified when a JS Promise rejects with no `.catch` / `then(_, onRejected)` attached at the time of rejection — fire-and-forget chains, failed dynamic imports without `try`, etc.
@@ -431,6 +462,8 @@ Quickjs.register_polyfill(
 The first VM with a given polyfill pays the parse cost (the source is compiled to QuickJS bytecode on a disposable VM with a generous timeout); subsequent VMs reuse the cached bytecode. The polyfill body runs without consuming the user VM's `timeout_msec` budget — that's reserved for user code.
 
 The polyfill's top level must settle synchronously — no top-level `await`. `VM.new(features:)` guarantees a usable polyfill on return, but loads don't drain the job queue, so nothing past the first `await` would have run by then. A polyfill left pending raises a `Quickjs::NoAwaitError`, and any top-level throw raises the matching `Quickjs::RuntimeError` subclass, both naming the feature at construction, rather than handing back a VM with the polyfill silently half-applied.
+
+To ship JS that user code `import`s rather than globals it reaches for, see [`Quickjs.register_module`](#quickjsregister_module--preload-es-modules-as-bytecode), which follows the same registry protocol at the module layer instead of the global one.
 
 Intl APIs (Collator, DateTimeFormat, NumberFormat, PluralRules, Locale, etc.) live in a separate companion gem: [`quickjs-polyfill-intl`](https://github.com/hmsk/quickjs-polyfill-intl). Granular, dependency-aware, opt-in per API.
 

--- a/README.md
+++ b/README.md
@@ -254,6 +254,8 @@ Two consequences worth knowing:
 
 Preloading a name that isn't registered raises `ArgumentError`; names must be `String`s (a `Symbol` raises `TypeError`). `Quickjs._unregister_module(name)` removes an entry, which is mostly useful for keeping tests isolated.
 
+**Preloading grants the module to everything running in that VM**, including untrusted code reaching it with a dynamic `import()`, and whether or not your Ruby code ever imports it. `module_loader` is the authorization point, and preloading deliberately bypasses it for that name, so a loader that allows a module for some importers and denies it for others has no say over a preloaded one. If a module needs per-importer or per-scope authorization, resolve it through `module_loader` instead of preloading it, and accept the parse cost as the price of that control.
+
 #### `Quickjs::VM#on_unhandled_rejection`: 🚨 Catch promise rejections that have no handler
 
 Register a block to be notified when a JS Promise rejects with no `.catch` / `then(_, onRejected)` attached at the time of rejection — fire-and-forget chains, failed dynamic imports without `try`, etc.

--- a/README.md
+++ b/README.md
@@ -247,6 +247,8 @@ The first VM to preload a given module pays the compile cost (on a disposable VM
 
 **`name` is the canonical name, not a label.** It is the string JS writes in its `import` statement, the name QuickJS keys its module map by, and it is baked into the compiled bytecode. If your `module_loader` resolves specifiers to absolute paths, register under the resolved path (`/vendor/lodash.js`), not the bare specifier your JS happens to write (`lodash`). A loader that maps a specifier onto a preloaded canonical via `as:` still lands on the preloaded module, so importmap-style scoping keeps working.
 
+Relative-looking names are the one case where that bites without a loader in play. With no `module_loader` set, QuickJS's own normalization resolves `./lib.js` against the importing file before looking in the module map, so a module registered as `./lib.js` is never found and the import falls through to the filesystem loader. Register a bare or absolute name (`lib.js`, `/app/lib.js`) unless a `module_loader` is doing the normalizing.
+
 Two consequences worth knowing:
 
 - **A preloaded module wins over `module_loader`, which is never asked for that name.** The module is already in the VM's module map, exactly as if it had been imported earlier, so resolution finds it before any loader runs.

--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -1814,8 +1814,9 @@ static VALUE vm_m_compileModule(VALUE r_self, VALUE r_code, VALUE r_name)
 // first import, and js_resolve_module recurses into it from the importer, so
 // no loader hook is involved for a preloaded name.
 //
-// The baked-in name is recorded in preloaded_module_names for the normalize
-// hook's short-circuit, and returned so the caller can confirm it.
+// The name is recorded in preloaded_module_names for the normalize hook's
+// short-circuit, and returned so the caller can confirm the blob was filed
+// where it asked.
 //
 // `name` is the name the caller expects the blob to carry. Reading the same
 // module into a context twice can't be undone — js_read_module appends a
@@ -1843,7 +1844,14 @@ static VALUE vm_m_preloadModuleBytecode(VALUE r_self, VALUE r_bytecode, VALUE r_
   }
   Check_Type(r_name, T_STRING);
 
-  if (RTEST(rb_hash_aref(data->preloaded_module_names, r_name)))
+  // A module name crosses into QuickJS as raw bytes and comes back binary, so
+  // it is compared and keyed on bytes here. Encoding-aware equality would call
+  // a non-ASCII name different from the identical name the caller passed in
+  // (UTF-8 from the registry), and this is also the form the normalize hook
+  // looks up, since it builds its specifier from a C string too.
+  VALUE r_key = rb_str_new(RSTRING_PTR(r_name), RSTRING_LEN(r_name));
+
+  if (RTEST(rb_hash_aref(data->preloaded_module_names, r_key)))
     return r_name;
 
   JSValue j_mod = JS_ReadObject(data->context, (const uint8_t *)RSTRING_PTR(r_bytecode),
@@ -1875,14 +1883,14 @@ static VALUE vm_m_preloadModuleBytecode(VALUE r_self, VALUE r_bytecode, VALUE r_
   // it again and every preload would read another copy. There is no way to
   // take the read back, so the VM is already polluted: raise and let the
   // caller discard it.
-  if (!RTEST(rb_str_equal(r_baked, r_name)))
+  if (!RTEST(rb_str_equal(r_baked, r_key)))
   {
     rb_raise(rb_eArgError, "module bytecode is named %"PRIsVALUE", not %"PRIsVALUE,
              rb_str_inspect(r_baked), rb_str_inspect(r_name));
   }
 
-  rb_hash_aset(data->preloaded_module_names, rb_str_freeze(r_baked), Qtrue);
-  return r_baked;
+  rb_hash_aset(data->preloaded_module_names, rb_str_freeze(r_key), Qtrue);
+  return r_name;
 }
 
 // Number of sources the normalize hook is holding for the load hook to pick

--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -1815,16 +1815,27 @@ static VALUE vm_m_compileModule(VALUE r_self, VALUE r_code, VALUE r_name)
 // no loader hook is involved for a preloaded name.
 //
 // The baked-in name is recorded in preloaded_module_names for the normalize
-// hook's short-circuit, and returned so the Ruby layer can assert it matches
-// the registry key.
-static VALUE vm_m_preloadModuleBytecode(VALUE r_self, VALUE r_bytecode)
+// hook's short-circuit, and returned so the caller can confirm it.
+//
+// `name` is the name the caller expects the blob to carry. Reading the same
+// module into a context twice can't be undone — js_read_module appends a
+// second JSModuleDef under the same name, js_find_loaded_module returns the
+// first one it walks past, and the orphan holds its bytecode until the
+// context is freed — so a name already preloaded here skips the read
+// entirely. That also makes this idempotent, which the caller relies on: it
+// is legitimate to preload the same module into a VM more than once.
+static VALUE vm_m_preloadModuleBytecode(VALUE r_self, VALUE r_bytecode, VALUE r_name)
 {
   VMData *data;
   TypedData_Get_Struct(r_self, VMData, &vm_type, data);
 
   StringValue(r_bytecode);
+  Check_Type(r_name, T_STRING);
   check_disposed(data);
   check_oom_poisoned(data);
+
+  if (RTEST(rb_hash_aref(data->preloaded_module_names, r_name)))
+    return r_name;
 
   JSValue j_mod = JS_ReadObject(data->context, (const uint8_t *)RSTRING_PTR(r_bytecode),
                                 (size_t)RSTRING_LEN(r_bytecode), JS_READ_OBJ_BYTECODE);
@@ -1839,18 +1850,30 @@ static VALUE vm_m_preloadModuleBytecode(VALUE r_self, VALUE r_bytecode)
 
   js_module_set_import_meta(data->context, j_mod, FALSE, FALSE);
 
-  JSAtom j_name = JS_GetModuleName(data->context, JS_VALUE_GET_PTR(j_mod));
-  const char *name = JS_AtomToCString(data->context, j_name);
-  VALUE r_name = rb_str_new_cstr(name ? name : "");
-  if (name)
-    JS_FreeCString(data->context, name);
-  JS_FreeAtom(data->context, j_name);
-  rb_hash_aset(data->preloaded_module_names, rb_str_freeze(r_name), Qtrue);
+  JSAtom j_baked = JS_GetModuleName(data->context, JS_VALUE_GET_PTR(j_mod));
+  const char *baked = JS_AtomToCString(data->context, j_baked);
+  VALUE r_baked = rb_str_new_cstr(baked ? baked : "");
+  if (baked)
+    JS_FreeCString(data->context, baked);
+  JS_FreeAtom(data->context, j_baked);
 
   // The module def is owned by ctx->loaded_modules (js_new_module_def leaves
   // it there with ref_count 1); JS_NewModuleValue dup'd it for us.
   JS_FreeValue(data->context, j_mod);
-  return r_name;
+
+  // A blob whose baked name disagrees with the name it was filed under would
+  // be resolvable only by the baked one, so the guard above would never see
+  // it again and every preload would read another copy. There is no way to
+  // take the read back, so the VM is already polluted: raise and let the
+  // caller discard it.
+  if (!RTEST(rb_str_equal(r_baked, r_name)))
+  {
+    rb_raise(rb_eArgError, "module bytecode is named %"PRIsVALUE", not %"PRIsVALUE,
+             rb_str_inspect(r_baked), rb_str_inspect(r_name));
+  }
+
+  rb_hash_aset(data->preloaded_module_names, rb_str_freeze(r_baked), Qtrue);
+  return r_baked;
 }
 
 // Number of sources the normalize hook is holding for the load hook to pick
@@ -2453,7 +2476,7 @@ RUBY_FUNC_EXPORTED void Init_quickjsrb(void)
   rb_define_method(r_class_vm, "eval_code", vm_m_evalCode, -1);
   rb_define_private_method(r_class_vm, "_compile_to_bytecode", vm_m_compile, -1);
   rb_define_private_method(r_class_vm, "_compile_module_to_bytecode", vm_m_compileModule, 2);
-  rb_define_private_method(r_class_vm, "_preload_module_bytecode", vm_m_preloadModuleBytecode, 1);
+  rb_define_private_method(r_class_vm, "_preload_module_bytecode", vm_m_preloadModuleBytecode, 2);
   rb_define_private_method(r_class_vm, "_pending_module_source_count", vm_m_pendingModuleSourceCount, 0);
   rb_define_private_method(r_class_vm, "_run_bytecode", vm_m_evalBytecode, 1);
   rb_define_private_method(r_class_vm, "_load_polyfill_bytecode", vm_m_loadPolyfillBytecode, 1);

--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -1768,6 +1768,12 @@ static JSModuleDef *quickjsrb_stub_module_loader(JSContext *ctx, const char *mod
 // the name baked in here, so it is the module's identity in every VM that
 // later reads this blob. Quickjs.register_module keys the registry by that
 // same string, which is what keeps the two from drifting apart.
+//
+// Stays private, and must: the stub loader below is swapped in at the
+// *runtime* level for the duration, so this assumes exclusive use of the VM.
+// Quickjs._compile_registered_module honors that by compiling on a disposable
+// VM it owns; exposing this publicly would let a compile race an import on a
+// shared VM and resolve it against stubs.
 static VALUE vm_m_compileModule(VALUE r_self, VALUE r_code, VALUE r_name)
 {
   VMData *data;
@@ -1845,6 +1851,19 @@ static VALUE vm_m_preloadModuleBytecode(VALUE r_self, VALUE r_bytecode)
   // it there with ref_count 1); JS_NewModuleValue dup'd it for us.
   JS_FreeValue(data->context, j_mod);
   return r_name;
+}
+
+// Number of sources the normalize hook is holding for the load hook to pick
+// up. Exposed only so tests can assert the cache doesn't accumulate entries
+// nothing will ever collect: when a loader resolves a specifier onto a
+// preloaded canonical, QuickJS finds the module and never calls the load hook,
+// so a source stashed for that name would sit there for the VM's lifetime.
+static VALUE vm_m_pendingModuleSourceCount(VALUE r_self)
+{
+  VMData *data;
+  TypedData_Get_Struct(r_self, VMData, &vm_type, data);
+
+  return LONG2NUM(RHASH_SIZE(data->module_source_cache));
 }
 
 static VALUE vm_m_evalBytecode(VALUE r_self, VALUE r_bytecode)
@@ -2435,6 +2454,7 @@ RUBY_FUNC_EXPORTED void Init_quickjsrb(void)
   rb_define_private_method(r_class_vm, "_compile_to_bytecode", vm_m_compile, -1);
   rb_define_private_method(r_class_vm, "_compile_module_to_bytecode", vm_m_compileModule, 2);
   rb_define_private_method(r_class_vm, "_preload_module_bytecode", vm_m_preloadModuleBytecode, 1);
+  rb_define_private_method(r_class_vm, "_pending_module_source_count", vm_m_pendingModuleSourceCount, 0);
   rb_define_private_method(r_class_vm, "_run_bytecode", vm_m_evalBytecode, 1);
   rb_define_private_method(r_class_vm, "_load_polyfill_bytecode", vm_m_loadPolyfillBytecode, 1);
   rb_define_method(r_class_vm, "call", vm_m_callGlobalFunction, -1);

--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -1829,10 +1829,19 @@ static VALUE vm_m_preloadModuleBytecode(VALUE r_self, VALUE r_bytecode, VALUE r_
   VMData *data;
   TypedData_Get_Struct(r_self, VMData, &vm_type, data);
 
-  StringValue(r_bytecode);
-  Check_Type(r_name, T_STRING);
   check_disposed(data);
   check_oom_poisoned(data);
+
+  // Strict String rather than StringValue's coercion, matching
+  // vm_m_evalBytecode: bytecode is a binary blob, so there's no sensible
+  // to_str-able stand-in for one, and refusing the coercion means no yield
+  // point can open up between the checks above and the context access below.
+  if (!RB_TYPE_P(r_bytecode, T_STRING))
+  {
+    VALUE r_class = rb_class_name(CLASS_OF(r_bytecode));
+    rb_raise(rb_eTypeError, "Bytecode must be a String, got %s", StringValueCStr(r_class));
+  }
+  Check_Type(r_name, T_STRING);
 
   if (RTEST(rb_hash_aref(data->preloaded_module_names, r_name)))
     return r_name;

--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -584,6 +584,14 @@ static char *quickjsrb_module_normalize(JSContext *ctx, const char *base_name, c
   if (!NIL_P(r_cached_canonical))
     return js_strdup(ctx, StringValueCStr(r_cached_canonical));
 
+  // A preloaded name is already in ctx->loaded_modules, so js_find_loaded_module
+  // will hand back that module the moment we return the name. Resolving it here
+  // keeps the user's loader out of it entirely: it is never asked for a module
+  // the VM was constructed with, the way a browser's module map short-circuits
+  // a fetch.
+  if (RTEST(rb_hash_aref(data->preloaded_module_names, r_specifier)))
+    return js_strdup(ctx, StringValueCStr(r_specifier));
+
   struct module_loader_call_args args = {data->module_loader, r_specifier, r_importer};
   int state;
   VALUE r_return = rb_protect(r_module_loader_call, (VALUE)&args, &state);
@@ -630,7 +638,13 @@ static char *quickjsrb_module_normalize(JSContext *ctx, const char *base_name, c
     return NULL;
   }
 
-  rb_hash_aset(data->module_source_cache, r_canonical, r_source);
+  // The loader can also land on a preloaded module the long way round: an
+  // importmap-style scope maps a bare specifier to a canonical that was
+  // preloaded. QuickJS finds it in ctx->loaded_modules and never calls the
+  // load hook, so stashing the source it just handed us would leave an entry
+  // nothing ever clears.
+  if (!RTEST(rb_hash_aref(data->preloaded_module_names, r_canonical)))
+    rb_hash_aset(data->module_source_cache, r_canonical, r_source);
   rb_hash_aset(data->module_resolution_cache, r_key, r_canonical);
 
   return js_strdup(ctx, StringValueCStr(r_canonical));
@@ -1721,6 +1735,118 @@ static VALUE vm_m_compile(int argc, VALUE *argv, VALUE r_self)
   return rb_obj_freeze(r_bytecode);
 }
 
+// Stands in for the real loader while compiling a module to bytecode.
+//
+// __JS_EvalInternal runs js_resolve_module before it honors
+// JS_EVAL_FLAG_COMPILE_ONLY, so compiling `import { x } from 'dep'` tries to
+// load 'dep' — which would make a module impossible to compile without its
+// whole dependency graph on hand. Nothing about that resolution survives:
+// JS_WriteModule stores req_module_entries as the specifier written in the
+// source, never the module it resolved to, and export names aren't checked
+// until js_link_module at evaluation time. So an empty stub satisfies the
+// compile and leaves no trace in the blob; the importing VM resolves the real
+// dependency through its own loader.
+//
+// The stubs do land in the compiling context's module map, so this must only
+// ever run on a throwaway VM — otherwise a later real import of 'dep' on that
+// VM would find the empty stub.
+static JSModuleDef *quickjsrb_stub_module_loader(JSContext *ctx, const char *module_name, void *opaque, JSValueConst attributes)
+{
+  static const char *empty_module = "export {};";
+  JSValue j_stub = JS_Eval(ctx, empty_module, strlen(empty_module), module_name,
+                           JS_EVAL_TYPE_MODULE | JS_EVAL_FLAG_COMPILE_ONLY);
+  if (JS_IsException(j_stub))
+    return NULL;
+
+  JSModuleDef *m = JS_VALUE_GET_PTR(j_stub);
+  JS_FreeValue(ctx, j_stub);
+  return m;
+}
+
+// Compiles source as an ES module and serializes it. Unlike vm_m_compile,
+// `name` is not a debug label: js_read_module rebuilds the JSModuleDef under
+// the name baked in here, so it is the module's identity in every VM that
+// later reads this blob. Quickjs.register_module keys the registry by that
+// same string, which is what keeps the two from drifting apart.
+static VALUE vm_m_compileModule(VALUE r_self, VALUE r_code, VALUE r_name)
+{
+  VMData *data;
+  TypedData_Get_Struct(r_self, VMData, &vm_type, data);
+
+  check_disposed(data);
+  Check_Type(r_code, T_STRING);
+  Check_Type(r_name, T_STRING);
+
+  arm_eval_timer(data);
+
+  JS_SetModuleLoaderFunc2(JS_GetRuntime(data->context), NULL, quickjsrb_stub_module_loader,
+                          js_module_check_attributes, NULL);
+  JSValue j_mod = JS_Eval(data->context, RSTRING_PTR(r_code), RSTRING_LEN(r_code),
+                          StringValueCStr(r_name),
+                          JS_EVAL_TYPE_MODULE | JS_EVAL_FLAG_COMPILE_ONLY);
+  register_module_loader_funcs(data);
+  if (JS_IsException(j_mod))
+    return to_rb_value(data->context, j_mod); // raises
+
+  size_t out_len;
+  uint8_t *out_buf = JS_WriteObject(data->context, &out_len, j_mod, JS_WRITE_OBJ_BYTECODE);
+  JS_FreeValue(data->context, j_mod);
+  if (out_buf == NULL)
+  {
+    VALUE r_msg = rb_str_new2("failed to serialize compiled module bytecode");
+    rb_exc_raise(rb_funcall(QUICKJSRB_ERROR_FOR(QUICKJSRB_ROOT_RUNTIME_ERROR), rb_intern("new"), 2, r_msg, Qnil));
+  }
+
+  VALUE r_bytecode = rb_str_new((const char *)out_buf, (long)out_len);
+  rb_enc_associate(r_bytecode, rb_ascii8bit_encoding());
+  js_free(data->context, out_buf);
+  return rb_obj_freeze(r_bytecode);
+}
+
+// Reads module bytecode into this context. The read registers the JSModuleDef
+// in ctx->loaded_modules but does not evaluate it: evaluation still happens on
+// first import, and js_resolve_module recurses into it from the importer, so
+// no loader hook is involved for a preloaded name.
+//
+// The baked-in name is recorded in preloaded_module_names for the normalize
+// hook's short-circuit, and returned so the Ruby layer can assert it matches
+// the registry key.
+static VALUE vm_m_preloadModuleBytecode(VALUE r_self, VALUE r_bytecode)
+{
+  VMData *data;
+  TypedData_Get_Struct(r_self, VMData, &vm_type, data);
+
+  StringValue(r_bytecode);
+  check_disposed(data);
+  check_oom_poisoned(data);
+
+  JSValue j_mod = JS_ReadObject(data->context, (const uint8_t *)RSTRING_PTR(r_bytecode),
+                                (size_t)RSTRING_LEN(r_bytecode), JS_READ_OBJ_BYTECODE);
+  if (JS_IsException(j_mod))
+    return to_rb_value(data->context, j_mod); // raises
+
+  if (JS_VALUE_GET_TAG(j_mod) != JS_TAG_MODULE)
+  {
+    JS_FreeValue(data->context, j_mod);
+    rb_raise(rb_eTypeError, "bytecode is not an ES module (compile it with type: :module)");
+  }
+
+  js_module_set_import_meta(data->context, j_mod, FALSE, FALSE);
+
+  JSAtom j_name = JS_GetModuleName(data->context, JS_VALUE_GET_PTR(j_mod));
+  const char *name = JS_AtomToCString(data->context, j_name);
+  VALUE r_name = rb_str_new_cstr(name ? name : "");
+  if (name)
+    JS_FreeCString(data->context, name);
+  JS_FreeAtom(data->context, j_name);
+  rb_hash_aset(data->preloaded_module_names, rb_str_freeze(r_name), Qtrue);
+
+  // The module def is owned by ctx->loaded_modules (js_new_module_def leaves
+  // it there with ref_count 1); JS_NewModuleValue dup'd it for us.
+  JS_FreeValue(data->context, j_mod);
+  return r_name;
+}
+
 static VALUE vm_m_evalBytecode(VALUE r_self, VALUE r_bytecode)
 {
   VMData *data;
@@ -2307,6 +2433,8 @@ RUBY_FUNC_EXPORTED void Init_quickjsrb(void)
   rb_define_method(r_class_vm, "initialize", vm_m_initialize, -1);
   rb_define_method(r_class_vm, "eval_code", vm_m_evalCode, -1);
   rb_define_private_method(r_class_vm, "_compile_to_bytecode", vm_m_compile, -1);
+  rb_define_private_method(r_class_vm, "_compile_module_to_bytecode", vm_m_compileModule, 2);
+  rb_define_private_method(r_class_vm, "_preload_module_bytecode", vm_m_preloadModuleBytecode, 1);
   rb_define_private_method(r_class_vm, "_run_bytecode", vm_m_evalBytecode, 1);
   rb_define_private_method(r_class_vm, "_load_polyfill_bytecode", vm_m_loadPolyfillBytecode, 1);
   rb_define_method(r_class_vm, "call", vm_m_callGlobalFunction, -1);

--- a/ext/quickjsrb/quickjsrb.h
+++ b/ext/quickjsrb/quickjsrb.h
@@ -64,6 +64,12 @@ typedef struct VMData
   // JS_Eval that follows. Keyed by canonical; populated when the user's
   // loader returns either a raw source String or `{ code:, as: }`.
   VALUE module_source_cache;
+  // Set (name → Qtrue) of modules read into this context by
+  // _preload_module_bytecode. QuickJS calls normalize *before* it looks in
+  // ctx->loaded_modules, so without this the normalize hook would ask the
+  // user's loader for a module that is already loaded — and raise
+  // ReferenceError when the loader doesn't know the name.
+  VALUE preloaded_module_names;
   JSValue j_file_proxy_creator;
   // Once the runtime has hit JS-level "out of memory", the QuickJS heap is in
   // a fragile state where further evaluation can trigger a use-after-free in
@@ -169,6 +175,7 @@ static void vm_mark(void *ptr)
   rb_gc_mark_movable(data->on_unhandled_rejection);
   rb_gc_mark_movable(data->module_resolution_cache);
   rb_gc_mark_movable(data->module_source_cache);
+  rb_gc_mark_movable(data->preloaded_module_names);
 }
 
 static void vm_compact(void *ptr)
@@ -181,6 +188,7 @@ static void vm_compact(void *ptr)
   data->on_unhandled_rejection = rb_gc_location(data->on_unhandled_rejection);
   data->module_resolution_cache = rb_gc_location(data->module_resolution_cache);
   data->module_source_cache = rb_gc_location(data->module_source_cache);
+  data->preloaded_module_names = rb_gc_location(data->preloaded_module_names);
 }
 
 static const rb_data_type_t vm_type = {
@@ -217,6 +225,7 @@ static VALUE vm_alloc(VALUE r_self)
   data->on_unhandled_rejection = Qnil;
   data->module_resolution_cache = rb_hash_new();
   data->module_source_cache = rb_hash_new();
+  data->preloaded_module_names = rb_hash_new();
   data->j_file_proxy_creator = JS_UNDEFINED;
   data->oom_poisoned = false;
   data->disposed = false;

--- a/lib/quickjs.rb
+++ b/lib/quickjs.rb
@@ -9,6 +9,7 @@ require_relative "quickjs/function"
 require_relative "quickjs/quickjsrb"
 require_relative "quickjs/runnable"
 require_relative "quickjs/polyfills"
+require_relative "quickjs/modules"
 
 module Quickjs
   class Blob

--- a/lib/quickjs/modules.rb
+++ b/lib/quickjs/modules.rb
@@ -58,7 +58,7 @@ module Quickjs
           compiled
         end
       }
-      vm.send(:_preload_module_bytecode, bytecode)
+      vm.send(:_preload_module_bytecode, bytecode, name)
     end
   end
 

--- a/lib/quickjs/modules.rb
+++ b/lib/quickjs/modules.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+module Quickjs
+  # Process-wide registry of ES modules; entries are lazily compiled to
+  # bytecode on first use and the bytecode is reused across VMs.
+  @_modules = {}
+
+  # `name` is the module's canonical name: the string JS code writes in its
+  # `import` statement, and the name QuickJS keys its module map by. It is
+  # baked into the compiled bytecode, so registering under it is what keeps
+  # the registry key and the module's identity from drifting apart.
+  #
+  # `source:` accepts either a `String` (eager) or a `Proc` returning one
+  # (lazy). The lazy form lets a gem register a module at require time
+  # without paying the file-read cost unless a VM actually preloads it.
+  #
+  # Registering only makes the module available; a VM picks it up with
+  # `VM.new(preload_modules: [name])`. Reading a module into a VM costs
+  # real time whether or not it ends up imported, so preloading is a
+  # per-VM decision rather than something registration forces on every VM.
+  def self.register_module(name, source:)
+    raise ::TypeError, "name must be a String, got #{name.class}" unless name.is_a?(String)
+    raise ::TypeError, "source: must be a String or Proc, got #{source.class}" unless source.is_a?(String) || source.is_a?(Proc)
+
+    @_modules[-name] = {source: source, bytecode: nil, mutex: Mutex.new}
+    nil
+  end
+
+  def self._module_registered?(name)
+    @_modules.key?(name)
+  end
+
+  def self._unregister_module(name)
+    @_modules.delete(name)
+    nil
+  end
+
+  def self._preload_modules(vm, names)
+    names.each do |name|
+      raise ::TypeError, "preload_modules: entries must be Strings, got #{name.class}" unless name.is_a?(String)
+
+      entry = @_modules[name]
+      unless entry
+        raise ::ArgumentError,
+          "#{name.inspect} is not a registered module; call Quickjs.register_module(#{name.inspect}, source: ...) first"
+      end
+
+      # Same locking as registered polyfills: `||=` alone isn't atomic
+      # because compilation yields the GVL, so threads racing to construct
+      # VMs could double-compile, or a loser could read entry[:source]
+      # after the winner cleared it. A compile failure leaves bytecode nil
+      # and source intact so a later VM can retry. The unlocked first read
+      # keeps the hot path off the lock once the bytecode exists.
+      bytecode = entry[:bytecode] || entry[:mutex].synchronize {
+        entry[:bytecode] ||= begin
+          compiled = _compile_registered_module(entry, name)
+          entry[:source] = nil # let the Proc's captured scope be GC'd
+          compiled
+        end
+      }
+      vm.send(:_preload_module_bytecode, bytecode)
+    end
+  end
+
+  # Compiled on a disposable VM: compilation installs a stub module loader
+  # to satisfy QuickJS's compile-time import resolution, and those stubs
+  # land in the compiling context's module map, so it must not be a VM
+  # anyone goes on to use. The generous timeout covers parsing large
+  # bundles, since the user's per-VM `timeout_msec` is a budget for their
+  # own JS. `features: []` keeps registered polyfills off the temp VM.
+  def self._compile_registered_module(entry, name)
+    source = entry[:source]
+    source = source.call if source.is_a?(Proc)
+    unless source.is_a?(String)
+      raise ::TypeError, "source: Proc for #{name.inspect} must return a String, got #{source.class}"
+    end
+
+    vm = VM.new(timeout_msec: 60_000, features: [])
+    vm.send(:_compile_module_to_bytecode, source, name)
+  ensure
+    vm&.dispose!
+  end
+
+  module ModulePreloader
+    def initialize(preload_modules: [], **opts)
+      super(**opts)
+      unless preload_modules.is_a?(Array)
+        raise ::TypeError, "preload_modules: must be an Array, got #{preload_modules.class}"
+      end
+
+      Quickjs._preload_modules(self, preload_modules)
+    end
+  end
+
+  # Prepended after PolyfillLoader so polyfills are installed first: a
+  # module body can reach for a polyfilled global when it evaluates.
+  VM.prepend(ModulePreloader) unless VM.ancestors.include?(ModulePreloader)
+end

--- a/sig/quickjs.rbs
+++ b/sig/quickjs.rbs
@@ -15,13 +15,15 @@ module Quickjs
 
   def self.register_polyfill: (Symbol name, source: String | ^() -> String, ?init: String?) -> nil
 
+  def self.register_module: (String name, source: String | ^() -> String) -> nil
+
   class Value
     UNDEFINED: Symbol
     NAN: Symbol
   end
 
   class VM
-    def initialize: (?features: Array[Symbol], ?memory_limit: Integer, ?max_stack_size: Integer, ?timeout_msec: Integer) -> void
+    def initialize: (?features: Array[Symbol], ?preload_modules: Array[String], ?memory_limit: Integer, ?max_stack_size: Integer, ?timeout_msec: Integer) -> void
 
     def eval_code: (String code, ?async: bool, ?filename: String) -> untyped
 

--- a/test/quickjs_module_bytecode_test.rb
+++ b/test/quickjs_module_bytecode_test.rb
@@ -94,6 +94,22 @@ describe "module bytecode primitives" do
       vm.import(['who'], filename: 'aliased')
 
       _(vm.eval_code('who()')).must_equal 'preloaded'
+      # The load hook never fires on this path (QuickJS finds the preloaded
+      # module first), so the source the loader handed us must not be stashed
+      # for it: nothing would ever clear the entry, and it is the seam where a
+      # second instance of the module could come back through the alias.
+      _(vm.send(:_pending_module_source_count)).must_equal 0
+    end
+
+    it "clears the stashed source once a loader-provided module is loaded" do
+      vm = Quickjs::VM.new
+      vm.module_loader = ->(specifier, _importer) {
+        "export const who = () => 'from-loader';" if specifier == 'plain'
+      }
+      vm.import(['who'], filename: 'plain')
+
+      _(vm.eval_code('who()')).must_equal 'from-loader'
+      _(vm.send(:_pending_module_source_count)).must_equal 0
     end
 
     it "still routes the preloaded module's own imports through the loader" do

--- a/test/quickjs_module_bytecode_test.rb
+++ b/test/quickjs_module_bytecode_test.rb
@@ -20,7 +20,7 @@ describe "module bytecode primitives" do
     _(bytecode).must_be :frozen?
 
     vm = Quickjs::VM.new
-    _(vm.send(:_preload_module_bytecode, bytecode)).must_equal 'lib'
+    _(vm.send(:_preload_module_bytecode, bytecode, 'lib')).must_equal 'lib'
     vm.import(['hi'], filename: 'lib')
 
     _(vm.eval_code('hi()')).must_equal 'hello'
@@ -34,13 +34,13 @@ describe "module bytecode primitives" do
     classic = Quickjs.compile("1 + 1;").to_s
 
     _ {
-      Quickjs::VM.new.send(:_preload_module_bytecode, classic)
+      Quickjs::VM.new.send(:_preload_module_bytecode, classic, 'classic')
     }.must_raise TypeError
   end
 
   it "rejects a blob that isn't bytecode at all" do
     _ {
-      Quickjs::VM.new.send(:_preload_module_bytecode, 'not bytecode')
+      Quickjs::VM.new.send(:_preload_module_bytecode, 'not bytecode', 'junk')
     }.must_raise Quickjs::SyntaxError
   end
 
@@ -51,7 +51,7 @@ describe "module bytecode primitives" do
 
     it "resolves without any module_loader set" do
       vm = Quickjs::VM.new
-      vm.send(:_preload_module_bytecode, @bytecode)
+      vm.send(:_preload_module_bytecode, @bytecode, 'lib')
       vm.import(['who'], filename: 'lib')
 
       _(vm.eval_code('who()')).must_equal 'preloaded'
@@ -64,7 +64,7 @@ describe "module bytecode primitives" do
       vm = Quickjs::VM.new
       asked = []
       vm.module_loader = ->(specifier, _importer) { asked << specifier; nil }
-      vm.send(:_preload_module_bytecode, @bytecode)
+      vm.send(:_preload_module_bytecode, @bytecode, 'lib')
       vm.import(['who'], filename: 'lib')
 
       _(vm.eval_code('who()')).must_equal 'preloaded'
@@ -78,7 +78,7 @@ describe "module bytecode primitives" do
         asked << specifier
         "export const who = () => 'from-loader';"
       }
-      vm.send(:_preload_module_bytecode, @bytecode)
+      vm.send(:_preload_module_bytecode, @bytecode, 'lib')
       vm.import(['who'], filename: 'lib')
 
       _(vm.eval_code('who()')).must_equal 'preloaded'
@@ -90,7 +90,7 @@ describe "module bytecode primitives" do
       vm.module_loader = ->(specifier, _importer) {
         {code: 'export const who = () => "unused";', as: 'lib'} if specifier == 'aliased'
       }
-      vm.send(:_preload_module_bytecode, @bytecode)
+      vm.send(:_preload_module_bytecode, @bytecode, 'lib')
       vm.import(['who'], filename: 'aliased')
 
       _(vm.eval_code('who()')).must_equal 'preloaded'
@@ -120,7 +120,7 @@ describe "module bytecode primitives" do
         seen << [specifier, importer]
         "export const d = () => 'dep';" if specifier == 'dep'
       }
-      vm.send(:_preload_module_bytecode, bytecode)
+      vm.send(:_preload_module_bytecode, bytecode, 'lib')
       vm.import(['combined'], filename: 'lib')
 
       _(vm.eval_code('combined()')).must_equal 'pre+dep'
@@ -132,10 +132,10 @@ describe "module bytecode primitives" do
     bytecode = compile_module("const s = { n: 0 };\nexport const inc = () => ++s.n;", 'counter')
 
     vm1 = Quickjs::VM.new
-    vm1.send(:_preload_module_bytecode, bytecode)
+    vm1.send(:_preload_module_bytecode, bytecode, 'counter')
     vm1.import(['inc'], filename: 'counter')
     vm2 = Quickjs::VM.new
-    vm2.send(:_preload_module_bytecode, bytecode)
+    vm2.send(:_preload_module_bytecode, bytecode, 'counter')
     vm2.import(['inc'], filename: 'counter')
 
     _(vm1.eval_code('inc()')).must_equal 1
@@ -143,11 +143,61 @@ describe "module bytecode primitives" do
     _(vm2.eval_code('inc()')).must_equal 1
   end
 
+  describe "preloading the same module twice" do
+    before do
+      @bytecode = compile_module("const s = { n: 0 };\nexport const inc = () => ++s.n;", 'counter')
+    end
+
+    # js_read_module appends a second JSModuleDef under the same name rather
+    # than replacing or rejecting, and js_find_loaded_module returns the first
+    # one it walks past, so a re-read leaves an orphan holding its bytecode for
+    # the life of the context.
+    it "reads the bytecode only once" do
+      vm = Quickjs::VM.new
+      vm.send(:_preload_module_bytecode, @bytecode, 'counter')
+      after_first = vm.memory_usage[:js_func_code_size]
+      vm.send(:_preload_module_bytecode, @bytecode, 'counter')
+
+      _(vm.memory_usage[:js_func_code_size]).must_equal after_first
+    end
+
+    it "keeps a single instance of the module" do
+      vm = Quickjs::VM.new
+      vm.send(:_preload_module_bytecode, @bytecode, 'counter')
+      vm.send(:_preload_module_bytecode, @bytecode, 'counter')
+      vm.import(['inc'], filename: 'counter')
+
+      _(vm.eval_code('inc()')).must_equal 1
+      _(vm.eval_code('inc()')).must_equal 2
+    end
+
+    it "tolerates a name listed twice in preload_modules:" do
+      Quickjs.register_module('_test_dup', source: 'export const x = 1;')
+      vm = Quickjs::VM.new(preload_modules: ['_test_dup'])
+      baseline = vm.memory_usage[:js_func_code_size]
+      vm.dispose!
+
+      vm = Quickjs::VM.new(preload_modules: ['_test_dup', '_test_dup'])
+
+      _(vm.memory_usage[:js_func_code_size]).must_equal baseline
+    ensure
+      Quickjs._unregister_module('_test_dup')
+    end
+  end
+
+  it "rejects bytecode whose baked name isn't the one it's filed under" do
+    bytecode = compile_module('export const x = 1;', 'actual')
+
+    _ {
+      Quickjs::VM.new.send(:_preload_module_bytecode, bytecode, 'claimed')
+    }.must_raise ArgumentError
+  end
+
   it "does not evaluate the module until it is imported" do
     bytecode = compile_module("globalThis.sideEffect = 'ran';\nexport const x = 1;", 'effectful')
 
     vm = Quickjs::VM.new
-    vm.send(:_preload_module_bytecode, bytecode)
+    vm.send(:_preload_module_bytecode, bytecode, 'effectful')
     _(vm.eval_code('typeof globalThis.sideEffect')).must_equal 'undefined'
 
     vm.import(['x'], filename: 'effectful')

--- a/test/quickjs_module_bytecode_test.rb
+++ b/test/quickjs_module_bytecode_test.rb
@@ -44,6 +44,15 @@ describe "module bytecode primitives" do
     }.must_raise Quickjs::SyntaxError
   end
 
+  it "rejects a non-String blob rather than coercing it" do
+    coercible = Object.new
+    def coercible.to_str = 'not bytecode'
+
+    _ {
+      Quickjs::VM.new.send(:_preload_module_bytecode, coercible, 'junk')
+    }.must_raise TypeError
+  end
+
   describe "resolution" do
     before do
       @bytecode = compile_module("export const who = () => 'preloaded';", 'lib')

--- a/test/quickjs_module_bytecode_test.rb
+++ b/test/quickjs_module_bytecode_test.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+# Low-level tests for the two primitives Quickjs.register_module is built on:
+# compiling an ES module to bytecode, and reading that bytecode into a VM.
+describe "module bytecode primitives" do
+  def compile_module(source, name)
+    vm = Quickjs::VM.new
+    vm.send(:_compile_module_to_bytecode, source, name)
+  ensure
+    vm&.dispose!
+  end
+
+  it "round-trips a module through bytecode" do
+    bytecode = compile_module("export const hi = () => 'hello';", 'lib')
+
+    _(bytecode).must_be_kind_of String
+    _(bytecode.encoding).must_equal Encoding::ASCII_8BIT
+    _(bytecode).must_be :frozen?
+
+    vm = Quickjs::VM.new
+    _(vm.send(:_preload_module_bytecode, bytecode)).must_equal 'lib'
+    vm.import(['hi'], filename: 'lib')
+
+    _(vm.eval_code('hi()')).must_equal 'hello'
+  end
+
+  it "raises on a syntax error in the module source" do
+    _ { compile_module("export const = ;", 'broken') }.must_raise Quickjs::SyntaxError
+  end
+
+  it "rejects bytecode that isn't an ES module" do
+    classic = Quickjs.compile("1 + 1;").to_s
+
+    _ {
+      Quickjs::VM.new.send(:_preload_module_bytecode, classic)
+    }.must_raise TypeError
+  end
+
+  it "rejects a blob that isn't bytecode at all" do
+    _ {
+      Quickjs::VM.new.send(:_preload_module_bytecode, 'not bytecode')
+    }.must_raise Quickjs::SyntaxError
+  end
+
+  describe "resolution" do
+    before do
+      @bytecode = compile_module("export const who = () => 'preloaded';", 'lib')
+    end
+
+    it "resolves without any module_loader set" do
+      vm = Quickjs::VM.new
+      vm.send(:_preload_module_bytecode, @bytecode)
+      vm.import(['who'], filename: 'lib')
+
+      _(vm.eval_code('who()')).must_equal 'preloaded'
+    end
+
+    # QuickJS calls the normalize hook before it looks in ctx->loaded_modules,
+    # so without the preloaded-name short-circuit this raised
+    # Quickjs::ReferenceError even though the module was already loaded.
+    it "resolves when a module_loader is set that doesn't know the name" do
+      vm = Quickjs::VM.new
+      asked = []
+      vm.module_loader = ->(specifier, _importer) { asked << specifier; nil }
+      vm.send(:_preload_module_bytecode, @bytecode)
+      vm.import(['who'], filename: 'lib')
+
+      _(vm.eval_code('who()')).must_equal 'preloaded'
+      _(asked).must_be_empty
+    end
+
+    it "wins over a module_loader that does know the name" do
+      vm = Quickjs::VM.new
+      asked = []
+      vm.module_loader = ->(specifier, _importer) {
+        asked << specifier
+        "export const who = () => 'from-loader';"
+      }
+      vm.send(:_preload_module_bytecode, @bytecode)
+      vm.import(['who'], filename: 'lib')
+
+      _(vm.eval_code('who()')).must_equal 'preloaded'
+      _(asked).must_be_empty
+    end
+
+    it "is reachable through a loader that maps a specifier onto the preloaded name" do
+      vm = Quickjs::VM.new
+      vm.module_loader = ->(specifier, _importer) {
+        {code: 'export const who = () => "unused";', as: 'lib'} if specifier == 'aliased'
+      }
+      vm.send(:_preload_module_bytecode, @bytecode)
+      vm.import(['who'], filename: 'aliased')
+
+      _(vm.eval_code('who()')).must_equal 'preloaded'
+    end
+
+    it "still routes the preloaded module's own imports through the loader" do
+      bytecode = compile_module("import { d } from 'dep';\nexport const combined = () => `pre+${d()}`;", 'lib')
+      vm = Quickjs::VM.new
+      seen = []
+      vm.module_loader = ->(specifier, importer) {
+        seen << [specifier, importer]
+        "export const d = () => 'dep';" if specifier == 'dep'
+      }
+      vm.send(:_preload_module_bytecode, bytecode)
+      vm.import(['combined'], filename: 'lib')
+
+      _(vm.eval_code('combined()')).must_equal 'pre+dep'
+      _(seen).must_equal [['dep', 'lib']]
+    end
+  end
+
+  it "gives each VM its own instance of the module" do
+    bytecode = compile_module("const s = { n: 0 };\nexport const inc = () => ++s.n;", 'counter')
+
+    vm1 = Quickjs::VM.new
+    vm1.send(:_preload_module_bytecode, bytecode)
+    vm1.import(['inc'], filename: 'counter')
+    vm2 = Quickjs::VM.new
+    vm2.send(:_preload_module_bytecode, bytecode)
+    vm2.import(['inc'], filename: 'counter')
+
+    _(vm1.eval_code('inc()')).must_equal 1
+    _(vm1.eval_code('inc()')).must_equal 2
+    _(vm2.eval_code('inc()')).must_equal 1
+  end
+
+  it "does not evaluate the module until it is imported" do
+    bytecode = compile_module("globalThis.sideEffect = 'ran';\nexport const x = 1;", 'effectful')
+
+    vm = Quickjs::VM.new
+    vm.send(:_preload_module_bytecode, bytecode)
+    _(vm.eval_code('typeof globalThis.sideEffect')).must_equal 'undefined'
+
+    vm.import(['x'], filename: 'effectful')
+    _(vm.eval_code('globalThis.sideEffect')).must_equal 'ran'
+  end
+end

--- a/test/quickjs_register_module_test.rb
+++ b/test/quickjs_register_module_test.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+describe "Quickjs.register_module" do
+  # Each test registers under a unique name and tears it down so tests
+  # don't leak registry state into each other.
+  before { @name = "_test_module_#{object_id}" }
+  after  { Quickjs._unregister_module(@name) }
+
+  it "rejects non-String names" do
+    _ {
+      Quickjs.register_module(:not_a_string, source: 'export const x = 1;')
+    }.must_raise TypeError
+  end
+
+  it "rejects non-String, non-Proc sources" do
+    _ {
+      Quickjs.register_module(@name, source: 42)
+    }.must_raise TypeError
+  end
+
+  it "is importable by a VM that preloads it" do
+    Quickjs.register_module(@name, source: 'export const greet = () => "hello";')
+    vm = Quickjs::VM.new(preload_modules: [@name])
+    vm.import(['greet'], filename: @name)
+
+    _(vm.eval_code('greet()')).must_equal 'hello'
+  end
+
+  it "accepts a Proc source and calls it lazily" do
+    calls = 0
+    Quickjs.register_module(@name, source: -> { calls += 1; 'export const x = 42;' })
+    _(calls).must_equal 0
+
+    vm = Quickjs::VM.new(preload_modules: [@name])
+    vm.import(['x'], filename: @name)
+
+    _(vm.eval_code('x')).must_equal 42
+    _(calls).must_equal 1
+  end
+
+  it "compiles once and reuses the bytecode across VMs" do
+    calls = 0
+    Quickjs.register_module(@name, source: -> { calls += 1; 'export const x = 1;' })
+
+    3.times { Quickjs::VM.new(preload_modules: [@name]).dispose! }
+
+    _(calls).must_equal 1
+  end
+
+  it "leaves the source intact when compilation fails, so a later VM can retry" do
+    sources = ['export const = ;', 'export const x = "recovered";']
+    Quickjs.register_module(@name, source: -> { sources.shift })
+
+    _ { Quickjs::VM.new(preload_modules: [@name]) }.must_raise Quickjs::SyntaxError
+
+    vm = Quickjs::VM.new(preload_modules: [@name])
+    vm.import(['x'], filename: @name)
+    _(vm.eval_code('x')).must_equal 'recovered'
+  end
+
+  it "raises when a Proc source doesn't return a String" do
+    Quickjs.register_module(@name, source: -> { 42 })
+
+    _ { Quickjs::VM.new(preload_modules: [@name]) }.must_raise TypeError
+  end
+
+  it "raises for a name that isn't registered" do
+    _ {
+      Quickjs::VM.new(preload_modules: ['_never_registered'])
+    }.must_raise ArgumentError
+  end
+
+  it "rejects Symbols in preload_modules:" do
+    Quickjs.register_module(@name, source: 'export const x = 1;')
+
+    _ {
+      Quickjs::VM.new(preload_modules: [@name.to_sym])
+    }.must_raise TypeError
+  end
+
+  it "rejects a non-Array preload_modules:" do
+    Quickjs.register_module(@name, source: 'export const x = 1;')
+
+    _ {
+      Quickjs::VM.new(preload_modules: @name)
+    }.must_raise TypeError
+  end
+
+  it "does not preload registered modules a VM didn't ask for" do
+    Quickjs.register_module(@name, source: 'export const x = 1;')
+    vm = Quickjs::VM.new
+
+    _ { vm.import(['x'], filename: @name) }.must_raise Quickjs::ReferenceError
+  end
+
+  it "replaces the entry when a name is registered again" do
+    Quickjs.register_module(@name, source: 'export const x = "first";')
+    Quickjs::VM.new(preload_modules: [@name]).dispose!
+    Quickjs.register_module(@name, source: 'export const x = "second";')
+
+    vm = Quickjs::VM.new(preload_modules: [@name])
+    vm.import(['x'], filename: @name)
+    _(vm.eval_code('x')).must_equal 'second'
+  end
+
+  it "preloads a registered module that imports another registered module" do
+    dep = "#{@name}_dep"
+    Quickjs.register_module(dep, source: 'export const d = () => "dep";')
+    Quickjs.register_module(@name, source: "import { d } from '#{dep}';\nexport const combined = () => `main+${d()}`;")
+
+    vm = Quickjs::VM.new(preload_modules: [dep, @name])
+    vm.import(['combined'], filename: @name)
+
+    _(vm.eval_code('combined()')).must_equal 'main+dep'
+  ensure
+    Quickjs._unregister_module(dep)
+  end
+
+  it "coexists with a module_loader that resolves everything else" do
+    Quickjs.register_module(@name, source: 'export const fromRegistry = () => "registry";')
+    vm = Quickjs::VM.new(preload_modules: [@name])
+    asked = []
+    vm.module_loader = ->(specifier, _importer) {
+      asked << specifier
+      'export const fromLoader = () => "loader";' if specifier == 'other'
+    }
+
+    vm.import(['fromRegistry'], filename: @name)
+    vm.import(['fromLoader'], filename: 'other')
+
+    _(vm.eval_code('fromRegistry() + "/" + fromLoader()')).must_equal 'registry/loader'
+    _(asked).must_equal ['other']
+  end
+
+  it "sees polyfilled globals from a preloaded module" do
+    Quickjs.register_module(@name, source: 'export const kind = typeof Blob;')
+    vm = Quickjs::VM.new(features: [Quickjs::POLYFILL_FILE], preload_modules: [@name])
+    vm.import(['kind'], filename: @name)
+
+    _(vm.eval_code('kind')).must_equal 'function'
+  end
+
+  it "compiles once across threads racing to construct VMs" do
+    calls = Queue.new
+    Quickjs.register_module(@name, source: -> { calls << 1; 'export const x = 1;' })
+
+    threads = Array.new(4) { Thread.new { Quickjs::VM.new(preload_modules: [@name]).dispose! } }
+    threads.each(&:join)
+
+    _(calls.size).must_equal 1
+  end
+end

--- a/test/quickjs_register_module_test.rb
+++ b/test/quickjs_register_module_test.rb
@@ -66,6 +66,33 @@ describe "Quickjs.register_module" do
     _ { Quickjs::VM.new(preload_modules: [@name]) }.must_raise TypeError
   end
 
+  # Module names cross into QuickJS as raw bytes and come back binary-encoded,
+  # so anything comparing them against the caller's UTF-8 name has to do it on
+  # bytes rather than with encoding-aware equality.
+  describe "a non-ASCII name" do
+    before { @jp = "_test_モジュール_#{object_id}" }
+    after  { Quickjs._unregister_module(@jp) }
+
+    it "is importable" do
+      Quickjs.register_module(@jp, source: 'export const 値 = "日本語";')
+      vm = Quickjs::VM.new(preload_modules: [@jp])
+      vm.import(['値'], filename: @jp)
+
+      _(vm.eval_code('値')).must_equal '日本語'
+    end
+
+    it "is deduplicated like any other" do
+      Quickjs.register_module(@jp, source: 'export const x = 1;')
+      vm = Quickjs::VM.new(preload_modules: [@jp])
+      baseline = vm.memory_usage[:js_func_code_size]
+      vm.dispose!
+
+      vm = Quickjs::VM.new(preload_modules: [@jp, @jp])
+
+      _(vm.memory_usage[:js_func_code_size]).must_equal baseline
+    end
+  end
+
   it "raises for a name that isn't registered" do
     _ {
       Quickjs::VM.new(preload_modules: ['_never_registered'])


### PR DESCRIPTION
Closes #65.

Adds `Quickjs.register_module`, which compiles an ES module to bytecode once per process so VMs can skip the parse:

```rb
Quickjs.register_module('lib', source: File.read('lib.js'))

vm = Quickjs::VM.new(preload_modules: ['lib'])
vm.import(['call'], filename: 'lib')
```

Measured on the 220KB module from the issue:

| | ms/VM |
|---|---|
| `VM.new` + `dispose!` (floor) | 0.100 |
| source via `module_loader` + import | 10.781 |
| preloaded + import | 1.869 |
| preloaded, never imported | 1.357 |

Import cost above the floor goes from 10.68ms to 1.77ms, a **6.0x** improvement, matching the number reported in the issue.

## Why registration and preloading are separate

Registration is process-wide, `preload_modules:` is per VM. The measurement above is the reason: reading a module into a context costs ~1.26ms per 220KB whether or not it is imported, so a registry that every VM read wholesale would lose to plain source loading as soon as a VM imported only part of it (10 registered / 1 imported measured at 13.3ms/VM, slower than doing nothing). This is also why browsers ask for `<link rel="modulepreload">` per document rather than preloading everything they know about.

## Naming

The registry is keyed by the canonical module name, the string JS writes in its `import` statement, which is also what gets baked into the bytecode. This is the main departure from the `{ code:, as: }` shape sketched in the issue: there the name is stated twice, and if the two disagree QuickJS registers the module under the baked name while later lookups go by canonical, silently producing two live instances of the same module. Keying by one string makes that unrepresentable.

## QuickJS details worth review

**Compilation cannot be done in isolation.** `__JS_EvalInternal` runs `js_resolve_module` before it honors `JS_EVAL_FLAG_COMPILE_ONLY`, so compiling `import { x } from 'dep'` tries to load `dep`. Nothing about that resolution is serialized (`JS_WriteModule` stores the specifier as written in the source, and export names are not checked until `js_link_module` at evaluation), so compilation installs a stub loader and the importing VM resolves dependencies through its own loader. The stubs land in the compiling context's module map, which is why `_compile_module_to_bytecode` has to stay private and compile on a disposable VM.

**Preloading needed a short-circuit in the normalize hook.** QuickJS calls normalize before consulting `ctx->loaded_modules`, so a preloaded name was still routed to the user's `module_loader`, which raised `Quickjs::ReferenceError` when that loader did not know the name. `VMData` now tracks preloaded names and normalize resolves them directly, which also keeps the loader from being asked for a module the VM already has.

**Preloading is idempotent.** `js_read_module` appends a second `JSModuleDef` under the same name rather than replacing or rejecting one, and `js_find_loaded_module` returns the first entry it walks past, so a re-read left an orphan holding its bytecode until the context was freed. The read cannot be taken back after the fact, so `_preload_module_bytecode` takes the name the caller expects the blob to carry and returns early when that name is already preloaded.

## Scope

Bytecode stays internal: no public `compile_module`, and no on-disk caching, so the bytecode versioning question (which `Runnable` also has today, handing out raw build-tied bytecode) is untouched here. `Quickjs.configure` for global defaults is deliberately left out; it makes more sense alongside a way to enable registered polyfills globally, which is a separate change.

## Review rounds

Thanks to @ursm and the automated review for the passes over this. What changed since the first push:

**Correctness**

- Preloading the same module into a VM twice is now a no-op, per the orphan-`JSModuleDef` problem above. `VM.new(preload_modules: ["lib", "lib"])` hit it.
- Module names are compared and keyed on bytes rather than with encoding-aware equality. A name crosses into QuickJS as a C string and comes back binary-encoded, while the caller's name is UTF-8 from the registry, so `Quickjs.register_module("ライブラリ", ...)` raised `ArgumentError` claiming the bytecode was named something else, and the same mismatch broke the dedup guard's lookup. This one was a regression introduced by the dedup guard itself and caught on a later re-read, so it is worth a second look from anyone who reviewed the earlier version.
- Bytecode arguments are refused rather than coerced, matching `vm_m_evalBytecode`. The invariant is that the disposed check sits after the last GVL-yield point and before the context is touched; refusing `to_str` coercion removes the yield point instead of ordering around it. #70 tracks the one remaining entry point still on the coerce-then-check form.

**Tests**

- `_pending_module_source_count`, so the "loader lands on a preloaded canonical" case asserts the source cache stays empty rather than trusting it. Reverting the skip fails that test and leaves the ordinary loader path passing.
- Preload-twice and non-ASCII-name cases assert against `memory_usage[:js_func_code_size]`, because the orphaned module def is invisible to behavior: the first-registered def always wins, so a behavioral test alone passes either way.

**Docs**

- Preloading grants the module to everything in that VM, including untrusted code using a dynamic `import()`. `module_loader` is the authorization point and preloading deliberately bypasses it for that name, so a module needing per-importer authorization should resolve through the loader instead of being preloaded (#71).
- A relative-looking canonical name (`./lib.js`) is not found when no `module_loader` is set, because QuickJS resolves it against the importing file before consulting the module map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
