### PR TITLE
Compile an ES module once and import it into any VM

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ It takes the same import shapes and `code_to_expose:` as an inline source, so sw
 
 Hold the `Importable` wherever the JS belongs — a constant in a gem, an attribute on a service object — and import it into as many VMs as you like. Nothing about it is process-global, which matters when several libraries in one app each ship their own JS: none of them has to agree with the others about anything.
 
-The module's name is generated, not taken from you. It is baked into the bytecode and becomes the module's identity in every VM that imports it, so generating it means two `Importable`s built independently can never collide. `filename:` only prefixes the generated name to keep stack traces readable (`renderer.js-3f9a...`); it is a label, not an identity. Each VM still gets its own instance of the module with its own module-level state, and importing the same `Importable` into one VM more than once reads the bytecode only the first time.
+The module's name is generated, not taken from you. It is baked into the bytecode and becomes the module's identity in every VM that imports it, so generating it means two `Importable`s built independently can never collide. `filename:` only prefixes the generated name to keep stack traces readable; it is a label, not an identity. `Importable#canonical_name` returns the generated one (`renderer.js-3f9a...`), which is what a `module_loader` means by `as:`. Each VM still gets its own instance of the module with its own module-level state, and importing the same `Importable` into one VM more than once reads the bytecode only the first time.
 
 Compilation happens eagerly, so defer it if the JS might never be used:
 
@@ -267,7 +267,7 @@ An imported module's own `import`s still resolve through `module_loader` on firs
 ```rb
 vm.import(['render'], from: RENDERER)
 vm.module_loader = ->(specifier, _importer) {
-  {as: RENDERER.name} if specifier == 'renderer'
+  {as: RENDERER.canonical_name} if specifier == 'renderer'
 }
 
 # JS elsewhere in the graph can now write: import { render } from 'renderer'

--- a/README.md
+++ b/README.md
@@ -262,7 +262,15 @@ def self.compiled = @compiled ||= Quickjs.compile_module(File.read('vendor/lib.j
 
 An imported module's own `import`s still resolve through `module_loader` on first use, and `module_loader` is never asked about the `Importable` itself.
 
-**Use this when the module's name is your own business.** If JS code elsewhere in the graph needs to write `import 'lib'` and have a `module_loader` resolve it, the module needs a name everyone agrees on, which is what `register_module` below is for.
+**Use this when the module's name is your own business.** If JS code elsewhere in the graph needs to write `import 'lib'` and have a `module_loader` resolve it, the module needs a name everyone agrees on, which is what `register_module` below is for. Or give the generated name a friendly alias on the VMs that want one, with a [redirect](#quickjsvmmodule_loader--resolve-import-specifiers-from-ruby):
+
+```rb
+vm.import(['render'], from: MyGem::MODULE)
+vm.module_loader = ->(specifier, _importer) {
+  {as: MyGem::MODULE.name} if specifier == 'my-gem'
+}
+# JS can now write: import { render } from 'my-gem'
+```
 
 #### `Quickjs.register_module`: 📦 Preload ES modules as bytecode
 

--- a/README.md
+++ b/README.md
@@ -239,25 +239,25 @@ When `module_loader=` is set, pass `filename:` to `import` instead of `from:` to
 `import(from: source)` reparses the module in every VM you import it into. `compile_module` parses once and returns a `Quickjs::Importable` you can import into any number of VMs, which is what `compile` does for classic scripts.
 
 ```rb
-module MyGem
-  MODULE = Quickjs.compile_module(File.read('vendor/lib.js'), filename: 'my_gem/lib.js')
+RENDERER = Quickjs.compile_module(File.read('vendor/renderer.js'), filename: 'renderer.js')
 
-  def self.new_vm
-    vm = Quickjs::VM.new
-    vm.import(['render'], from: MODULE)
-    vm
-  end
-end
+vm = Quickjs::VM.new
+vm.import(['render'], from: RENDERER)   # no parse cost, on this VM or any other
+vm.eval_code('render({ id: 1 })')
 ```
 
 It takes the same import shapes and `code_to_expose:` as an inline source, so switching an existing `from:` a `String` to `from:` an `Importable` is the only change needed.
 
-The module's name is generated, not taken from you. It is baked into the bytecode and becomes the module's identity in every VM that imports it, so generating it means two `Importable`s built independently can never collide. `filename:` only prefixes the generated name to keep stack traces readable (`my_gem/lib.js-3f9a...`); it is a label, not an identity. Each VM still gets its own instance of the module with its own module-level state, and importing the same `Importable` into one VM more than once reads the bytecode only the first time.
+Hold the `Importable` wherever the JS belongs — a constant in a gem, an attribute on a service object — and import it into as many VMs as you like. Nothing about it is process-global, which matters when several libraries in one app each ship their own JS: none of them has to agree with the others about anything.
 
-Compilation happens eagerly, so a gem that may never be used should defer it:
+The module's name is generated, not taken from you. It is baked into the bytecode and becomes the module's identity in every VM that imports it, so generating it means two `Importable`s built independently can never collide. `filename:` only prefixes the generated name to keep stack traces readable (`renderer.js-3f9a...`); it is a label, not an identity. Each VM still gets its own instance of the module with its own module-level state, and importing the same `Importable` into one VM more than once reads the bytecode only the first time.
+
+Compilation happens eagerly, so defer it if the JS might never be used:
 
 ```rb
-def self.compiled = @compiled ||= Quickjs.compile_module(File.read('vendor/lib.js'))
+def self.renderer
+  @renderer ||= Quickjs.compile_module(File.read('vendor/renderer.js'))
+end
 ```
 
 An imported module's own `import`s still resolve through `module_loader` on first use, and `module_loader` is never asked about the `Importable` itself.
@@ -265,11 +265,12 @@ An imported module's own `import`s still resolve through `module_loader` on firs
 **Use this when the module's name is your own business.** If JS code elsewhere in the graph needs to write `import 'lib'` and have a `module_loader` resolve it, the module needs a name everyone agrees on, which is what `register_module` below is for. Or give the generated name a friendly alias on the VMs that want one, with a [redirect](#quickjsvmmodule_loader--resolve-import-specifiers-from-ruby):
 
 ```rb
-vm.import(['render'], from: MyGem::MODULE)
+vm.import(['render'], from: RENDERER)
 vm.module_loader = ->(specifier, _importer) {
-  {as: MyGem::MODULE.name} if specifier == 'my-gem'
+  {as: RENDERER.name} if specifier == 'renderer'
 }
-# JS can now write: import { render } from 'my-gem'
+
+# JS elsewhere in the graph can now write: import { render } from 'renderer'
 ```
 
 #### `Quickjs.register_module`: 📦 Preload ES modules as bytecode

--- a/README.md
+++ b/README.md
@@ -234,6 +234,36 @@ When `module_loader=` is set, pass `filename:` to `import` instead of `from:` to
 
 `import` awaits the module's top-level evaluation — top-level `await`, synchronous body execution, and any chained dynamic `import()`. The call blocks until the module's settle promise resolves. A top-level throw, a failed dynamic `import()`, or a rejected top-level `await` propagates back to Ruby as the matching `Quickjs::*Error` instead of being silently dropped.
 
+#### `Quickjs.compile_module`: 🧊 Compile a module once and import it anywhere
+
+`import(from: source)` reparses the module in every VM you import it into. `compile_module` parses once and returns a `Quickjs::Importable` you can import into any number of VMs, which is what `compile` does for classic scripts.
+
+```rb
+module MyGem
+  MODULE = Quickjs.compile_module(File.read('vendor/lib.js'), filename: 'my_gem/lib.js')
+
+  def self.new_vm
+    vm = Quickjs::VM.new
+    vm.import(['render'], from: MODULE)
+    vm
+  end
+end
+```
+
+It takes the same import shapes and `code_to_expose:` as an inline source, so switching an existing `from:` a `String` to `from:` an `Importable` is the only change needed.
+
+The module's name is generated, not taken from you. It is baked into the bytecode and becomes the module's identity in every VM that imports it, so generating it means two `Importable`s built independently can never collide. `filename:` only prefixes the generated name to keep stack traces readable (`my_gem/lib.js-3f9a...`); it is a label, not an identity. Each VM still gets its own instance of the module with its own module-level state, and importing the same `Importable` into one VM more than once reads the bytecode only the first time.
+
+Compilation happens eagerly, so a gem that may never be used should defer it:
+
+```rb
+def self.compiled = @compiled ||= Quickjs.compile_module(File.read('vendor/lib.js'))
+```
+
+An imported module's own `import`s still resolve through `module_loader` on first use, and `module_loader` is never asked about the `Importable` itself.
+
+**Use this when the module's name is your own business.** If JS code elsewhere in the graph needs to write `import 'lib'` and have a `module_loader` resolve it, the module needs a name everyone agrees on, which is what `register_module` below is for.
+
 #### `Quickjs.register_module`: 📦 Preload ES modules as bytecode
 
 A module resolved through `module_loader` is parsed again by every VM that imports it. `register_module` parses it once per process and hands each VM the compiled bytecode instead, which is the same trick `compile` plays for classic scripts. On a 220KB module that takes importing from ~10.7ms to ~1.8ms per VM.

--- a/lib/quickjs.rb
+++ b/lib/quickjs.rb
@@ -10,6 +10,7 @@ require_relative "quickjs/quickjsrb"
 require_relative "quickjs/runnable"
 require_relative "quickjs/polyfills"
 require_relative "quickjs/modules"
+require_relative "quickjs/importable"
 
 module Quickjs
   class Blob

--- a/lib/quickjs/importable.rb
+++ b/lib/quickjs/importable.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+module Quickjs
+  # An ES module compiled to bytecode once and importable into any number of
+  # VMs without reparsing. The module-map counterpart of `Runnable`, which does
+  # the same for classic scripts.
+  #
+  # Unlike `Quickjs.register_module`, nothing about this is process-global:
+  # hold the object, drop it when you're done. That matters for a library that
+  # ships JS of its own, since a global registry would make unrelated gems
+  # coordinate on a name none of their VMs ever share.
+  class Importable
+    attr_reader :name
+
+    def initialize(bytecode, name)
+      @bytecode = bytecode
+      @name = name
+    end
+
+    def inspect
+      "#<#{self.class} #{@name} (#{@bytecode.bytesize} bytes)>"
+    end
+
+    private
+
+    # Deliberately not public. Handing out the blob would invite persisting it,
+    # and the bytecode format is tied to the QuickJS build with only a one-byte
+    # version tag to catch a mismatch.
+    def bytecode
+      @bytecode
+    end
+  end
+
+  # Compiles `source` as an ES module and returns an `Importable`.
+  #
+  # The module's name is generated rather than taken from the caller, because
+  # it is baked into the bytecode and becomes the module's identity in every VM
+  # that imports it. Generating it means two independently built Importables
+  # can never collide, which is the whole point when the JS ships inside a gem.
+  # `filename:` prefixes the generated name so stack traces stay readable; it is
+  # a label, not an identity.
+  #
+  # Compiles on a disposable VM: compilation installs a stub module loader to
+  # satisfy QuickJS's compile-time import resolution, and those stubs land in
+  # the compiling context's module map. The default timeout is generous because
+  # a VM's `timeout_msec` is a budget for its own JS, not for parsing.
+  def self.compile_module(source, filename: nil, **opts)
+    raise ::TypeError, "source must be a String, got #{source.class}" unless source.is_a?(String)
+    unless filename.nil? || filename.is_a?(String)
+      raise ::TypeError, "filename: must be a String, got #{filename.class}"
+    end
+
+    name = "#{filename || 'module'}-#{SecureRandom.hex(8)}"
+    vm = VM.new(**{timeout_msec: 60_000, features: []}.merge(opts))
+    Importable.new(vm.send(:_compile_module_to_bytecode, source, name), name)
+  ensure
+    vm&.dispose!
+  end
+
+  module ImportableSupport
+    # `from:` an Importable reads the bytecode into this VM and then imports it
+    # by name, so it takes the same path a preloaded module does: resolution
+    # finds it in the module map and `module_loader` is never asked about it.
+    # Reading is idempotent, so importing the same Importable repeatedly costs
+    # nothing after the first.
+    def import(imported, **opts)
+      importable = opts[:from]
+      return super unless importable.is_a?(Importable)
+
+      send(:_preload_module_bytecode, importable.send(:bytecode), importable.name)
+      super(imported, **opts.except(:from), filename: importable.name)
+    end
+  end
+
+  VM.prepend(ImportableSupport) unless VM.ancestors.include?(ImportableSupport)
+end

--- a/lib/quickjs/importable.rb
+++ b/lib/quickjs/importable.rb
@@ -10,15 +10,19 @@ module Quickjs
   # ships JS of its own, since a global registry would make unrelated gems
   # coordinate on a name none of their VMs ever share.
   class Importable
-    attr_reader :name
+    # The name QuickJS keys its module map by, the same thing a module_loader
+    # calls `as:`. Not the `filename:` that was passed in: that is only a
+    # prefix of this. Useful for pointing a loader at this module by a
+    # friendlier specifier.
+    attr_reader :canonical_name
 
-    def initialize(bytecode, name)
+    def initialize(bytecode, canonical_name)
       @bytecode = bytecode
-      @name = name
+      @canonical_name = canonical_name
     end
 
     def inspect
-      "#<#{self.class} #{@name} (#{@bytecode.bytesize} bytes)>"
+      "#<#{self.class} #{@canonical_name} (#{@bytecode.bytesize} bytes)>"
     end
 
     private
@@ -67,8 +71,8 @@ module Quickjs
       importable = opts[:from]
       return super unless importable.is_a?(Importable)
 
-      send(:_preload_module_bytecode, importable.send(:bytecode), importable.name)
-      super(imported, **opts.except(:from), filename: importable.name)
+      send(:_preload_module_bytecode, importable.send(:bytecode), importable.canonical_name)
+      super(imported, **opts.except(:from), filename: importable.canonical_name)
     end
   end
 

--- a/sig/quickjs.rbs
+++ b/sig/quickjs.rbs
@@ -17,6 +17,12 @@ module Quickjs
 
   def self.register_module: (String name, source: String | ^() -> String) -> nil
 
+  def self.compile_module: (String source, ?filename: String?, **untyped) -> Quickjs::Importable
+
+  class Importable
+    attr_reader name: String
+  end
+
   class Value
     UNDEFINED: Symbol
     NAN: Symbol
@@ -34,7 +40,7 @@ module Quickjs
     def define_function: (String | Symbol name, *Symbol flags) { (*untyped) -> untyped } -> Symbol
                        | (Array[String | Symbol] path, *Symbol flags) { (*untyped) -> untyped } -> Array[Symbol]
 
-    def import: (String | Array[String] | Hash[Symbol, String] imported, from: String, ?code_to_expose: String?) -> true
+    def import: (String | Array[String] | Hash[Symbol, String] imported, from: String | Quickjs::Importable, ?code_to_expose: String?) -> true
               | (String | Array[String] | Hash[Symbol, String] imported, filename: String, ?code_to_expose: String?) -> true
 
     type module_loader_return = String | Hash[Symbol, String] | nil

--- a/sig/quickjs.rbs
+++ b/sig/quickjs.rbs
@@ -20,7 +20,7 @@ module Quickjs
   def self.compile_module: (String source, ?filename: String?, **untyped) -> Quickjs::Importable
 
   class Importable
-    attr_reader name: String
+    attr_reader canonical_name: String
   end
 
   class Value

--- a/test/quickjs_importable_test.rb
+++ b/test/quickjs_importable_test.rb
@@ -1,0 +1,163 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+describe "Quickjs.compile_module" do
+  it "is importable into a VM" do
+    lib = Quickjs.compile_module('export const greet = () => "hello";')
+    vm = Quickjs::VM.new
+    vm.import(['greet'], from: lib)
+
+    _(vm.eval_code('greet()')).must_equal 'hello'
+  end
+
+  it "imports into any number of VMs without recompiling" do
+    lib = Quickjs.compile_module('export const greet = () => "hello";')
+
+    3.times do
+      vm = Quickjs::VM.new
+      vm.import(['greet'], from: lib)
+      _(vm.eval_code('greet()')).must_equal 'hello'
+      vm.dispose!
+    end
+  end
+
+  it "gives each VM its own instance of the module" do
+    counter = Quickjs.compile_module("const s = { n: 0 };\nexport const inc = () => ++s.n;")
+
+    vm1 = Quickjs::VM.new
+    vm1.import(['inc'], from: counter)
+    vm2 = Quickjs::VM.new
+    vm2.import(['inc'], from: counter)
+
+    _(vm1.eval_code('inc()')).must_equal 1
+    _(vm1.eval_code('inc()')).must_equal 2
+    _(vm2.eval_code('inc()')).must_equal 1
+  end
+
+  it "supports the same import shapes as an inline source" do
+    lib = Quickjs.compile_module('export default { v: "def" };
+export const member = () => "mem";')
+
+    vm = Quickjs::VM.new
+    vm.import({default: 'aliased', member: 'member'}, from: lib)
+
+    _(vm.eval_code('aliased.v')).must_equal 'def'
+    _(vm.eval_code('member()')).must_equal 'mem'
+  end
+
+  it "honors code_to_expose:" do
+    lib = Quickjs.compile_module('export const value = () => "renamed";')
+    vm = Quickjs::VM.new
+    vm.import(['value'], from: lib, code_to_expose: 'globalThis.custom = value;')
+
+    _(vm.eval_code('custom()')).must_equal 'renamed'
+    _(vm.eval_code('typeof globalThis.value')).must_equal 'undefined'
+  end
+
+  # Each import compiles a small bridge module, so a repeat import is never
+  # free. What must not repeat is reading the module itself, so the module is
+  # made large enough here that a second read would dwarf the bridge.
+  it "reads the bytecode only once when imported repeatedly into one VM" do
+    body = Array.new(200) { |i| "export const fn#{i} = (a) => a + #{i};" }.join("\n")
+    lib = Quickjs.compile_module(body)
+    vm = Quickjs::VM.new
+
+    before = vm.memory_usage[:js_func_code_size]
+    vm.import(['fn0'], from: lib)
+    first = vm.memory_usage[:js_func_code_size] - before
+    vm.import(['fn1'], from: lib)
+    second = vm.memory_usage[:js_func_code_size] - before - first
+
+    _(second).must_be :<, first / 10
+  end
+
+  # The reason to generate the name rather than take one: two gems that both
+  # ship a 'lib.js' must not collide in a VM that imports both.
+  it "never collides with another Importable built from the same filename" do
+    one = Quickjs.compile_module('export const which = () => "one";', filename: 'lib.js')
+    two = Quickjs.compile_module('export const which = () => "two";', filename: 'lib.js')
+
+    _(one.name).wont_equal two.name
+
+    vm = Quickjs::VM.new
+    vm.import({which: 'whichOne'}, from: one)
+    vm.import({which: 'whichTwo'}, from: two)
+
+    _(vm.eval_code('whichOne()')).must_equal 'one'
+    _(vm.eval_code('whichTwo()')).must_equal 'two'
+  end
+
+  it "puts filename: in the module name for stack traces" do
+    lib = Quickjs.compile_module('export const boom = () => { throw new Error("bang"); };',
+                                 filename: 'my_gem/lib.js')
+    _(lib.name).must_match(%r{\Amy_gem/lib\.js-\h{16}\z})
+
+    vm = Quickjs::VM.new
+    vm.import(['boom'], from: lib)
+    err = _ { vm.eval_code('boom()') }.must_raise Quickjs::RuntimeError
+
+    _(err.backtrace.join("\n")).must_include 'my_gem/lib.js'
+  end
+
+  it "rejects a non-String source" do
+    _ { Quickjs.compile_module(42) }.must_raise TypeError
+  end
+
+  it "rejects a non-String filename" do
+    _ { Quickjs.compile_module('export const x = 1;', filename: :lib) }.must_raise TypeError
+  end
+
+  it "raises on a syntax error in the module source" do
+    _ { Quickjs.compile_module('export const = ;') }.must_raise Quickjs::SyntaxError
+  end
+
+  it "accepts VM options for compiling large sources" do
+    lib = Quickjs.compile_module('export const x = 1;', memory_limit: 1024 * 1024 * 64)
+    vm = Quickjs::VM.new
+    vm.import(['x'], from: lib)
+
+    _(vm.eval_code('x')).must_equal 1
+  end
+
+  it "does not leak the bytecode through the public interface" do
+    lib = Quickjs.compile_module('export const x = 1;')
+
+    _(lib).wont_respond_to :to_s_bytecode
+    _ { lib.bytecode }.must_raise NoMethodError
+  end
+
+  describe "alongside module_loader" do
+    it "resolves without consulting a loader that doesn't know the name" do
+      lib = Quickjs.compile_module('export const x = "from-importable";')
+      vm = Quickjs::VM.new
+      asked = []
+      vm.module_loader = ->(specifier, _importer) { asked << specifier; nil }
+      vm.import(['x'], from: lib)
+
+      _(vm.eval_code('x')).must_equal 'from-importable'
+      _(asked).must_be_empty
+    end
+
+    it "still routes the module's own imports through the loader" do
+      lib = Quickjs.compile_module("import { d } from 'dep';\nexport const combined = () => `imp+${d()}`;")
+      vm = Quickjs::VM.new
+      seen = []
+      vm.module_loader = ->(specifier, importer) {
+        seen << specifier
+        "export const d = () => 'dep';" if specifier == 'dep'
+      }
+      vm.import(['combined'], from: lib)
+
+      _(vm.eval_code('combined()')).must_equal 'imp+dep'
+      _(seen).must_equal ['dep']
+    end
+  end
+
+  it "leaves a String from: working as before" do
+    vm = Quickjs::VM.new
+    vm.import(['plain'], from: 'export const plain = () => "inline";')
+
+    _(vm.eval_code('plain()')).must_equal 'inline'
+  end
+end

--- a/test/quickjs_importable_test.rb
+++ b/test/quickjs_importable_test.rb
@@ -78,7 +78,7 @@ export const member = () => "mem";')
     one = Quickjs.compile_module('export const which = () => "one";', filename: 'lib.js')
     two = Quickjs.compile_module('export const which = () => "two";', filename: 'lib.js')
 
-    _(one.name).wont_equal two.name
+    _(one.canonical_name).wont_equal two.canonical_name
 
     vm = Quickjs::VM.new
     vm.import({which: 'whichOne'}, from: one)
@@ -91,7 +91,7 @@ export const member = () => "mem";')
   it "puts filename: in the module name for stack traces" do
     lib = Quickjs.compile_module('export const boom = () => { throw new Error("bang"); };',
                                  filename: 'my_gem/lib.js')
-    _(lib.name).must_match(%r{\Amy_gem/lib\.js-\h{16}\z})
+    _(lib.canonical_name).must_match(%r{\Amy_gem/lib\.js-\h{16}\z})
 
     vm = Quickjs::VM.new
     vm.import(['boom'], from: lib)
@@ -148,7 +148,7 @@ export const member = () => "mem";')
       asked = []
       vm.module_loader = ->(specifier, _importer) {
         asked << specifier
-        {as: lib.name} if specifier == 'my-gem'
+        {as: lib.canonical_name} if specifier == 'my-gem'
       }
 
       vm.import(['render'], from: lib)

--- a/test/quickjs_importable_test.rb
+++ b/test/quickjs_importable_test.rb
@@ -139,6 +139,26 @@ export const member = () => "mem";')
       _(asked).must_be_empty
     end
 
+    # An Importable's name is generated, so JS elsewhere in the graph can't
+    # write `import 'my-gem'` and reach it. A redirect gives it a name on the
+    # VMs that want one, without a process-global registry entry.
+    it "can be reached by a name of the host's choosing through a redirect" do
+      lib = Quickjs.compile_module('export const render = () => "rendered";')
+      vm = Quickjs::VM.new
+      asked = []
+      vm.module_loader = ->(specifier, _importer) {
+        asked << specifier
+        {as: lib.name} if specifier == 'my-gem'
+      }
+
+      vm.import(['render'], from: lib)
+      vm.import({render: 'aliasRender'}, from: "import { render } from 'my-gem'; export { render };")
+
+      _(vm.eval_code('aliasRender()')).must_equal 'rendered'
+      _(vm.eval_code('render === aliasRender')).must_equal true
+      _(asked).must_equal ['my-gem']
+    end
+
     it "still routes the module's own imports through the loader" do
       lib = Quickjs.compile_module("import { d } from 'dep';\nexport const combined = () => `imp+${d()}`;")
       vm = Quickjs::VM.new


### PR DESCRIPTION
Adds `Quickjs.compile_module`, returning a `Quickjs::Importable` that can be imported into any number of VMs without reparsing. The module-map counterpart of what `Runnable` does for classic scripts.

```rb
RENDERER = Quickjs.compile_module(File.read("vendor/renderer.js"), filename: "renderer.js")

vm = Quickjs::VM.new
vm.import(["render"], from: RENDERER)   # no parse cost, on this VM or any other
vm.eval_code("render({ id: 1 })")
```

## Why, given #66 already landed

`register_module` addresses the case in #65: a module graph where JS writes `import 'lodash'` and a `module_loader` resolves it. The name has to mean something to everyone, so a process-global registry is the right home for it.

This addresses the opposite case. Several gems in one Rails app each instantiate their own VM and import their own module from a string. Those VMs never meet, so the module's name is an implementation detail of one gem, and a global registry would force unrelated gems to coordinate on names for modules that never share a module map. It is also the cached form of the call those gems already make: `from:` a `String` reparses per VM, `from:` an `Importable` does not.

## The name is generated, not accepted

It gets baked into the bytecode and becomes the module's identity in every VM that imports it, so generating it makes collisions between independently built `Importable`s impossible, which is the entire point when the JS ships inside a gem. `filename:` only prefixes the generated name so stack traces stay readable (`renderer.js-3f9a...`); it is a label, not an identity. A test covers two `Importable`s built with the same `filename:` being imported into one VM.

## Implementation

Pure Ruby on top of the primitives #66 added. `from:` an `Importable` reads the bytecode into the VM and then imports by name, so it takes exactly the path a preloaded module takes: resolution finds it in the module map and `module_loader` is never asked about it. Reads are already idempotent after #66, which is what makes repeat imports of one `Importable` cheap; there is a test asserting a second import adds an order of magnitude less code than the first.

## Deliberately not included

`Importable` does not expose its bytecode. Handing out the blob invites persisting it, and the format is tied to the QuickJS build with only a one-byte version tag to catch a mismatch. `Runnable#to_s` already has that hazard; this does not add a second one until someone asks for it.

Compilation is eager. A gem that may never be used can defer with `@compiled ||= Quickjs.compile_module(...)`, which is idiomatic enough not to need API support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
