### PR TITLE
Follow-ups to the polyfill load settle check

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,7 +430,7 @@ Quickjs.register_polyfill(
 
 The first VM with a given polyfill pays the parse cost (the source is compiled to QuickJS bytecode on a disposable VM with a generous timeout); subsequent VMs reuse the cached bytecode. The polyfill body runs without consuming the user VM's `timeout_msec` budget — that's reserved for user code.
 
-The polyfill's top level must settle synchronously — no top-level `await`. `VM.new(features:)` guarantees a usable polyfill on return, but loads don't drain the job queue, so nothing past the first `await` would have run by then. A polyfill left pending (and any top-level throw) raises a `Quickjs::RuntimeError` naming the feature at construction, rather than handing back a VM with the polyfill silently half-applied.
+The polyfill's top level must settle synchronously — no top-level `await`. `VM.new(features:)` guarantees a usable polyfill on return, but loads don't drain the job queue, so nothing past the first `await` would have run by then. A polyfill left pending raises a `Quickjs::NoAwaitError`, and any top-level throw raises the matching `Quickjs::RuntimeError` subclass, both naming the feature at construction, rather than handing back a VM with the polyfill silently half-applied.
 
 Intl APIs (Collator, DateTimeFormat, NumberFormat, PluralRules, Locale, etc.) live in a separate companion gem: [`quickjs-polyfill-intl`](https://github.com/hmsk/quickjs-polyfill-intl). Granular, dependency-aware, opt-in per API.
 

--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -1227,6 +1227,15 @@ static VALUE vm_m_initialize(int argc, VALUE *argv, VALUE r_self)
         quickjsrb_new_ruby_bridge(data->context, js_quickjsrb_set_timeout, "setTimeout", 2));
   }
 
+  // finish_polyfill_load raises (Ruby longjmp) on a load that fails or
+  // doesn't settle, so nothing holding a JSValue may stay live across the
+  // loads: the free at the bottom of this function would be skipped and
+  // the leaked reference pins its whole object graph past JS_FreeRuntime
+  // (the teardown GC only reclaims what's internally referenced, and the
+  // gc_obj_list assert is compiled out by -DNDEBUG). Drop the global here
+  // and re-acquire it below.
+  JS_FreeValue(data->context, j_global);
+
   if (RTEST(rb_funcall(r_features, rb_intern("include?"), 1, QUICKJSRB_SYM(featurePolyfillFileId))))
   {
     finish_polyfill_load(data, load_polyfill_bytecode(data, &qjsc_polyfill_file_min, qjsc_polyfill_file_min_size, false));
@@ -1243,6 +1252,8 @@ static VALUE vm_m_initialize(int argc, VALUE *argv, VALUE r_self)
   {
     finish_polyfill_load(data, load_polyfill_bytecode(data, &qjsc_polyfill_url_min, qjsc_polyfill_url_min_size, false));
   }
+
+  j_global = JS_GetGlobalObject(data->context);
 
   if (RTEST(rb_funcall(r_features, rb_intern("include?"), 1, QUICKJSRB_SYM(featurePolyfillCryptoId))))
   {

--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -1135,6 +1135,8 @@ static JSValue load_polyfill_bytecode(VMData *data, const uint8_t *buf, size_t b
 // drain the job queue, so nothing past the first await has run — refuse
 // loudly instead of shipping a silently half-applied VM; polyfill top
 // levels must settle synchronously (the register_polyfill contract).
+// That refusal reuses NoAwaitError, the same class eval_code raises for
+// a promise left unawaited at the top level.
 // Frees j_result on every path.
 static void finish_polyfill_load(VMData *data, JSValue j_result)
 {
@@ -1157,7 +1159,7 @@ static void finish_polyfill_load(VMData *data, JSValue j_result)
   {
     JS_FreeValue(data->context, j_result);
     VALUE r_msg = rb_str_new2("polyfill top level must settle synchronously: top-level await leaves the load pending and the polyfill silently half-applied");
-    rb_exc_raise(rb_funcall(QUICKJSRB_ERROR_FOR(QUICKJSRB_ROOT_RUNTIME_ERROR), rb_intern("new"), 2, r_msg, Qnil));
+    rb_exc_raise(rb_funcall(QUICKJSRB_ERROR_FOR(QUICKJSRB_NO_AWAIT_ERROR), rb_intern("new"), 2, r_msg, Qnil));
   }
 
   JS_FreeValue(data->context, j_result);

--- a/lib/quickjs/polyfills.rb
+++ b/lib/quickjs/polyfills.rb
@@ -15,7 +15,7 @@ module Quickjs
   # The polyfill's top level must settle synchronously — no top-level
   # await. `VM.new(features:)` promises a usable polyfill on return, but
   # loads never drain the job queue, so nothing past the first await
-  # would have run by then; a pending load raises Quickjs::RuntimeError
+  # would have run by then; a pending load raises Quickjs::NoAwaitError
   # instead of handing back a silently half-applied VM.
   #
   # Re-registering a name replaces the entry wholesale, lock included: a

--- a/test/quickjs_polyfill_test.rb
+++ b/test/quickjs_polyfill_test.rb
@@ -664,3 +664,17 @@ describe "PolyfillCrypto" do
     end
   end
 end
+
+# A bundled polyfill load that fails partway (here: OOM under a tight
+# memory_limit) used to have its result freed unchecked, so VM.new handed
+# back a VM with the polyfill's globals missing and the failure only
+# surfaced later, inside unrelated user code. Bundled loads go through the
+# same settle check as registered ones now.
+describe "bundled polyfill load failure" do
+  it "raises from VM.new instead of returning a half-applied VM" do
+    err = _ { ::Quickjs::VM.new(memory_limit: 80_000, features: [::Quickjs::POLYFILL_ENCODING]) }
+      .must_raise Quickjs::RuntimeError
+
+    _(err.message).must_match(/out of memory/)
+  end
+end

--- a/test/quickjs_register_polyfill_test.rb
+++ b/test/quickjs_register_polyfill_test.rb
@@ -132,12 +132,14 @@ describe "Quickjs.register_polyfill" do
   # run when VM.new returns — the load used to report success with the
   # polyfill's globals missing (and a throw behind the await, the same
   # PENDING shape at load time, was swallowed outright). PENDING is now an
-  # error: registered polyfill top-levels must settle synchronously. The
-  # message names the offending feature, since a VM can enable several.
+  # error: registered polyfill top-levels must settle synchronously. It
+  # reuses NoAwaitError, the class eval_code raises for a promise left
+  # unawaited at the top level, and the message names the offending
+  # feature, since a VM can enable several.
   it 'raises when the polyfill uses top-level await' do
     Quickjs.register_polyfill(@feature, source: 'await 0; throw new TypeError("never surfaces");')
 
-    err = _ { Quickjs::VM.new(features: [@feature]) }.must_raise Quickjs::RuntimeError
+    err = _ { Quickjs::VM.new(features: [@feature]) }.must_raise Quickjs::NoAwaitError
     _(err.message).must_match(/#{@feature}.*settle synchronously/)
   end
 

--- a/test/quickjs_register_polyfill_test.rb
+++ b/test/quickjs_register_polyfill_test.rb
@@ -128,6 +128,19 @@ describe "Quickjs.register_polyfill" do
     _(err.message).must_match(/polyfill exploded/)
   end
 
+  # _apply_registered_polyfills re-raises with the feature name prefixed,
+  # since the C layer only sees bytecode and a VM can enable several
+  # polyfills. `raise e, msg` clones rather than building a fresh error,
+  # so everything the original carried has to survive the prefixing.
+  it 'keeps the JS error class, js_name and JS backtrace when naming the feature' do
+    Quickjs.register_polyfill(@feature, source: 'throw new TypeError("polyfill exploded");')
+
+    err = _ { Quickjs::VM.new(features: [@feature]) }.must_raise Quickjs::TypeError
+    _(err.message).must_equal "#{@feature}: polyfill exploded"
+    _(err.js_name).must_equal 'TypeError'
+    _(err.backtrace.first).must_match(/#{@feature}:1/)
+  end
+
   # Loads never drain the job queue, so nothing past a top-level await has
   # run when VM.new returns — the load used to report success with the
   # polyfill's globals missing (and a throw behind the await, the same


### PR DESCRIPTION
Follow-ups to #61, as promised in the merge comment. Three independent commits.

### Free the global object across polyfill loads in `VM.new`

#61 made `finish_polyfill_load` raise, and `vm_m_initialize` was holding its `JS_GetGlobalObject` reference from before the polyfill loads down to the free at the end of the function. The raise longjmps past that free, and the leaked reference pins the whole global object graph past `JS_FreeRuntime`: the teardown GC only reclaims what is internally referenced, and the `gc_obj_list` assert is compiled out by `-DNDEBUG`.

Over 3000 failing `VM.new` calls, growth per call drops from about 128KB to about 21KB. The remainder is pre-existing OOM residue that `main` shows on the same loop.

The test that comes with it covers the bundled load sites, which had no coverage for a failed load at all: under a tight `memory_limit` the encoding bundle OOMs mid-load, and before #61 that left `VM.new` returning a VM with `TextEncoder` missing.

### Raise `NoAwaitError` for a polyfill left pending

`Quickjs::NoAwaitError` already means "a promise was left unawaited at the top level", which is exactly what a polyfill load that never settles is. It subclasses `Quickjs::RuntimeError`, so the feature-prefixing rescue in `_apply_registered_polyfills` and any caller rescuing `RuntimeError` behave as before. Callers that want to tell "your polyfill awaited" from "your polyfill threw" now can.

### Assert the feature-prefixed re-raise keeps the error's identity

`_apply_registered_polyfills` re-raises with `raise e, msg`, which clones the exception rather than building a new one. Nothing covered that the clone keeps the mapped JS error class, `js_name`, and the JS backtrace, all of which a plain `raise Quickjs::RuntimeError, msg` would have dropped.

Full suite green locally: 500 runs, 783 assertions, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
