### PR TITLE
Release the GVL while deserializing preloaded module bytecode

### DIFF
--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -1086,7 +1086,7 @@ static JSValue js_console_error(JSContext *ctx, JSValueConst this, int argc, JSV
 // pools populating VMs, per-thread Runnable#run) proceed in parallel with
 // the main thread on multi-core hosts.
 //
-// Three call sites use the run_bytecode_release_gvl wrapper below:
+// Four call sites use the run_bytecode_release_gvl wrapper below:
 //
 //   1. vm_m_initialize — pre-built polyfill bytecode (file / encoding /
 //      url) embedded as static C constants. setTimeout (FEATURE_TIMEOUT)
@@ -1112,6 +1112,14 @@ static JSValue js_console_error(JSContext *ctx, JSValueConst this, int argc, JSV
 //      buffer copy as 2, but with the awaiting runner: js_std_await's job
 //      drain is bridge-free under the gate, the same argument eval_code's
 //      released path relies on.
+//
+//   4. vm_m_preloadModuleBytecode — module bytecode from a Ruby String,
+//      copied like 2/3, but with the deserialize-only runner
+//      (bytecode_read_job_run) and no can_eval_gvl_free gate. A preload
+//      registers the module def without running any top level, so no bridge
+//      can fire regardless of what's installed — the release is
+//      unconditional, and safe even on a bridged VM where 2/3 fall back to
+//      the GVL-held path.
 //
 // run_bytecode_release_gvl delegates to the shared GVL-release region
 // (see run_gvl_release_region) so every caller inherits the re-acquire
@@ -1155,6 +1163,20 @@ static void *bytecode_eval_await_job_run(void *p)
   struct bytecode_load_job *job = p;
   bytecode_load_job_run(job);
   job->result = js_std_await(job->ctx, job->result);
+  return NULL;
+}
+
+// Deserialize-only variant, for vm_m_preloadModuleBytecode: reads a module
+// def into ctx->loaded_modules without evaluating it, so a later import can
+// link and run it. Unlike the two runners above this never reaches JS
+// execution or the job queue — JS_ReadObject only deserializes, deferring
+// import resolution to js_link_module at eval time — so its release needs no
+// can_eval_gvl_free gate: there is no top level that could reach a Ruby
+// bridge, on any VM. Same MUST-NOT-touch-Ruby constraint all the same.
+static void *bytecode_read_job_run(void *p)
+{
+  struct bytecode_load_job *job = p;
+  job->result = JS_ReadObject(job->ctx, job->buf, job->buf_len, JS_READ_OBJ_BYTECODE);
   return NULL;
 }
 
@@ -1862,8 +1884,25 @@ static VALUE vm_m_preloadModuleBytecode(VALUE r_self, VALUE r_bytecode, VALUE r_
   if (RTEST(rb_hash_aref(data->preloaded_module_names, r_key)))
     return r_name;
 
-  JSValue j_mod = JS_ReadObject(data->context, (const uint8_t *)RSTRING_PTR(r_bytecode),
-                                (size_t)RSTRING_LEN(r_bytecode), JS_READ_OBJ_BYTECODE);
+  // Deserialize with the GVL released. The read touches no Ruby and no
+  // bridge — it only registers the def, deferring linking to import — so it
+  // releases unconditionally (no can_eval_gvl_free gate): a pool of
+  // per-thread VMs each preloading the same modules deserializes in parallel
+  // instead of serializing through the GVL. RSTRING_PTR is GC-movable while
+  // released, so the bytecode is copied to a buffer the region owns and frees.
+  //
+  // An async interrupt in the region's GVL re-acquire frees j_mod but leaves
+  // the def js_new_module_def already registered in loaded_modules, untracked
+  // by preloaded_module_names. That is reachable on a VM the caller keeps —
+  // import(names, from:) preloads into a live VM, not just VM.new into a
+  // half-built one — so it is worth spelling out what a retry does: the
+  // untracked name misses the guard above, a second def is read under the same
+  // name, js_find_loaded_module returns the first, and the retry records the
+  // name. Behaviour recovers, at the cost of one orphan holding its bytecode
+  // for the life of the context, so unregistering on interrupt isn't worth it.
+  size_t buf_len;
+  uint8_t *buf = (uint8_t *)copy_rstring_to_owned_buffer(r_bytecode, &buf_len, false);
+  JSValue j_mod = run_bytecode_release_gvl(data, bytecode_read_job_run, buf, buf_len, true);
   if (JS_IsException(j_mod))
     return to_rb_value(data->context, j_mod); // raises
 

--- a/test/quickjs_module_bytecode_test.rb
+++ b/test/quickjs_module_bytecode_test.rb
@@ -212,4 +212,71 @@ describe "module bytecode primitives" do
     vm.import(['x'], filename: 'effectful')
     _(vm.eval_code('globalThis.sideEffect')).must_equal 'ran'
   end
+
+  it "reads the same bytecode into a VM per thread without crashing" do
+    bytecode = compile_module('export const answer = () => 21 * 2;', 'answer')
+
+    results = Array.new(8) {
+      Thread.new {
+        vm = Quickjs::VM.new
+
+        begin
+          vm.send(:_preload_module_bytecode, bytecode, 'answer')
+          vm.import(['answer'], filename: 'answer')
+          vm.eval_code('answer()')
+        ensure
+          vm.dispose!
+        end
+      }
+    }.map(&:value)
+
+    _(results).must_equal Array.new(8, 42)
+  end
+
+  # Deserializing is proportional to the blob, not to what the module computes,
+  # so the timing workload is a module made large rather than one made slow.
+  #
+  # The size is tuned rather than arbitrary, because it trades the two failure
+  # modes against each other. Growing it grows the GVL-free dispose! in lockstep
+  # with the read, which lifts the GVL-held case toward the 0.8 threshold —
+  # measured 1.11 at 5k functions, 0.92 at 10k, 0.83 at 20k, i.e. closer to
+  # passing when it shouldn't. Shrinking it leaves thread setup a bigger share
+  # of a shorter run, which lifts the released case — 0.62 at 5k, up to 0.75 at
+  # 2.5k, closer to failing when it shouldn't. 5k sits near the widest point.
+  def bulky_module_source(functions: 5_000)
+    Array.new(functions) {|i|
+      "export function f#{i}(a, b) { return a * #{i} + b - Math.sqrt(a + #{i}); }"
+    }.join("\n")
+  end
+
+  # Preloading is the warmer-pool hot path for modules: compile a bundle once,
+  # read it into a VM per thread. The read releases the GVL unconditionally —
+  # it registers the module def without running any of it, so no bridge can
+  # fire and no can_eval_gvl_free gate is needed. Before the release, threads
+  # populating their VMs serialized on the GVL.
+  #
+  # Each iteration reads a distinct module into one long-lived VM rather than
+  # building a VM per read, because dispose! releases the GVL on its own: with
+  # a VM per iteration the freeing parallelizes either way and swamps what is
+  # being measured, leaving held and released only 0.85 vs 0.78 apart. Reading
+  # into a single VM keeps the deserialize dominant, and the two land on
+  # opposite sides of the threshold with room to spare (~1.1 vs ~0.5).
+  it "reads module bytecode concurrently with measurable speedup" do
+    source  = bulky_module_source
+    modules = Array.new(8) {|i| [compile_module(source, "bulky#{i}"), "bulky#{i}"] }
+
+    # The iteration count is told to the helper rather than left to its default,
+    # because every iteration has to read a module the VM hasn't seen: a repeat
+    # is deduplicated into a no-op, so wrapping around the list would silently
+    # give the one-thread and two-thread runs different amounts of work to do.
+    assert_run_in_parallel(total_iterations: modules.size) do |iterations|
+      vm = Quickjs::VM.new
+
+      begin
+        iterations.times {|i| vm.send(:_preload_module_bytecode, *modules[i]) }
+      ensure
+        vm.dispose!
+      end
+    end
+  end
 end


### PR DESCRIPTION
Continues the GVL-release line (#56 eval, #59 polyfill load, #63 Runnable#run) onto the module preloading path added in #66.

## What

`_preload_module_bytecode`'s only heavy step is the `JS_ReadObject` that deserializes a compiled module into the context. This releases the GVL around that read so a pool of per-thread VMs each preloading the same registered modules deserializes in parallel instead of serializing through the GVL.

It reuses the shared GVL-release region via a new deserialize-only job runner (`bytecode_read_job_run`), so it inherits the `dispose!` handshake, the stale-dispose re-check, and interrupt-proof buffer cleanup for free. The bytecode is copied to a region-owned buffer first, because `RSTRING_PTR` is GC-movable while the GVL is released.

## Why it's an unconditional release (no `can_eval_gvl_free` gate)

This is the part worth a second look. The polyfill (#59) and `Runnable#run` (#63) loads gate the release on `can_eval_gvl_free` because they **execute** JS — a top level could reach a direct-`rb_funcall` bridge (crypto, File proxy) without holding the GVL. A preload doesn't execute anything: `JS_ReadObject` with `JS_READ_OBJ_BYTECODE` only registers the module def in `loaded_modules` and defers import resolution to `js_link_module` at eval time. No top level, no bridge, no job-queue drain — on any VM. So the release is unconditional, and safe even on a bridged VM where the polyfill/eval loads fall back to the held path. That's preload-specific upside: it parallelizes in configurations the other released loads can't.

I verified against the QuickJS submodule that reading a module blob (`JS_ReadModule` → `js_new_module_def`) never invokes the module loader, the normalize hook, or any host callback, and that the runtime uses the default `malloc` (no Ruby allocator re-entry while released).

## One exposure to flag

The release introduces a GVL re-acquire point that the GVL-held read didn't have. If a thread is asynchronously interrupted (`Thread#kill` / `Timeout`) in that re-acquire window — after `JS_ReadObject` registered the def but before `preloaded_module_names` records it — the def stays in `loaded_modules` untracked. Since #73 that can happen on a VM the caller keeps (`import(names, from:)` preloads into a live VM), not only on a half-built one that gets discarded, so it's worth stating what a retry does: the untracked name misses the guard, a second def is read under the same name, `js_find_loaded_module` returns the first, and the retry records the name. Behaviour recovers, at the cost of one orphan holding its bytecode for the life of the context. It's documented at the read site. Truly closing it would mean unregistering the def from `loaded_modules` on interrupt, which I judged disproportionate for a window this narrow that already self-heals — happy to reconsider if you'd rather.

## Tests

Existing tests pass unchanged. Added the same pair the other released paths carry, in `quickjs_module_bytecode_test.rb` next to the primitive they cover: one that reads the same bytecode into a VM per thread and asserts the modules come out usable, and one `assert_run_in_parallel` that measures the speedup.

The timing test needed one non-obvious shape, and the module size in it is tuned rather than arbitrary — see the review thread for the measurements, but in short the margin is two-sided: growing the blob grows the GVL-free `dispose!` in lockstep with the read and drags the held case toward the threshold, shrinking it leaves thread setup a bigger share of a shorter run and drags the released case up. My first attempt built a VM per read and **passed with the release reverted** — `dispose!` already releases the GVL, so the freeing parallelizes whether or not the read does, and it swamped what was being measured: held vs released came out only 0.85 vs 0.78, straddling the helper's 0.8 threshold. Reading distinct modules into a single long-lived VM instead keeps the deserialize dominant, and the two land at ~1.1 vs ~0.5 — so the test now genuinely fails if the release is reverted (verified both directions, 3 runs each). The workload is a module made *large* rather than *slow*, since deserialize cost tracks the blob, not what the module computes.

## Review

Reviewed with two independent passes (a manual adversarial C review tracing the QuickJS source, and `/code-review`); both found no correctness defects. The buffer is freed on every region exit path (success, JS exception, non-module tag, name mismatch, disposed bail, async interrupt), the counters stay balanced, and the `j_mod` refcount is unchanged from before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
