### PR TITLE
Retry a GVL parallelism comparison instead of failing on the first miss

### DIFF
--- a/test/quickjs_module_bytecode_test.rb
+++ b/test/quickjs_module_bytecode_test.rb
@@ -269,7 +269,16 @@ describe "module bytecode primitives" do
     # because every iteration has to read a module the VM hasn't seen: a repeat
     # is deduplicated into a no-op, so wrapping around the list would silently
     # give the one-thread and two-thread runs different amounts of work to do.
-    assert_run_in_parallel(total_iterations: modules.size) do |iterations|
+    #
+    # More trials than the helper's default because this workload has less
+    # headroom above the 0.8 threshold than the other GVL tests: it flapped on
+    # CI at 0.811, missing by 1.3%, on 4 of 8 jobs in one run while the same
+    # commit went 8 for 8 in the other. Each side is the min of its trials, so
+    # more attempts only lowers both floors, and a runner has to be busy across
+    # all of them to produce a false failure. Widening the threshold instead
+    # would buy false passes, which is the worse direction: the GVL-held case
+    # measures as low as 0.83 on some machines.
+    assert_run_in_parallel(trials: 12, total_iterations: modules.size) do |iterations|
       vm = Quickjs::VM.new
 
       begin

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -24,7 +24,22 @@ module QuickjsTestHelpers
   # Each thread should create its own VM internally, because QuickJS records
   # the runtime's stack base at construction time — using a VM from a thread
   # other than its creator trips a (false) stack-overflow guard.
-  def assert_run_in_parallel(trials: 5, total_iterations: 8, &workload)
+  # A whole comparison is retried rather than the trial count being raised,
+  # because the two are equivalent for flake resistance but not for cost. The
+  # margin on a busy runner is thinner than the paragraph above suggests: two
+  # different callers have flapped on macOS at 0.811 and 0.831, once taking 4
+  # of 8 jobs down while the same commit passed 8 of 8 in the sibling run, so
+  # runner-wide noise rather than the code under test. Raising `trials` to
+  # cover that costs every run (5 to 12 took the suite from 12s to 19s);
+  # re-measuring only when a comparison misses costs nothing when it passes,
+  # and a genuinely GVL-held workload still has to beat the threshold on a
+  # whole fresh comparison to slip through, which it doesn't: reverting a
+  # release under test fails all attempts.
+  #
+  # Widening the 0.8 would be the wrong lever either way. It buys false
+  # passes, and a GVL-held case can measure as low as 0.83, so there is little
+  # room above 0.8 before these stop detecting a lost release at all.
+  def assert_run_in_parallel(trials: 5, total_iterations: 8, attempts: 3, &workload)
     skip 'requires 2+ cores' if Etc.nprocessors < 2
 
     measure = ->(&block) {
@@ -35,21 +50,26 @@ module QuickjsTestHelpers
 
     workload.call(1) # warmup: load JIT / page in caches before timing
 
-    single = trials.times.map {
-      measure.call { workload.call(total_iterations) }
-    }.min
+    attempts.times do |attempt|
+      single = trials.times.map {
+        measure.call { workload.call(total_iterations) }
+      }.min
 
-    parallel = trials.times.map {
-      measure.call {
-        threads = Array.new(2) {
-          Thread.new { workload.call(total_iterations / 2) }
+      parallel = trials.times.map {
+        measure.call {
+          threads = Array.new(2) {
+            Thread.new { workload.call(total_iterations / 2) }
+          }
+          threads.each(&:join)
         }
-        threads.each(&:join)
-      }
-    }.min
+      }.min
 
-    assert_operator parallel, :<=, single * 0.8,
-      "parallel wall clock #{(parallel * 1000).round(1)}ms not ≤ 0.8 × single #{(single * 1000).round(1)}ms — work may not be releasing the GVL"
+      next if parallel > single * 0.8 && attempt < attempts - 1
+
+      assert_operator parallel, :<=, single * 0.8,
+        "parallel wall clock #{(parallel * 1000).round(1)}ms not ≤ 0.8 × single #{(single * 1000).round(1)}ms — work may not be releasing the GVL (#{attempt + 1} of #{attempts} attempts)"
+      return
+    end
   end
 end
 


### PR DESCRIPTION
The GVL timing comparisons flap on busy CI runners. Two different callers have now missed the helper's 0.8 threshold by a few percent on macOS:

| test | ratio | added by |
|---|---|---|
| `reads module bytecode concurrently with measurable speedup` | 0.811 | #75 |
| `runs compiled bytecode concurrently with measurable speedup` | 0.831 | #63 |

The first took down 4 of 8 jobs in one run while the same commit passed 8 of 8 in the sibling run, so this is runner-wide noise rather than the code under test. The second flapped *while this PR was in CI*, which is what turned it from a one-test problem into a helper problem: three of the four call sites use the default trial count, and the flake hit one of those.

## Retry rather than measure more

Both levers buy the same flake resistance, at very different prices:

| approach | suite time | notes |
|---|---|---|
| baseline | 12.1s | flaps |
| `trials: 12` everywhere | 19.5s | everyone pays on every run |
| retry on miss (this PR) | 12.6s | costs nothing when comparisons pass |

Each side of a comparison is already the `.min` of five trials, so a retry is a whole fresh comparison rather than a second roll of the same dice.

## It does not weaken the assertion

A GVL-held workload has to beat the threshold on an entire fresh comparison to slip through, and it doesn't. With the release under test reverted:

- **5 of 5 runs fail**, each exhausting all three attempts
- with the release restored, **5 of 5 pass**

The failure message now names the attempt count, so a flake and a real regression are distinguishable in a CI log.

Widening the 0.8 stays off the table in either shape: it buys false passes, and a GVL-held case measures as low as 0.83 on some machines, so there is very little room above 0.8 before these tests stop detecting a lost release at all. Raising `functions:` on the preload workload is off the table for the reason @ursm measured in #75 and I confirmed on a second machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)