### PR TITLE
Release the GVL while compiling source to bytecode

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,7 +443,7 @@ vm.eval_code('1 + 1') # raises Quickjs::RuntimeError "VM has been disposed"
 Thread.new { vm.dispose! }
 ```
 
-Disposing a VM that is mid-evaluation on another thread would free the runtime out from under the running JS, so `dispose!` raises `ThreadError` while JS is executing on the VM (`eval_code`, `call`, `import`, `drain_jobs!`, `Runnable#run`) — dispose after the call returns.
+Disposing a VM that is mid-evaluation on another thread would free the runtime out from under the running JS, so `dispose!` raises `ThreadError` while JS is executing on the VM (`eval_code`, `call`, `import`, `drain_jobs!`, `compile`, `Runnable#run`) — dispose after the call returns.
 
 #### `Quickjs::VM#drain_jobs!`: Run pending JS jobs to completion
 
@@ -464,6 +464,8 @@ Useful when porting JS that assumed V8's implicit-drain semantics — V8 (and th
 #### Threads and parallelism
 
 `eval_code` and `Runnable#run` release Ruby's GVL while JS runs, as long as no JS→Ruby bridge is registered on the VM (no `define_function`, `module_loader`, `on_unhandled_rejection`, and none of `FEATURE_TIMEOUT` / `POLYFILL_FILE` / `POLYFILL_CRYPTO` — `console.log` is fine). Separate VMs on separate Ruby threads then evaluate genuinely in parallel on multi-core hosts — including the compile-once-run-everywhere pattern, where per-thread VMs execute the same `Runnable` concurrently. When a bridge is registered, the GVL stays held for that VM's evals and they serialize as usual.
+
+`compile` releases the GVL for the parse regardless of what is registered on the VM — parsing to bytecode runs no JS, so no bridge can be reached and the no-bridge rule above doesn't apply to it. Serializing the result back into a Ruby String stays on the GVL, which costs about 5% of the available speedup. So a dedicated compile VM, on its own thread, parses in parallel with everything else running in the process. `compile_module` (and therefore `Quickjs.register_module` / `Quickjs.compile_module`) does not release the GVL.
 
 The rules for sharing VMs across threads:
 

--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -1860,6 +1860,42 @@ static VALUE compiled_to_bytecode_string(VMData *data, JSValue j_compiled, const
   return run_held_js_entry(data, bytecode_serialize_held, (VALUE)&job);
 }
 
+struct js_exception_job
+{
+  VMData *data;
+  JSValue j_exception;
+};
+
+static VALUE js_exception_body(VALUE p)
+{
+  struct js_exception_job *job = (struct js_exception_job *)p;
+  return to_rb_value(job->data->context, job->j_exception); // raises
+}
+
+// Turns a thrown JSValue into the Ruby exception it raises, as a counted JS
+// entry rather than a bare call. Converting an error is JS execution: it
+// reads name, message and stack off the thrown object, and any of the three
+// can be an accessor inherited from a prototype the VM's own code has
+// replaced. So a parse failure on a VM where something did
+//
+//   Object.defineProperty(SyntaxError.prototype, 'name', { get: () => boom() })
+//
+// runs boom() during conversion — and with evals_in_flight back at zero after
+// the release region, a dispose! from that bridge was granted and the rest of
+// the conversion ran against a freed context. Reproducible SIGSEGV.
+//
+// The parse half of a compile is counted and the serialize half is counted;
+// this is the third tail out of the same function, and it was the one left
+// bare.
+static VALUE js_exception_to_rb(VMData *data, JSValue j_exception)
+{
+  struct js_exception_job job = {
+      .data = data,
+      .j_exception = j_exception,
+  };
+  return run_held_js_entry(data, js_exception_body, (VALUE)&job);
+}
+
 static VALUE vm_m_compile(int argc, VALUE *argv, VALUE r_self)
 {
   VMData *data;
@@ -1914,7 +1950,7 @@ static VALUE vm_m_compile(int argc, VALUE *argv, VALUE r_self)
   JSValue j_func = compile_release_gvl(data, r_code, filename);
   if (JS_IsException(j_func))
   {
-    return to_rb_value(data->context, j_func); // raises Ruby exception
+    return js_exception_to_rb(data, j_func); // raises Ruby exception
   }
 
   return compiled_to_bytecode_string(data, j_func, "failed to serialize compiled bytecode");
@@ -2003,7 +2039,7 @@ static VALUE vm_m_compileModule(VALUE r_self, VALUE r_code, VALUE r_name)
                           JS_EVAL_TYPE_MODULE | JS_EVAL_FLAG_COMPILE_ONLY);
   register_module_loader_funcs(data);
   if (JS_IsException(j_mod))
-    return to_rb_value(data->context, j_mod); // raises
+    return js_exception_to_rb(data, j_mod); // raises
 
   return compiled_to_bytecode_string(data, j_mod, "failed to serialize compiled module bytecode");
 }

--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -1706,6 +1706,14 @@ static VALUE vm_m_evalCode(int argc, VALUE *argv, VALUE r_self)
       async_mode = false;
   }
 
+  // Argument parsing allocates, so it can yield the GVL to a concurrent
+  // dispose! that leaves data->context dangling — and arm_eval_timer
+  // dereferences the runtime, which puts it ahead of both the release
+  // region's own re-check and run_held_js_entry's. Nothing between here and
+  // the release yields (StringValue can't coerce: parse_code_and_filename
+  // already refused a non-String), and dispose! refuses once either of those
+  // has counted us, so re-checking here closes the window on both paths.
+  check_disposed(data);
   arm_eval_timer(data);
 
   StringValue(r_code);
@@ -1729,40 +1737,157 @@ static VALUE vm_m_evalCode(int argc, VALUE *argv, VALUE r_self)
   return to_rb_return_value(data->context, job.result);
 }
 
+struct compile_job
+{
+  JSContext *ctx;
+  const char *code;
+  size_t code_len;
+  const char *filename;
+  JSValue result;
+};
+
+// Parses to a function object and stops there. Like the preload read, and
+// unlike the eval core above, this runs no JS at all, so its release needs
+// no can_eval_gvl_free gate — there is no top level that could reach a Ruby
+// bridge, on any VM. JS_EVAL_TYPE_GLOBAL is what carries that argument:
+// __JS_EvalInternal only resolves imports for the JSModuleDef it builds
+// under JS_EVAL_TYPE_MODULE, so no module loader can fire here either. A
+// module compile is a different story and gets no such freedom. Same
+// MUST-NOT-touch-Ruby constraint as every other released job.
+static void *compile_job_run(void *p)
+{
+  struct compile_job *job = p;
+  job->result = JS_Eval(job->ctx, job->code, job->code_len, job->filename,
+                        JS_EVAL_TYPE_GLOBAL | JS_EVAL_FLAG_ASYNC | JS_EVAL_FLAG_COMPILE_ONLY);
+  return NULL;
+}
+
+// Inputs are copied because RSTRING_PTR can be invalidated by GC compaction
+// while we're released, same as eval_code_release_gvl.
+static JSValue compile_release_gvl(VMData *data, VALUE r_code, const char *filename)
+{
+  size_t code_len;
+  char *code_buf = copy_rstring_to_owned_buffer(r_code, &code_len, true);
+
+  char *filename_buf = strdup(filename);
+  if (filename_buf == NULL)
+  {
+    free(code_buf);
+    rb_raise(rb_eNoMemError, "failed to allocate compile filename buffer");
+  }
+
+  struct compile_job job = {
+      .ctx = data->context,
+      .code = code_buf,
+      .code_len = code_len,
+      .filename = filename_buf,
+      .result = JS_UNDEFINED,
+  };
+  run_gvl_release_region(data, compile_job_run, &job, &job.result, code_buf, filename_buf);
+
+  return job.result;
+}
+
+struct bytecode_serialize_job
+{
+  VMData *data;
+  JSValue j_compiled; // owned here: freed by the cleanup on every exit
+  uint8_t *out_buf;
+  const char *failure_message;
+};
+
+static VALUE bytecode_serialize_body(VALUE p)
+{
+  struct bytecode_serialize_job *job = (struct bytecode_serialize_job *)p;
+
+  size_t out_len;
+  job->out_buf = JS_WriteObject(job->data->context, &out_len, job->j_compiled, JS_WRITE_OBJ_BYTECODE);
+  if (job->out_buf == NULL)
+  {
+    VALUE r_msg = rb_str_new2(job->failure_message);
+    rb_exc_raise(rb_funcall(QUICKJSRB_ERROR_FOR(QUICKJSRB_ROOT_RUNTIME_ERROR), rb_intern("new"), 2, r_msg, Qnil));
+  }
+
+  VALUE r_bytecode = rb_str_new((const char *)job->out_buf, (long)out_len);
+  rb_enc_associate(r_bytecode, rb_ascii8bit_encoding());
+  return rb_obj_freeze(r_bytecode);
+}
+
+static VALUE bytecode_serialize_cleanup(VALUE p)
+{
+  struct bytecode_serialize_job *job = (struct bytecode_serialize_job *)p;
+
+  JS_FreeValue(job->data->context, job->j_compiled);
+  if (job->out_buf != NULL)
+    js_free(job->data->context, job->out_buf);
+  return Qnil;
+}
+
+static VALUE bytecode_serialize_held(VALUE p)
+{
+  return rb_ensure(bytecode_serialize_body, p, bytecode_serialize_cleanup, p);
+}
+
+// Serializes a compiled function or module into a frozen ASCII-8BIT String,
+// consuming j_compiled. Shared by both compile entry points, and a GVL-held
+// JS entry rather than plain inline code for two reasons: rb_str_new
+// allocates, which is a thread switch point, so without evals_in_flight
+// elevated a concurrent dispose! could free the context between
+// JS_WriteObject and the js_free below; and the blob JS_WriteObject hands
+// back is js_malloc'd, so it has to go home through js_free to keep the
+// runtime's memory accounting straight — the ensure gets it there however
+// the body exits, including an async interrupt landing in rb_str_new.
+static VALUE compiled_to_bytecode_string(VMData *data, JSValue j_compiled, const char *failure_message)
+{
+  struct bytecode_serialize_job job = {
+      .data = data,
+      .j_compiled = j_compiled,
+      .out_buf = NULL,
+      .failure_message = failure_message,
+  };
+  return run_held_js_entry(data, bytecode_serialize_held, (VALUE)&job);
+}
+
 static VALUE vm_m_compile(int argc, VALUE *argv, VALUE r_self)
 {
   VMData *data;
   TypedData_Get_Struct(r_self, VMData, &vm_type, data);
 
   check_disposed(data);
+  check_oom_poisoned(data);
 
   VALUE r_code, r_opts;
   rb_scan_args(argc, argv, "1:", &r_code, &r_opts);
   const char *filename = parse_code_and_filename(r_code, r_opts);
 
+  // Re-check for the same reason vm_m_evalCode does: argument parsing can
+  // yield to a concurrent dispose!, and arm_eval_timer is the first thing
+  // here to touch the context.
+  //
+  // Arming is a formality for a compile, though: the parser never calls
+  // js_poll_interrupts — every call site is in the interpreter, for-in,
+  // instanceof or regexp exec — so timeout_msec does not bound a compile,
+  // and a pathological source parses for as long as it takes. Releasing the
+  // GVL at least keeps that off every other Ruby thread.
+  check_disposed(data);
   arm_eval_timer(data);
 
+  // A guaranteed no-op: parse_code_and_filename already refused a
+  // non-String, so no to_str can run here and open a yield point between
+  // the check above and the release below.
   StringValue(r_code);
-  JSValue j_func = JS_Eval(data->context, RSTRING_PTR(r_code), RSTRING_LEN(r_code), filename,
-                           JS_EVAL_TYPE_GLOBAL | JS_EVAL_FLAG_ASYNC | JS_EVAL_FLAG_COMPILE_ONLY);
+  // Serializing stays on the GVL-held side of the region: the region frees
+  // its buffers with free(), while JS_WriteObject's blob has to go back
+  // through js_free, and teaching it a second kind of ownership for one
+  // caller isn't worth it. Parsing dominates anyway — leaving the serialize
+  // behind only pulls the two-thread ratio from ~0.5 to ~0.55.
+  JSValue j_func = compile_release_gvl(data, r_code, filename);
   if (JS_IsException(j_func))
   {
     return to_rb_value(data->context, j_func); // raises Ruby exception
   }
 
-  size_t out_len;
-  uint8_t *out_buf = JS_WriteObject(data->context, &out_len, j_func, JS_WRITE_OBJ_BYTECODE);
-  JS_FreeValue(data->context, j_func);
-  if (out_buf == NULL)
-  {
-    VALUE r_msg = rb_str_new2("failed to serialize compiled bytecode");
-    rb_exc_raise(rb_funcall(QUICKJSRB_ERROR_FOR(QUICKJSRB_ROOT_RUNTIME_ERROR), rb_intern("new"), 2, r_msg, Qnil));
-  }
-
-  VALUE r_bytecode = rb_str_new((const char *)out_buf, (long)out_len);
-  rb_enc_associate(r_bytecode, rb_ascii8bit_encoding());
-  js_free(data->context, out_buf);
-  return rb_obj_freeze(r_bytecode);
+  return compiled_to_bytecode_string(data, j_func, "failed to serialize compiled bytecode");
 }
 
 // Stands in for the real loader while compiling a module to bytecode.
@@ -1810,6 +1935,7 @@ static VALUE vm_m_compileModule(VALUE r_self, VALUE r_code, VALUE r_name)
   TypedData_Get_Struct(r_self, VMData, &vm_type, data);
 
   check_disposed(data);
+  check_oom_poisoned(data);
   Check_Type(r_code, T_STRING);
   Check_Type(r_name, T_STRING);
 
@@ -1824,19 +1950,7 @@ static VALUE vm_m_compileModule(VALUE r_self, VALUE r_code, VALUE r_name)
   if (JS_IsException(j_mod))
     return to_rb_value(data->context, j_mod); // raises
 
-  size_t out_len;
-  uint8_t *out_buf = JS_WriteObject(data->context, &out_len, j_mod, JS_WRITE_OBJ_BYTECODE);
-  JS_FreeValue(data->context, j_mod);
-  if (out_buf == NULL)
-  {
-    VALUE r_msg = rb_str_new2("failed to serialize compiled module bytecode");
-    rb_exc_raise(rb_funcall(QUICKJSRB_ERROR_FOR(QUICKJSRB_ROOT_RUNTIME_ERROR), rb_intern("new"), 2, r_msg, Qnil));
-  }
-
-  VALUE r_bytecode = rb_str_new((const char *)out_buf, (long)out_len);
-  rb_enc_associate(r_bytecode, rb_ascii8bit_encoding());
-  js_free(data->context, out_buf);
-  return rb_obj_freeze(r_bytecode);
+  return compiled_to_bytecode_string(data, j_mod, "failed to serialize compiled module bytecode");
 }
 
 // Reads module bytecode into this context. The read registers the JSModuleDef

--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -1791,7 +1791,7 @@ static JSValue compile_release_gvl(VMData *data, VALUE r_code, const char *filen
 struct bytecode_serialize_job
 {
   VMData *data;
-  JSValue j_compiled; // owned here: freed by the cleanup on every exit
+  JSValue j_compiled; // owned here; see compiled_to_bytecode_string for the rule
   uint8_t *out_buf;
   const char *failure_message;
 };
@@ -1828,15 +1828,27 @@ static VALUE bytecode_serialize_held(VALUE p)
   return rb_ensure(bytecode_serialize_body, p, bytecode_serialize_cleanup, p);
 }
 
-// Serializes a compiled function or module into a frozen ASCII-8BIT String,
-// consuming j_compiled. Shared by both compile entry points, and a GVL-held
-// JS entry rather than plain inline code for two reasons: rb_str_new
-// allocates, which is a thread switch point, so without evals_in_flight
-// elevated a concurrent dispose! could free the context between
-// JS_WriteObject and the js_free below; and the blob JS_WriteObject hands
-// back is js_malloc'd, so it has to go home through js_free to keep the
-// runtime's memory accounting straight — the ensure gets it there however
-// the body exits, including an async interrupt landing in rb_str_new.
+// Serializes a compiled function or module into a frozen ASCII-8BIT String.
+// Shared by both compile entry points, and a GVL-held JS entry rather than
+// plain inline code for two reasons: rb_str_new allocates, which is a thread
+// switch point, so without evals_in_flight elevated a concurrent dispose!
+// could free the context between JS_WriteObject and the js_free below; and
+// the blob JS_WriteObject hands back is js_malloc'd, so it has to go home
+// through js_free to keep the runtime's memory accounting straight — the
+// ensure gets it there however the body exits, including an async interrupt
+// landing in rb_str_new.
+//
+// Ownership of j_compiled transfers here in full, but "consumes it" is not
+// quite the whole rule, because run_held_js_entry's disposed check raises
+// ahead of the rb_ensure that does the freeing. That path frees nothing, and
+// must not: dispose! sets disposed before handing the teardown to
+// JS_FreeRuntime, so by the time the check fires j_compiled's storage is
+// either already reclaimed or being reclaimed concurrently with the GVL
+// released, and a JS_FreeValue aimed at it would be a use-after-free rather
+// than a cleanup. Nothing leaks either way — the runtime took it. So: freed
+// through the context on every exit while the VM is alive, abandoned to the
+// teardown once it is not. Unreachable today in any case, since neither
+// caller yields the GVL between its compile and this call.
 static VALUE compiled_to_bytecode_string(VMData *data, JSValue j_compiled, const char *failure_message)
 {
   struct bytecode_serialize_job job = {
@@ -1864,13 +1876,31 @@ static VALUE vm_m_compile(int argc, VALUE *argv, VALUE r_self)
   // yield to a concurrent dispose!, and arm_eval_timer is the first thing
   // here to touch the context.
   //
-  // Arming is a formality for a compile, though: the parser never calls
-  // js_poll_interrupts — every call site is in the interpreter, for-in,
-  // instanceof or regexp exec — so timeout_msec does not bound a compile,
-  // and a pathological source parses for as long as it takes. Releasing the
-  // GVL at least keeps that off every other Ruby thread.
+  // Arming buys a compile nothing: the parser never calls js_poll_interrupts
+  // — every call site is in the interpreter, for-in, instanceof or regexp
+  // exec — so timeout_msec does not bound a compile, and a pathological
+  // source parses for as long as it takes. Releasing the GVL at least keeps
+  // that off every other Ruby thread. It is kept only so an outermost
+  // compile starts from a fresh clock rather than inheriting a lapsed one.
+  //
+  // Nested, it is worse than useless: a compile issued from a bridge
+  // callback (a define_function proc, an on_log listener) would overwrite
+  // the enclosing eval's started_at on every call, so interrupt_handler
+  // never sees the elapsed limit and the enclosing eval never times out at
+  // all. vm_m_loadPolyfillBytecode conditions on the same counter for the
+  // same reason.
+  //
+  // Not a file-wide invariant yet, to be clear. vm_m_evalCode,
+  // vm_m_evalBytecode, call_global_function_body, vm_m_import and
+  // vm_m_drainJobs all still arm unconditionally and all still defeat
+  // timeout_msec the same way. Hoisting the condition into arm_eval_timer
+  // would close them together, but it would also start interrupting
+  // workloads that re-enter the VM from a bridge and today run unbounded —
+  // a semantics change that deserves its own PR rather than a ride on this
+  // one.
   check_disposed(data);
-  arm_eval_timer(data);
+  if (data->evals_in_flight == 0)
+    arm_eval_timer(data);
 
   // A guaranteed no-op: parse_code_and_filename already refused a
   // non-String, so no to_str can run here and open a yield point between
@@ -1939,12 +1969,37 @@ static VALUE vm_m_compileModule(VALUE r_self, VALUE r_code, VALUE r_name)
   Check_Type(r_code, T_STRING);
   Check_Type(r_name, T_STRING);
 
-  arm_eval_timer(data);
+  // Hoisted above everything that touches the runtime. Check_Type already
+  // ruled out a to_str, but StringValueCStr still calls rb_str_modify to
+  // NUL-terminate a shared or embedded-NUL-free substring, and that
+  // allocates — the same thread switch point the rest of this file treats as
+  // a yield. Left where it read most naturally, inline in the JS_Eval
+  // arguments, a concurrent dispose! landing there would free the runtime
+  // out from under the loader swap and the eval. Coercing first puts the
+  // disposed check after the last yield and before the first context access,
+  // as on the other JS entry points.
+  const char *name = StringValueCStr(r_name);
+
+  check_disposed(data);
+  // Guarded for the reason spelled out in vm_m_compile: only the outermost
+  // JS entry point owns the timeout budget. Nesting can't happen on this
+  // path today — it is private and both callers compile on a disposable VM
+  // they own — but the two compile entry points arming differently would be
+  // a difference with no reason behind it.
+  if (data->evals_in_flight == 0)
+    arm_eval_timer(data);
 
   JS_SetModuleLoaderFunc2(JS_GetRuntime(data->context), NULL, quickjsrb_stub_module_loader,
                           js_module_check_attributes, NULL);
-  JSValue j_mod = JS_Eval(data->context, RSTRING_PTR(r_code), RSTRING_LEN(r_code),
-                          StringValueCStr(r_name),
+  // RSTRING_PTR raw, where the released paths copy — the copy there is for GC
+  // movability, and the NUL that quickjs.h:835 asks for comes free with it.
+  // Held here, the raw pointer carries that NUL anyway: Ruby only shares one
+  // String's buffer with another when the substring runs to the parent's end,
+  // so ptr[len] is always somebody's terminator. Worth stating because the
+  // lexer's comment and regexp scanners test for the NUL before the end
+  // pointer, so a buffer without one would let a source ending mid-comment
+  // read on into whatever follows it in memory.
+  JSValue j_mod = JS_Eval(data->context, RSTRING_PTR(r_code), RSTRING_LEN(r_code), name,
                           JS_EVAL_TYPE_MODULE | JS_EVAL_FLAG_COMPILE_ONLY);
   register_module_loader_funcs(data);
   if (JS_IsException(j_mod))
@@ -2327,6 +2382,7 @@ static VALUE vm_m_defineGlobalFunction(int argc, VALUE *argv, VALUE r_self)
   }
 }
 
+
 struct js_entry_call
 {
   int argc;
@@ -2450,8 +2506,7 @@ static VALUE call_global_function_body(VALUE p)
       j_args[i] = to_js_value(data->context, argv[i + 1]);
   }
 
-  clock_gettime(CLOCK_MONOTONIC, &data->eval_time->started_at);
-  JS_SetInterruptHandler(JS_GetRuntime(data->context), interrupt_handler, data->eval_time);
+  arm_eval_timer(data);
 
   JSValue j_result = JS_Call(data->context, j_func, j_this, nargs, (JSValueConst *)j_args);
 

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -1581,6 +1581,37 @@ describe Quickjs::VM do
       _(err.message).must_match(/poisoned/)
     end
 
+    # Converting a thrown value reads name, message and stack off the error
+    # object, and any of the three can be an accessor inherited from a
+    # prototype the VM's own JS has replaced. So a parse failure runs a bridge
+    # during conversion — and with the parse's counter already released,
+    # dispose! from that bridge was granted and the rest of the conversion ran
+    # against a freed context. SIGSEGV rather than an exception, so a
+    # regression takes the suite down with it.
+    it "refuses dispose! from a bridge reached while converting a compile error" do
+      vm = Quickjs::VM.new
+      outcome = nil
+      vm.define_function('probe') {
+        outcome = begin
+          vm.dispose!
+          :disposed
+        rescue ThreadError => e
+          e
+        end
+        'Poisoned'
+      }
+      vm.eval_code(<<~JS)
+        Object.defineProperty(SyntaxError.prototype, 'name', { configurable: true, get: () => probe() });
+        0
+      JS
+
+      _ { vm.compile('function (') }.must_raise Quickjs::RuntimeError
+      _(outcome).must_be_kind_of ThreadError
+      _(vm.disposed?).must_equal false
+    ensure
+      vm.dispose!
+    end
+
     it "run with no on: disposes the temporary VM after execution" do
       runnable = @vm.compile('40 + 2')
       _(runnable.run).must_equal 42

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -1553,6 +1553,17 @@ describe Quickjs::VM do
       _(err.message).must_match(/poisoned/)
     end
 
+    # Compiling is the entry point that most needs the guard: the state OOM
+    # leaves behind is precisely what another throw on the parser-error path
+    # can turn into a segfault.
+    it "compile raises Quickjs::RuntimeError after the VM is OOM-poisoned" do
+      vm = Quickjs::VM.new(memory_limit: 1024 * 1024)
+      _ { vm.eval_code('new Array(2_000_000).fill(0); void 0') }.must_raise Quickjs::RuntimeError
+
+      err = _ { vm.compile('1 + 1') }.must_raise Quickjs::RuntimeError
+      _(err.message).must_match(/poisoned/)
+    end
+
     it "run with no on: disposes the temporary VM after execution" do
       runnable = @vm.compile('40 + 2')
       _(runnable.run).must_equal 42
@@ -2038,6 +2049,62 @@ describe "Quickjs::Blocking" do
         vm = Quickjs::VM.new(timeout_msec: 10_000)
         begin
           iterations.times { runnable.run(on: vm) }
+        ensure
+          vm.dispose!
+        end
+      end
+    end
+
+    # Parsing is proportional to the source, not to what the source computes,
+    # so the compile workloads below are made large rather than slow. Scaling
+    # this much further needs a different shape: JS_EVAL_FLAG_ASYNC turns
+    # these top-level declarations into closure variables, and somewhere past
+    # 65k of them the compile fails outright.
+    def bulky_source(functions: 500)
+      Array.new(functions) {|i|
+        "function f#{i}(a, b) { return a * #{i} + b - Math.sqrt(a + #{i}); }"
+      }.join("\n")
+    end
+
+    it "compiles on a VM per thread without crashing" do
+      source   = bulky_source(functions: 20)
+      expected = Quickjs.compile(source).to_s
+
+      results = Array.new(4) {
+        Thread.new {
+          vm = Quickjs::VM.new(timeout_msec: 10_000)
+
+          begin
+            3.times.map { vm.compile(source).to_s }
+          ensure
+            vm.dispose!
+          end
+        }
+      }.map(&:value)
+
+      # Not `.uniq`: a thread that quietly produced fewer results than it was
+      # asked for would still leave one distinct value behind.
+      _(results.flatten).must_equal Array.new(12, expected)
+    end
+
+    # Compiling is a pool's other bottleneck: a shared compile-only VM turns
+    # each new script body into bytecode, and before the release it held the
+    # GVL for the whole parse — stopping every other thread, including the
+    # warmers building the next VMs. What the ratio below measures is only
+    # the compiles overlapping each other; VM.new and dispose! are ~2% of the
+    # timed block, and both already release the GVL anyway.
+    #
+    # The release is unconditional here, unlike the two above: a compile-only
+    # eval runs no JS, so no bridge can fire and no can_eval_gvl_free gate is
+    # needed.
+    it "compiles concurrently with measurable speedup" do
+      source = bulky_source
+
+      assert_run_in_parallel do |iterations|
+        vm = Quickjs::VM.new(timeout_msec: 10_000)
+
+        begin
+          iterations.times { vm.compile(source) }
         ensure
           vm.dispose!
         end

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -2108,7 +2108,7 @@ describe "Quickjs::Blocking" do
     # this much further needs a different shape: JS_EVAL_FLAG_ASYNC turns
     # these top-level declarations into closure variables, and somewhere past
     # 65k of them the compile fails outright.
-    def bulky_source(functions: 500)
+    def bulky_source(functions: 2_000)
       Array.new(functions) {|i|
         "function f#{i}(a, b) { return a * #{i} + b - Math.sqrt(a + #{i}); }"
       }.join("\n")
@@ -2135,16 +2135,25 @@ describe "Quickjs::Blocking" do
       _(results.flatten).must_equal Array.new(12, expected)
     end
 
-    # Compiling is a pool's other bottleneck: a shared compile-only VM turns
-    # each new script body into bytecode, and before the release it held the
-    # GVL for the whole parse — stopping every other thread, including the
-    # warmers building the next VMs. What the ratio below measures is only
-    # the compiles overlapping each other; VM.new and dispose! are ~2% of the
-    # timed block, and both already release the GVL anyway.
+    # Compiling is a pool's other bottleneck: a dedicated compile-only VM
+    # turns each new script body into bytecode, and before the release it
+    # held the GVL for the whole parse — stopping every other thread,
+    # including the warmers building the next VMs.
     #
     # The release is unconditional here, unlike the two above: a compile-only
     # eval runs no JS, so no bridge can fire and no can_eval_gvl_free gate is
     # needed.
+    #
+    # 2000 functions rather than the 500 this started at, because 500 put the
+    # single-threaded side at ~13ms on a macOS runner and a window that short
+    # loses to scheduler noise: it measured 0.88 there and exhausted all three
+    # of the helper's attempts, while the same commit passed the same job on
+    # an earlier run. Raising the workload is available here even though #77
+    # ruled it out for the preload test — that one's confound is dispose!
+    # cost growing with the resident module defs, and a compile VM keeps
+    # nothing, so its dispose! stays flat. Measured: VM.new + dispose! is
+    # 0.04ms, which is 0.6% of the timed block at 500 and 0.1% at 2000, and
+    # the ratio itself holds at 0.50-0.58 from 31KB of source through 262KB.
     it "compiles concurrently with measurable speedup" do
       source = bulky_source
 

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -556,6 +556,23 @@ describe Quickjs::VM do
     assert_in_delta(started + 200, Time.now.to_f * 1000, 100)
   end
 
+  # compile arms the eval timer, which resets the clock the enclosing eval is
+  # being measured against. Unguarded, every c() here pushed started_at
+  # forward, interrupt_handler never saw the limit elapse, and the loop ran
+  # forever on a VM that asked to be bounded at 200ms.
+  #
+  # Bounded rather than `while (true)` so a regression fails instead of
+  # hanging the suite: one bridged compile costs ~7us, so the budget lapses
+  # around iteration 27k and the loop caps out at ~1.5s if it doesn't.
+  it "a compile inside a bridge callback does not reset the enclosing eval's budget" do
+    vm = Quickjs::VM.new(timeout_msec: 200)
+    vm.define_function('c') { vm.compile('function a() {}'); 1 }
+
+    _ {
+      vm.eval_code('let s = 0; for (let i = 0; i < 200000; i++) { s += c(); } s')
+    }.must_raise Quickjs::InterruptedError
+  end
+
   it "can enable setTimeout selectively" do
     skip "should timeout"
     vm = Quickjs::VM.new(features: [::Quickjs::MODULE_OS])


### PR DESCRIPTION
Continues the GVL-release line (#56 eval, #59 polyfill load, #63 `Runnable#run`, #75 module preload) onto `_compile_to_bytecode`. This is the one you flagged as a follow-up when #63 landed.

## What

`vm_m_compile`'s heavy step is a `JS_Eval` with `COMPILE_ONLY`, which parses and stops. That runs no JS and reaches no Ruby, so like the preload read it releases **unconditionally** — no `can_eval_gvl_free` gate — and parallelizes even on a bridged VM, where the polyfill/eval loads fall back to holding the GVL.

Your note on #63 was that "loader-free" is a property of today's `JS_EVAL_TYPE_GLOBAL` path rather than of `COMPILE_ONLY` itself. That's exactly the shape of the argument, so I wrote it in with the mechanism attached: `__JS_EvalInternal` assigns `m` only under `JS_EVAL_TYPE_MODULE` (quickjs.c:37094) and calls `js_resolve_module` only `if (m)` (:37164), and `COMPILE_ONLY` takes `ret_val = fun_obj` instead of `JS_EvalFunctionInternal` (:37169). A module compile gets no such freedom, and the comment says so.

## Why it's worth doing

A VM pool has two bottlenecks, not one. #75 covered per-VM module reads; this covers the other: a shared compile-only VM turning script bodies into bytecode used to hold the GVL for the whole parse, stopping every other thread — including the warmers building the next VMs.

## What stays GVL-held, on purpose

Serialization. The release region frees its buffers with `free()`, while `JS_WriteObject` hands back a `js_malloc`'d blob that has to go home through `js_free` to keep the runtime's memory accounting straight, and teaching the region a second kind of ownership for one caller isn't worth it. Measured cost: it pulls the two-thread ratio from ~0.5 to ~0.55, so about 5% of the available speedup.

## Three fixes the review turned up

None are caused by this change, but two of them are made worse or newly asymmetric by it, and the third is in the function this PR is rewriting.

1. **`vm_m_compile` / `vm_m_compileModule` never checked `oom_poisoned`.** Every other JS entry point does. Demonstrated: after driving a VM to OOM, `vm.eval_code('1')` correctly refuses but `vm.compile('1')` ran anyway. Compiling is the entry point that most needs it — the guard's own rationale is that "another throw inside the parser-error path can corrupt the shape table and segfault", and compile *is* the parser-error path.

2. **Both compile entry points duplicated the serialize tail, unguarded.** `rb_str_new` allocates and is a thread switch point, so a concurrent `dispose!` could free the context between `JS_WriteObject` and `js_free`; and any raise in between leaked the blob. That half was fine when the whole function was GVL-held-and-uncounted, but this PR guards the parse half and would have left the serialize half as the only unguarded part. Now it's one shared helper (also removing the duplication), run as a GVL-held JS entry with an ensure that frees both the blob and the compiled value.

3. **`arm_eval_timer` ran after argument parsing but before any disposed re-check.** `rb_scan_args` allocates, so it can yield to a concurrent `dispose!`, and `arm_eval_timer` then dereferences a freed runtime — ahead of the re-check inside the release region. Same window in `vm_m_evalCode`, so I fixed both rather than leaving one half-closed. This restores the invariant we settled on in #66: the disposed check sits after the last yield point and before the context is touched.

## Tests

The usual pair in `ParallelEval`, plus an OOM-poison test for compile. Each new guard is proven by removing it: the timing test fails 3/3 with the release reverted (held ~1.07 vs released ~0.55 against the helper's 0.8 threshold), and the poison test fails without the guard.

The margin here is wider and steadier than #75's — the held ratio stays at 1.01–1.11 across 12 KB to 129 KB of source instead of drifting toward the threshold, because the compile VM's `dispose!` cost is constant rather than growing with the workload. I also confirmed the timed block is ~98% compile, so the speedup isn't leaking in from `VM.new` / `dispose!`, which already release the GVL.

## One thing to know, not fixed here

`timeout_msec` does not bound a compile at all, and never did: the parser never calls `js_poll_interrupts` — every call site is in the interpreter, for-in, instanceof or regexp exec — so `Quickjs::VM.new(timeout_msec: 1).compile(<800 KB source>)` returns normally after 21 ms of parsing. `arm_eval_timer` is a formality for this caller. I left the behaviour alone and documented it at the call site; releasing the GVL arguably improves the situation, since a runaway parse no longer freezes every other Ruby thread. Happy to file it separately if you'd rather it were bounded.

## Review

Reviewed with an adversarial pass that tried to falsify the no-gate claim specifically. It confirmed no JS class or finalizer is registered anywhere in the extension (so a GC mid-parse can't reach Ruby), that the runtime uses the stock allocator, and that syntax-error backtrace building can't invoke a JS getter even when an outer eval's frames are live — which matters precisely because the release is unconditional, so `vm.define_function('go') { vm.compile('!!!') }` really does compile with the GVL released underneath a bridged eval. Buffer and counter discipline were checked empirically: 50 completed compiles and 50 interrupt-aborted compiles leave `malloc_size` byte-identical, and `dispose!` still succeeds after 30 interrupt rounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Review follow-ups

- **`compile` no longer restarts an enclosing eval's timeout budget.** `arm_eval_timer` overwrote `started_at`, so a compile issued from a `define_function` bridge in a loop meant `interrupt_handler` never saw the limit elapse and the enclosing eval never timed out at all. Guarded on `evals_in_flight == 0`, matching `vm_m_loadPolyfillBytecode`. Pre-existing on `main` and *not* compile-specific — `eval_code`, `call`, `drain_jobs!`, `import` and `Runnable#run` all still have it. Fixing those changes their semantics in the direction of more interruption, so it wants its own PR; the comment says so rather than claiming an invariant the file doesn't implement.
- **`vm_m_compileModule` no longer coerces a String after touching the runtime.** `StringValueCStr` can call `rb_str_modify`, which allocates, which is a yield point — and since C leaves argument evaluation order unspecified, `RSTRING_PTR(r_code)` could be taken before it. Hoisted above `arm_eval_timer`, disposed re-check after it, so all three compile paths have the same shape.
- **`compiled_to_bytecode_string`'s ownership rule is stated in full.** The comment claimed it consumes `j_compiled` unconditionally, and `run_held_js_entry`'s disposed check raises ahead of the `rb_ensure` that frees it. That path frees nothing and must not — `dispose!` hands the runtime to `JS_FreeRuntime` before the flag is observable, so a `JS_FreeValue` there is a use-after-free, not a cleanup.
- **`call_global_function_body`'s open-coded arming now goes through `arm_eval_timer`.** No behaviour change; it makes the call site greppable so the wider timer fix can't miss it.
- **`dispose!` now raises `ThreadError` during a `compile`.** On `main`, `Thread.new { vm.dispose! }` racing a large compile blocked on the GVL and then succeeded. `compile` elevates `evals_in_flight` twice now (the release region, then the serialize entry), so it refuses instead — the right trade-off, but user-visible, so `compile` is in the README's list. The parallelism section also said only `eval_code` and `Runnable#run` release the GVL; it now says what `compile` releases (the parse) and what it doesn't (the serialize, and `compile_module` entirely).

## Split out

The review turned up a reachable use-after-free in `define_function`, unrelated to compile — path resolution runs `JS_Eval` / `JS_GetPropertyStr`, an accessor property can run a bridge, and `evals_in_flight` was zero throughout, so `dispose!` succeeded and the traversal continued on a freed context. Fixed in #79 rather than here.

Two more found and not fixed anywhere yet, both worth their own issues:

- **Result conversion runs outside the counter.** `to_rb_value` is called after the region returns, and it executes user JS (getters via `JS_GetProperty`, `toJSON` via `JS_Call`, `toString` on functions). `vm.define_function('boom') { vm.dispose!; 1 }` plus `vm.eval_code("({ get a() { boom(); return 1; } })")` aborts with `corrupted double-linked list`. Same in `Runnable#run`.
- **A VM built on the main thread cannot be used from a Ruby thread.** `JS_NewRuntime` latches `rt->stack_top` at construction and nothing calls `JS_UpdateStackTop`, so a Ruby thread's lower stack trips `js_check_stack_overflow` immediately: `Thread.new { vm.eval_code('1 + 1') }.value` raises `Quickjs::SyntaxError: stack overflow` while the same call succeeds on the creating thread. That contradicts README L472 ("Handing a VM off between threads … is fine"), and it makes thread-to-thread handoff depend on which stack happens to sit lower — directly relevant to the warmer-pool pattern this GVL work is aimed at. `JS_UpdateStackTop` is available in the vendored engine.
