### PR TITLE
Refuse non-String polyfill bytecode instead of coercing it

### DIFF
--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -1983,10 +1983,17 @@ static VALUE vm_m_loadPolyfillBytecode(VALUE r_self, VALUE r_bytecode)
   VMData *data;
   TypedData_Get_Struct(r_self, VMData, &vm_type, data);
 
-  // StringValue can invoke a non-String argument's to_str, which may
-  // yield the GVL — run it before the disposed check so nothing below
-  // touches a context freed by a concurrent dispose! in that window.
-  StringValue(r_bytecode);
+  // The disposed check has to sit after the last GVL-yield point and before
+  // the context is touched. Refusing a to_str-able stand-in removes the yield
+  // instead of ordering around it: bytecode is a binary blob, so coercion buys
+  // nothing, and without it there is no window for a concurrent dispose! to
+  // free the context between the check and the load. Same guard as
+  // vm_m_evalBytecode and _preload_module_bytecode.
+  if (!RB_TYPE_P(r_bytecode, T_STRING))
+  {
+    VALUE r_class = rb_class_name(CLASS_OF(r_bytecode));
+    rb_raise(rb_eTypeError, "Bytecode must be a String, got %s", StringValueCStr(r_class));
+  }
 
   check_disposed(data);
   check_oom_poisoned(data);

--- a/test/quickjs_register_polyfill_test.rb
+++ b/test/quickjs_register_polyfill_test.rb
@@ -196,6 +196,21 @@ describe "Quickjs.register_polyfill" do
     vm&.dispose!
   end
 
+  # The disposed check has to sit after the last GVL-yield point and before
+  # the context is touched. Refusing the coercion is what removes the yield,
+  # so a to_str-able stand-in has to be rejected rather than accepted.
+  it "rejects a non-String blob rather than coercing it" do
+    vm = Quickjs::VM.new
+    coercible = Object.new
+    def coercible.to_str = 'this is not valid bytecode'
+
+    _ {
+      vm.send(:_load_polyfill_bytecode, coercible)
+    }.must_raise TypeError
+  ensure
+    vm&.dispose!
+  end
+
   # Same assertion on the GVL-held path (crypto latches a Ruby bridge, so
   # can_eval_gvl_free bails): the short-circuit lives in the shared core,
   # but only a test on each branch keeps it that way.


### PR DESCRIPTION
Closes #70. Follow-up to the review discussion on #66.

**Tidy, not a bugfix.** The previous ordering was safe, and so is `vm_m_evalBytecode`'s.

The invariant across the bytecode entry points is:

> the disposed check sits after the last GVL-yield point and before you touch the context

`vm_m_loadPolyfillBytecode` satisfied it by coercing first and checking after, since `StringValue` can run a non-String argument's `to_str` and yield there. `vm_m_evalBytecode` satisfies it the other way, by refusing the coercion so there is no yield to order around, and `_preload_module_bytecode` adopted that form in #66.

This makes the convention uniform. Bytecode is a binary blob, so there is no sensible `to_str`-able stand-in for one, and the strict guard gives a clearer error than a bare `StringValue` would. The ordering comment goes away with it: once the guard is in place there is nothing left to order, so a later edit cannot reintroduce the window by moving a line.

Credit to @ursm for the framing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)