### PR TITLE
Make define_function a counted JS entry point

### DIFF
--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -2289,20 +2289,21 @@ static VALUE vm_m_loadPolyfillBytecode(VALUE r_self, VALUE r_bytecode)
   return Qnil;
 }
 
-static VALUE vm_m_defineGlobalFunction(int argc, VALUE *argv, VALUE r_self)
+struct define_function_call
 {
-  rb_need_block();
-
+  VMData *data;
   VALUE r_name;
   VALUE r_flags;
   VALUE r_block;
-  rb_scan_args(argc, argv, "10*&", &r_name, &r_flags, &r_block);
+};
 
-  VMData *data;
-  TypedData_Get_Struct(r_self, VMData, &vm_type, data);
-
-  check_disposed(data);
-  check_no_gvl_release_in_flight(data);
+static VALUE define_global_function_body(VALUE p)
+{
+  struct define_function_call *call = (struct define_function_call *)p;
+  VMData *data = call->data;
+  VALUE r_name = call->r_name;
+  VALUE r_flags = call->r_flags;
+  VALUE r_block = call->r_block;
 
   if (RB_TYPE_P(r_name, T_ARRAY))
   {
@@ -2347,9 +2348,12 @@ static VALUE vm_m_defineGlobalFunction(int argc, VALUE *argv, VALUE r_self)
     {
       VALUE r_first_str = rb_funcall(RARRAY_AREF(r_name, 0), rb_intern("to_s"), 0);
       const char *first_seg = StringValueCStr(r_first_str);
-      // This lookup eval runs under whatever interrupt handler the
-      // previous eval left armed; refresh the clock so a lapsed budget
-      // can't misfire here and masquerade as "'%s' is not an object".
+      // Resolving the first segment is not a lookup, it is an eval: `myLib`
+      // can be an accessor property, so this runs arbitrary JS and can reach
+      // a Ruby bridge. It runs under whatever interrupt handler the previous
+      // eval left armed, so refresh the clock — a lapsed budget misfires here
+      // and masquerades as "'%s' is not an object", blaming the caller's path
+      // for what was a timeout.
       arm_eval_timer(data);
       j_parent = JS_Eval(data->context, first_seg, strlen(first_seg), vmInternalFilename, JS_EVAL_TYPE_GLOBAL);
 
@@ -2418,6 +2422,44 @@ static VALUE vm_m_defineGlobalFunction(int argc, VALUE *argv, VALUE r_self)
   }
 }
 
+// Registering a function is a JS entry point like any other, and was the one
+// that never said so. The body resolves the path with JS_Eval and
+// JS_GetPropertyStr, either of which can land on an accessor property and run
+// user JS that calls a bridge — and it interleaves that with rb_funcall(to_s)
+// on caller-supplied objects, which yields the GVL. With evals_in_flight left
+// at zero throughout, dispose! did not refuse:
+//
+//   vm.define_function('boom') { vm.dispose!; 1 }
+//   vm.eval_code("Object.defineProperty(globalThis, 'myLib', { get() { boom(); return {}; } }); 0")
+//   vm.define_function(['myLib', 'hello']) { 1 }   # SIGSEGV
+//
+// dispose! succeeds from inside the getter, and the traversal then runs
+// JS_GetPropertyStr and JS_FreeValue against a freed JSContext. Elevating the
+// counter for the whole body is what every other JS entry point already does,
+// and it turns that into the ThreadError dispose! owes the caller.
+static VALUE vm_m_defineGlobalFunction(int argc, VALUE *argv, VALUE r_self)
+{
+  rb_need_block();
+
+  VALUE r_name;
+  VALUE r_flags;
+  VALUE r_block;
+  rb_scan_args(argc, argv, "10*&", &r_name, &r_flags, &r_block);
+
+  VMData *data;
+  TypedData_Get_Struct(r_self, VMData, &vm_type, data);
+
+  check_disposed(data);
+  check_no_gvl_release_in_flight(data);
+
+  struct define_function_call call = {
+      .data = data,
+      .r_name = r_name,
+      .r_flags = r_flags,
+      .r_block = r_block,
+  };
+  return run_held_js_entry(data, define_global_function_body, (VALUE)&call);
+}
 
 struct js_entry_call
 {

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -877,6 +877,35 @@ describe Quickjs::VM do
         err = _ { @vm.define_function(["obj", 123]) { } }.must_raise TypeError
         _(err.message).must_include "Symbol or a String"
       end
+
+      # Resolving a path is not a lookup: the first segment goes through
+      # JS_Eval and the rest through JS_GetPropertyStr, so an accessor
+      # property runs user JS that can call back into Ruby. Until
+      # define_function elevated evals_in_flight for its whole body, dispose!
+      # did not refuse from inside that callback, and the traversal carried on
+      # against a freed JSContext — a SIGSEGV rather than an exception, so a
+      # regression takes the whole suite down with it.
+      it "refuses dispose! from a bridge reached while resolving the path" do
+        outcome = nil
+        @vm.eval_code(<<~JS)
+          globalThis._lib = {};
+          Object.defineProperty(globalThis, 'myLib', { get: () => { probe(); return _lib; } });
+          0
+        JS
+        @vm.define_function('probe') {
+          outcome = begin
+            @vm.dispose!
+            :disposed
+          rescue ThreadError => e
+            e
+          end
+          nil
+        }
+
+        _(@vm.define_function(["myLib", "hello"]) { 42 }).must_equal [:myLib, :hello]
+        _(outcome).must_be_kind_of ThreadError
+        _(@vm.eval_code("_lib.hello()")).must_equal 42
+      end
     end
   end
 


### PR DESCRIPTION
`define_function` is a JS entry point that never declared itself one, and the gap is reachable as a use-after-free.

## The bug

Resolving an array path runs `JS_Eval` on the first segment and `JS_GetPropertyStr` on the rest. Either can land on an accessor property, which runs user JS, which can call a `define_function` bridge. The body also interleaves that with `rb_funcall(:to_s)` on caller-supplied objects, which yields the GVL. Through all of it `evals_in_flight` stayed at zero, so `dispose!` had nothing to refuse:

```rb
vm = Quickjs::VM.new
vm.define_function('boom') { vm.dispose!; 1 }
vm.eval_code("Object.defineProperty(globalThis, 'myLib', { get() { boom(); return {}; } }); 0")
vm.define_function(['myLib', 'hello']) { 1 }
```

```
dispose! SUCCEEDED from inside the bridge
[BUG] Segmentation fault at 0xfffffffffffffffc
ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +PRISM [x86_64-linux]
c:0003 p:---- s:0012 e:000011 l:y b:0001 CFUNC  :define_function
```

`dispose!` returns from inside the getter, `JS_FreeRuntime` runs, and the traversal carries on with `JS_GetPropertyStr` and `JS_FreeValue` on a freed `JSContext`. The same shape reaches it from another thread — `Thread.new { vm.dispose! }` racing a `define_function` whose path getter blocks — since the GVL is yielded inside the body either way.

## The fix

Split the body out and run it through `run_held_js_entry`, which is what `import`, `call` and `drain_jobs!` already do. The counter is then elevated for the whole traversal and `dispose!` raises `ThreadError`, which is the documented contract (README L446). No behaviour changes for any correct caller: `grep` finds no internal `define_function` in `lib/`, so nothing in the gem nests one inside another JS entry point.

The struct split is mechanical — `data`, `r_name`, `r_flags`, `r_block` move into a `struct define_function_call` passed by address, matching `struct js_entry_call`.

## Review

Adversarially reviewed. Counter balance was exercised on every raise path in the body (empty array, bad element type, first-segment-not-object, mid-path-not-object, bad name type, a `to_s` returning a non-String) — `run_held_js_entry`'s `rb_ensure` covers all of them and `dispose!` succeeds after each, so nothing is stranded. GC safety was stress-tested with `GC.compact` from inside a path getter and with `GC.stress` around a three-segment define; the struct is address-taken and therefore on the machine stack, and the `rb_ensure` longjmp target is deeper than the entry frame, so `&call` is live when the cleanup runs.

## Two related holes this does not close

Found while reviewing this; both are independent of the fix and want their own change.

- **Result conversion runs outside the counter.** `to_rb_value` is called after `run_held_js_entry` / the release region has returned, and conversion executes user JS — `JS_GetProperty` fires getters, `toJSON` goes through `JS_Call`, functions get `toString`. So `vm.define_function('boom') { vm.dispose!; 1 }` plus `vm.eval_code("({ get a() { boom(); return 1; } })")` disposes mid-conversion and aborts with `corrupted double-linked list`. Same for `Runnable#run`.
- **The traversal cannot tell "interrupted" from "not an object".** If the eval timer fires during path resolution, `JS_IsException(j_parent)` is true and the caller gets `ArgumentError: cannot define function: 'myLib' is not an object`. The block has already been stored in `defined_functions` at that point, which also permanently demotes the VM off the GVL-release fast path via `can_eval_gvl_free`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
