### PR TITLE
Let a module_loader Hash omit code: to redirect a specifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,8 +190,19 @@ Return value:
 
 - A `String` — that's the source. The canonical name used for QuickJS's module cache is the specifier itself.
 - A `Hash` `{ code:, as: }` — `code:` is the source, `as:` becomes the canonical name. Use this when the same specifier should resolve to different modules depending on the importer (importmap "scopes"), since QuickJS caches by canonical name and changing the canonical is what isolates the two modules.
+- A `Hash` `{ as: }` with no `code:` — a redirect: "resolve this specifier to `as:`". No source is provided, so the target has to be a module the VM already has, whether preloaded with `preload_modules:` or loaded by an earlier import. Pointing at anything else raises `Quickjs::ReferenceError`, since there is nothing left to load.
 - `nil` or `false` — raises `Quickjs::ReferenceError` on the JS side ("module not found").
 - Anything else — `Quickjs::TypeError`.
+
+```rb
+# Give a preloaded module a name of your choosing, without shipping its source twice
+vm = Quickjs::VM.new(preload_modules: ['/vendor/lodash.js'])
+vm.module_loader = ->(specifier, _importer) {
+  {as: '/vendor/lodash.js'} if specifier == 'lodash'
+}
+```
+
+Watch out for one consequence: `{code: modules[specifier], as: name}` where the lookup misses is a redirect to `name` rather than a `TypeError`, so it fails later with a `ReferenceError` instead of at the point of the mistake. Return `nil` for an unknown specifier rather than a `Hash` with a missing `code:`.
 
 Importmap scope example:
 

--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -620,14 +620,18 @@ static char *quickjsrb_module_normalize(JSContext *ctx, const char *base_name, c
   {
     r_source = rb_hash_aref(r_return, ID2SYM(rb_intern("code")));
     r_canonical = rb_hash_aref(r_return, ID2SYM(rb_intern("as")));
-    if (!RB_TYPE_P(r_source, T_STRING))
-    {
-      JS_ThrowTypeError(ctx, "module loader Hash must include code: (String, the module source)");
-      return NULL;
-    }
     if (!RB_TYPE_P(r_canonical, T_STRING))
     {
       JS_ThrowTypeError(ctx, "module loader Hash must include as: (String, the canonical module name)");
+      return NULL;
+    }
+    // `code:` is optional: omitting it makes the Hash a pure redirect, "resolve
+    // this specifier to `as:`", which is meaningful exactly when that module is
+    // already in the map and has no source left to provide. Requiring it would
+    // force importmap-style loaders to invent a source value nothing reads.
+    if (!NIL_P(r_source) && !RB_TYPE_P(r_source, T_STRING))
+    {
+      JS_ThrowTypeError(ctx, "module loader Hash code: must be a String (the module source), or omitted to redirect to as:");
       return NULL;
     }
   }
@@ -643,7 +647,7 @@ static char *quickjsrb_module_normalize(JSContext *ctx, const char *base_name, c
   // preloaded. QuickJS finds it in ctx->loaded_modules and never calls the
   // load hook, so stashing the source it just handed us would leave an entry
   // nothing ever clears.
-  if (!RTEST(rb_hash_aref(data->preloaded_module_names, r_canonical)))
+  if (!NIL_P(r_source) && !RTEST(rb_hash_aref(data->preloaded_module_names, r_canonical)))
     rb_hash_aset(data->module_source_cache, r_canonical, r_source);
   rb_hash_aset(data->module_resolution_cache, r_key, r_canonical);
 
@@ -658,8 +662,12 @@ static JSModuleDef *quickjsrb_module_loader(JSContext *ctx, const char *module_n
   VALUE r_source = rb_hash_aref(data->module_source_cache, r_canonical);
   if (NIL_P(r_source))
   {
-    // Defensive: normalize populates this on every miss.
-    JS_ThrowReferenceError(ctx, "module loader: no cached source for '%s'", module_name);
+    // Reachable through a redirect: a Hash without `code:` resolves a specifier
+    // onto another canonical without providing any source, which only works if
+    // that module is already loaded — and if it were, QuickJS would have found
+    // it and never called this hook. For every other path normalize stashes a
+    // source on the way past, so arriving here means the redirect dangled.
+    JS_ThrowReferenceError(ctx, "module loader has no source for '%s': a Hash without code: redirects to an already-loaded module, and this one isn't loaded", module_name);
     return NULL;
   }
   // QuickJS won't call load again for this canonical — its own module cache

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -1361,11 +1361,57 @@ describe Quickjs::VM do
       _(call_count).must_equal 1
     end
 
-    it "raises TypeError when the loader Hash is missing code:" do
+    # A Hash without code: is a redirect, so it can only point at a module that
+    # is already loaded. Pointing at one that isn't leaves nothing to load.
+    it "raises ReferenceError when a redirect points at a module that isn't loaded" do
       @vm.module_loader = ->(_specifier, _importer) { {as: '/anywhere'} }
+      err = _ {
+        @vm.import(['x'], from: "import { x } from 'mod'; export { x };")
+      }.must_raise Quickjs::ReferenceError
+
+      _(err.message).must_match(%r{/anywhere})
+      _(err.message).must_match(/without code:/)
+    end
+
+    it "raises TypeError when the loader Hash has a non-String code:" do
+      @vm.module_loader = ->(_specifier, _importer) { {code: 42, as: '/anywhere'} }
       _ {
         @vm.import(['x'], from: "import { x } from 'mod'; export { x };")
       }.must_raise Quickjs::TypeError
+    end
+
+    it "redirects a specifier onto a module the loader already provided" do
+      loaded = []
+      @vm.module_loader = ->(specifier, _importer) {
+        loaded << specifier
+        case specifier
+        when '/real.js' then {code: "const s = { n: 0 };\nexport const bump = () => ++s.n;", as: '/real.js'}
+        when 'alias' then {as: '/real.js'}
+        end
+      }
+
+      @vm.import(['bump'], from: "import { bump } from '/real.js'; export { bump };")
+      @vm.import({bump: 'aliasBump'}, from: "import { bump } from 'alias'; export { bump };")
+
+      # Same module instance behind both specifiers, so the counter is shared.
+      _(@vm.eval_code('bump()')).must_equal 1
+      _(@vm.eval_code('aliasBump()')).must_equal 2
+      _(loaded).must_equal ['/real.js', 'alias']
+    end
+
+    it "redirects a specifier onto a preloaded module" do
+      Quickjs.register_module('_test_redirect_target', source: 'export const hi = () => "preloaded";')
+      vm = Quickjs::VM.new(preload_modules: ['_test_redirect_target'])
+      vm.module_loader = ->(specifier, _importer) {
+        {as: '_test_redirect_target'} if specifier == 'friendly-name'
+      }
+
+      vm.import(['hi'], filename: 'friendly-name')
+
+      _(vm.eval_code('hi()')).must_equal 'preloaded'
+      _(vm.send(:_pending_module_source_count)).must_equal 0
+    ensure
+      Quickjs._unregister_module('_test_redirect_target')
     end
 
     it "raises TypeError when the loader Hash is missing as:" do


### PR DESCRIPTION
Implements the redirect shape @ursm proposed while reviewing #66, in place of the issue I said I'd open for it.

A loader pointing a specifier at a module the VM already has previously had to invent a source value nothing reads:

```rb
->(spec, _) { {code: '', as: '/vendor/lodash.js'} if spec == 'lodash' }
```

`code:` is now optional, and omitting it makes the Hash a pure redirect, "resolve this specifier to `as:`":

```rb
vm = Quickjs::VM.new(preload_modules: ['/vendor/lodash.js'])
vm.module_loader = ->(specifier, _importer) {
  {as: '/vendor/lodash.js'} if specifier == 'lodash'
}
```

That is meaningful exactly when the target is already in the module map, whether preloaded with `preload_modules:` or loaded by an earlier import, and an error otherwise since there is nothing left to load. As ursm put it, this reads honestly, where "`code:` is required except when it isn't" is a rule you have to memorize.

## The failure path already existed

The load hook refuses when normalize stashed no source for a canonical, which was previously unreachable and commented as defensive. A dangling redirect is now the way to reach it, so the message says what actually went wrong rather than talking about a cache:

```
module loader has no source for '/anywhere': a Hash without code: redirects to
an already-loaded module, and this one isn't loaded
```

## One behavior change

`{code: modules[specifier], as: name}` where the lookup misses used to raise `TypeError` at the point of the mistake. It is now a redirect, so it fails a moment later with `ReferenceError` instead. Still an error, just further from the cause. The README says to return `nil` for an unknown specifier rather than a `Hash` with a missing `code:`, and the test that asserted the old `TypeError` now asserts the new `ReferenceError`.

Non-String `code:` is still a `TypeError`, and `as:` is still mandatory.

## Note for after #73

This also gives a `Quickjs::Importable` a name on the VMs that want one, without a global registry entry, since an Importable's name is generated:

```rb
vm.import(['render'], from: MyGem::MODULE)
vm.module_loader = ->(spec, _) { {as: MyGem::MODULE.name} if spec == 'my-gem' }
```

Not tested here, since this branch is off main and #73 isn't merged yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)