### PR TITLE
Document that preloading bypasses module_loader authorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,8 @@ Two consequences worth knowing:
 
 Preloading a name that isn't registered raises `ArgumentError`; names must be `String`s (a `Symbol` raises `TypeError`). `Quickjs._unregister_module(name)` removes an entry, which is mostly useful for keeping tests isolated.
 
+**Preloading grants the module to everything running in that VM**, including untrusted code reaching it with a dynamic `import()`, and whether or not your Ruby code ever imports it. `module_loader` is the authorization point, and preloading deliberately bypasses it for that name, so a loader that allows a module for some importers and denies it for others has no say over a preloaded one. If a module needs per-importer or per-scope authorization, resolve it through `module_loader` instead of preloading it, and accept the parse cost as the price of that control.
+
 #### `Quickjs::VM#on_unhandled_rejection`: 🚨 Catch promise rejections that have no handler
 
 Register a block to be notified when a JS Promise rejects with no `.catch` / `then(_, onRejected)` attached at the time of rejection — fire-and-forget chains, failed dynamic imports without `try`, etc.


### PR DESCRIPTION
Stacked on #66, targeting its branch since the section this edits is introduced there.

Addresses the review note on #66 about preloaded names bypassing `module_loader`.

## The mechanism is real

Verified against the branch: a host that preloads a module without importing it still exposes it to any code in that VM via dynamic `import()`, and the loader is never consulted.

```
exports on globalThis before import: "undefined"
untrusted dynamic import(): "capability"
loader consulted: []
```

## Why documenting rather than changing it

The bypass requires a host that both preloads a module into a VM and relies on the loader to deny that same module to some code in that VM. Those are contradictory instructions: `preload_modules:` is a per-VM decision meaning "this VM has this module". The remedy needs no API, only removing one array element and letting the module resolve through the loader, which is how per-importer scoping already works.

It is also the behavior chosen deliberately and reviewed on #66, matching how a browser's module map short-circuits its import map: once a module is in the map, the import map does not re-adjudicate it.

The two fixes proposed in the review are both worse than the gap:

- A separate `preload_authorizer:` proc puts a Ruby call back into the resolution path for preloaded names, which is the cost and the failure mode the short-circuit exists to remove, and adds public API for a case answered by not preloading.
- Re-using the loader for authorization recreates the incompatibility fixed earlier in #66: a loader that does not know a preloaded name returns nil and raises `Quickjs::ReferenceError` even though the module is already in the VM. The review concedes this may break existing deployments.

The suggestion to also seed `module_resolution_cache` on the preloaded path would add work rather than save it. The preloaded check is a single `rb_hash_aref` on an existing String, while the resolution-cache path allocates a 2-element Array key on every normalize call before it can look up.

So the actual gap is that a reader could be surprised. This turns the resolution rule into a stated security property with an explicit remedy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)