### PR TITLE
Keep the generated import filename alive until the bridge is built

### DIFF
--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -2435,6 +2435,7 @@ static VALUE import_body(VALUE p)
   VALUE r_custom_exposure = rb_hash_aref(r_opts, ID2SYM(rb_intern("code_to_expose")));
 
   char *filename;
+  char generated_filename[QUICKJSRB_GENERATED_NAME_SIZE];
   VALUE r_seeded_key = Qnil;
   if (!NIL_P(r_filename))
   {
@@ -2442,7 +2443,8 @@ static VALUE import_body(VALUE p)
   }
   else
   {
-    filename = random_string();
+    random_filename(generated_filename);
+    filename = generated_filename;
     char *source = StringValueCStr(r_from);
     JSValue module = JS_Eval(data->context, source, strlen(source), filename, JS_EVAL_TYPE_MODULE | JS_EVAL_FLAG_COMPILE_ONLY);
     if (JS_IsException(module))

--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -2439,6 +2439,12 @@ static VALUE import_body(VALUE p)
   VALUE r_seeded_key = Qnil;
   if (!NIL_P(r_filename))
   {
+    // Borrowed for the rest of the call, so r_filename has to outlive the
+    // bridge snprintf below. A literal String is rooted by the kwargs hash
+    // through argv, but StringValueCStr writes a coerced String back through
+    // &r_filename, and a to_str result is referenced by nothing else — only
+    // this local, which the compiler is free to treat as dead right here
+    // while filename is still being read. Guarded after the last read.
     filename = StringValueCStr(r_filename);
   }
   else
@@ -2491,6 +2497,7 @@ static VALUE import_body(VALUE p)
   int length = snprintf(NULL, 0, importAndGlobalizeModule, import_name, filename, globalize);
   char *result = (char *)malloc(length + 1);
   snprintf(result, length + 1, importAndGlobalizeModule, import_name, filename, globalize);
+  RB_GC_GUARD(r_filename);
 
   JSValue j_codeResult = JS_Eval(data->context, result, strlen(result), vmInternalFilename, JS_EVAL_TYPE_MODULE);
   free(result);

--- a/ext/quickjsrb/quickjsrb.h
+++ b/ext/quickjsrb/quickjsrb.h
@@ -249,14 +249,21 @@ static VALUE vm_alloc(VALUE r_self)
 
 // Utils
 
-static char *random_string()
+#define QUICKJSRB_GENERATED_NAME_SIZE 16
+
+static void random_filename(char buf[QUICKJSRB_GENERATED_NAME_SIZE])
 {
   VALUE r_rand = rb_funcall(
       rb_const_get(rb_cClass, rb_intern("SecureRandom")),
       rb_intern("alphanumeric"),
       1,
       INT2NUM(12));
-  return StringValueCStr(r_rand);
+  // Copy the bytes out rather than handing back StringValueCStr(r_rand):
+  // nothing else references the generated String, so a GC anywhere in the
+  // caller's remaining work frees it and leaves the caller formatting bytes
+  // from a recycled slot.
+  snprintf(buf, QUICKJSRB_GENERATED_NAME_SIZE, "%s", StringValueCStr(r_rand));
+  RB_GC_GUARD(r_rand);
 }
 
 static bool is_native_error_name(const char *error_name)

--- a/ext/quickjsrb/quickjsrb.h
+++ b/ext/quickjsrb/quickjsrb.h
@@ -249,7 +249,11 @@ static VALUE vm_alloc(VALUE r_self)
 
 // Utils
 
-#define QUICKJSRB_GENERATED_NAME_SIZE 16
+// Derived, not two independent numbers: snprintf truncates silently, so a
+// buffer sized apart from the requested length would quietly hand back a
+// shorter name than asked for the moment anyone raised the entropy.
+#define QUICKJSRB_GENERATED_NAME_LEN 12
+#define QUICKJSRB_GENERATED_NAME_SIZE (QUICKJSRB_GENERATED_NAME_LEN + 1)
 
 static void random_filename(char buf[QUICKJSRB_GENERATED_NAME_SIZE])
 {
@@ -257,7 +261,7 @@ static void random_filename(char buf[QUICKJSRB_GENERATED_NAME_SIZE])
       rb_const_get(rb_cClass, rb_intern("SecureRandom")),
       rb_intern("alphanumeric"),
       1,
-      INT2NUM(12));
+      INT2NUM(QUICKJSRB_GENERATED_NAME_LEN));
   // Copy the bytes out rather than handing back StringValueCStr(r_rand):
   // nothing else references the generated String, so a GC anywhere in the
   // caller's remaining work frees it and leaves the caller formatting bytes

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -1308,6 +1308,22 @@ describe Quickjs::VM do
       _(asked).must_be_empty
     end
 
+    # A filename: that is not already a String is coerced by StringValueCStr,
+    # and the coerced String is referenced by nothing the caller can see: the
+    # kwargs hash still holds the original object. Pins that the borrowed
+    # pointer survives Quickjs._build_import running arbitrary Ruby.
+    it "accepts a to_str filename and still resolves it through the loader" do
+      coercible = Object.new
+      def coercible.to_str = 'mod.js'.dup
+
+      @vm.module_loader = ->(specifier, _importer) {
+        "export default () => 'from loader';" if specifier == 'mod.js'
+      }
+      @vm.import('Imported', filename: coercible)
+
+      _(@vm.eval_code('Imported()')).must_equal 'from loader'
+    end
+
     it "passes the from: bridge filename as importer to a 2-arity loader" do
       seen_importer = nil
       @vm.module_loader = ->(specifier, importer) {

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -1295,6 +1295,19 @@ describe Quickjs::VM do
       _ { @vm.module_loader = 'not a proc' }.must_raise TypeError
     end
 
+    # The bridge module imports the generated filename after looking it up in
+    # the resolution cache. A filename that went stale before the bridge source
+    # was built reads as garbage, misses the cache, and falls through here, so
+    # an empty `asked` is what pins the generated name staying valid.
+    it "never asks the loader for the bridge filename it generated" do
+      asked = []
+      @vm.module_loader = ->(specifier, _importer) { asked << specifier; nil }
+      @vm.import('Imported', from: File.read('./test/fixture.esm.js'))
+
+      _(@vm.eval_code("Imported()")).must_equal "I am a default export of ESM."
+      _(asked).must_be_empty
+    end
+
     it "passes the from: bridge filename as importer to a 2-arity loader" do
       seen_importer = nil
       @vm.module_loader = ->(specifier, importer) {


### PR DESCRIPTION
📝 This PR is sponsored by @persona-id

`random_string()` returned `StringValueCStr`'s pointer into a Ruby String that nothing else referenced, so the moment it returned, `filename` in import_body was dangling and waiting for a GC. The window is wide: seeding the resolution cache and then Quickjs._build_import running arbitrary Ruby both allocate before the bridge-source snprintf reads it.

Today that read happens to work, because conservative machine-stack scanning still finds the dead random_string frame -- which is why GC.stress alone can't provoke it. Overwriting that frame with a 32KB scratch buffer before forcing a GC does free the String, and the recycled slot made `filename` read as empty, turning an inline import into "module loader returned no source for ''". The mask is a property of frame layout, so a different compiler, a newer Ruby, or any deeper intervening call can take it away.

Copying the bytes into a caller-owned buffer stops the helper handing out a pointer it doesn't own, leaving no lifetime to get wrong and no long-range RB_GC_GUARD for a later edit to outlive.

The test pins the observable contract: an inline import resolves its own bridge filename from the cache and never falls through to the module_loader. It does not fail on the unfixed build -- the stale read returns the right bytes there -- but it is what trips if the accidental root ever goes away.