### PR TITLE
Refuse a second thread entering a VM that is already evaluating

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,7 +469,16 @@ Useful when porting JS that assumed V8's implicit-drain semantics — V8 (and th
 
 The rules for sharing VMs across threads:
 
-- **One VM, one thread at a time.** A `Quickjs::VM` is not safe for concurrent use from multiple threads — QuickJS contexts have no internal locking. Handing a VM off between threads (e.g. constructing it on a warmer thread and using it on another) is fine as long as only one thread touches it at a time.
+- **One VM, one thread at a time**, and this one is enforced. A `Quickjs::VM` is not safe for concurrent use from multiple threads — QuickJS contexts have no internal locking — so a second thread entering while another is mid-call raises `ThreadError` rather than corrupting the heap:
+
+  ```ruby
+  vm = Quickjs::VM.new
+  Thread.new { vm.eval_code('while (true) {}') }
+  vm.eval_code('1 + 1')
+  #=> ThreadError: cannot use a Quickjs::VM from two threads at once; it is already evaluating on #<Thread:...>
+  ```
+
+  It is refusal, not serialization: nothing queues and waits. Every method that touches the runtime is covered, `gc!` and `memory_usage` included. Handing a VM off between threads (e.g. constructing it on a warmer thread and using it on another) is still fine, since ownership is only held for the duration of a call. So is a bridge re-entering its own VM — a `define_function` proc or `on_log` listener calling `eval_code` is the same thread, and is allowed.
 - **The stack budget follows the evaluating thread.** QuickJS records the creating thread's stack bounds once, which used to make a handoff trip a false stack-overflow error on trivial code. The limit is now re-based on each outermost entry against the stack of the thread about to run JS, so where the VM was built no longer matters. `max_stack_size` is a ceiling rather than a guarantee: a Ruby thread's machine stack is a fraction of the main thread's, so the budget in force is whatever that thread actually has, less a margin to report the overflow with.
 - **Register bridges before evaluating.** `define_function`, `module_loader=`, and `on_unhandled_rejection` raise `ThreadError` while a GVL-released eval is in flight (e.g. from inside an `on_log` listener) — the running JS was allowed to release the GVL precisely because no bridge existed when it started.
 - **`MODULE_OS` caveat:** `os.signal` and `os.ttySetRaw` mutate process-wide state inside quickjs-libc, so don't call those two from VMs running concurrently on different threads. The common APIs (`os.sleep`, `os.setTimeout`, file I/O) only touch per-runtime state and are safe.

--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -27,6 +27,9 @@ const int num_native_errors = sizeof(native_errors) / sizeof(native_errors[0]);
 static int dispatch_log(VMData *data, const char *severity, VALUE r_row);
 static void check_disposed(VMData *data);
 static void run_gvl_release_region(VMData *data, void *(*job_run)(void *), void *job, JSValue *j_result, void *owned_buf0, void *owned_buf1);
+// Defined below, next to the stack-bounds query it depends on; enter_js_entry
+// above needs it.
+static void rebase_stack_limit(VMData *data);
 
 JSValue to_js_value(JSContext *ctx, VALUE r_value);
 VALUE to_rb_value(JSContext *ctx, JSValue j_val);
@@ -1489,6 +1492,72 @@ static void *eval_code_job_run(void *p)
   return NULL;
 }
 
+// Opens a JS entry on this VM, or refuses if another thread already has one
+// open. README's "one VM, one thread at a time" rule stops being advisory
+// here: QuickJS contexts have no internal locking, so two threads inside
+// JS_Eval on the same context corrupt the heap, and since eval can release
+// the GVL they really do run at the same time rather than interleaving by
+// accident.
+//
+// A mutex would be the wrong instrument twice over. Held across the release
+// it deadlocks — the unlock lives after rb_thread_call_without_gvl
+// re-acquires the GVL, so a second thread blocks in pthread_mutex_lock
+// while holding the GVL and the first can never get back in to release it.
+// And a plain mutex self-deadlocks on the nesting this codebase relies on,
+// where an on_log listener inside a released region re-enters the same VM
+// on the same thread. Comparing the owner has neither problem: it lets
+// nesting through by construction and needs no lock at all.
+// Split from the raise so callers holding malloc'd state can test first and
+// clean up before unwinding (run_gvl_release_region owns input buffers by
+// the time it asks).
+static bool js_entry_owned_elsewhere(VMData *data)
+{
+  return data->evals_in_flight > 0 && data->owner_thread != rb_thread_current();
+}
+
+static void refuse_cross_thread_entry(VMData *data)
+{
+  rb_raise(rb_eThreadError,
+           "cannot use a Quickjs::VM from two threads at once; it is already evaluating on %+" PRIsVALUE,
+           data->owner_thread);
+}
+
+// Entry-point guard, sitting next to check_disposed. enter_js_entry alone is
+// not enough: several entry points read or mutate runtime state before they
+// reach a counted region — JS_IsJobPending in drain_jobs!, arm_eval_timer
+// almost everywhere, JS_SetModuleLoaderFunc2 in compile_module — and those
+// touches are already unsafe against another thread's in-flight JS.
+static void check_js_entry_owner(VMData *data)
+{
+  if (js_entry_owned_elsewhere(data))
+    refuse_cross_thread_entry(data);
+}
+
+static void enter_js_entry(VMData *data)
+{
+  if (js_entry_owned_elsewhere(data))
+    refuse_cross_thread_entry(data);
+
+  // After the refusal and before the count, in that order for two reasons.
+  // The re-base mutates rt->stack_top, which another thread's in-flight JS is
+  // checking itself against, so a caller about to be turned away must not have
+  // touched it. And rebase_stack_limit reads evals_in_flight to recognise the
+  // outermost entry, which the increment below is about to spoil.
+  rebase_stack_limit(data);
+
+  data->owner_thread = rb_thread_current();
+  data->evals_in_flight++;
+}
+
+// Balances enter_js_entry. Clearing the owner only as the outermost entry
+// closes is what lets a VM be handed between threads sequentially, which
+// the README allows and pool warmers depend on.
+static void leave_js_entry(VMData *data)
+{
+  if (--data->evals_in_flight == 0)
+    data->owner_thread = Qnil;
+}
+
 // A GVL-release region — the one place that owns the handshake required to
 // run a pure-C QuickJS job with the GVL released: the save/restore of
 // gvl_released_js (restore, not clear, so a region nested through an
@@ -1525,7 +1594,7 @@ static VALUE gvl_release_region_cleanup(VALUE p)
   struct gvl_release_region *region = (struct gvl_release_region *)p;
   VMData *data = region->data;
   data->gvl_released_js = region->prev_gvl_released;
-  data->evals_in_flight--;
+  leave_js_entry(data);
   data->gvl_release_regions--;
   free(region->owned_bufs[0]);
   free(region->owned_bufs[1]);
@@ -1645,11 +1714,14 @@ static void rebase_stack_limit(VMData *data)
 
 static void run_gvl_release_region(VMData *data, void *(*job_run)(void *), void *job, JSValue *j_result, void *owned_buf0, void *owned_buf1)
 {
-  if (data->disposed)
+  // Both refusals have to happen before the buffers are handed to the
+  // region, since the rb_ensure that would free them is not armed yet.
+  if (data->disposed || js_entry_owned_elsewhere(data))
   {
     free(owned_buf0);
     free(owned_buf1);
-    check_disposed(data); // raises
+    check_disposed(data);            // raises when disposed
+    refuse_cross_thread_entry(data); // otherwise it was the owner check
   }
 
   struct gvl_release_region region = {
@@ -1662,8 +1734,7 @@ static void run_gvl_release_region(VMData *data, void *(*job_run)(void *), void 
       .completed = false,
   };
 
-  rebase_stack_limit(data);
-  data->evals_in_flight++;
+  enter_js_entry(data); // cannot raise: the check above already passed
   data->gvl_release_regions++;
   data->gvl_released_js = true;
   rb_ensure(gvl_release_region_run, (VALUE)&region, gvl_release_region_cleanup, (VALUE)&region);
@@ -1685,7 +1756,7 @@ static void check_no_gvl_release_in_flight(VMData *data)
 
 static VALUE evals_in_flight_release(VALUE p)
 {
-  ((VMData *)p)->evals_in_flight--;
+  leave_js_entry((VMData *)p);
   return Qnil;
 }
 
@@ -1706,8 +1777,9 @@ static VALUE evals_in_flight_release(VALUE p)
 static VALUE run_held_js_entry(VMData *data, VALUE (*body)(VALUE), VALUE arg)
 {
   check_disposed(data);
-  rebase_stack_limit(data);
-  data->evals_in_flight++;
+  // Raises before the ensure is armed, which is safe here: unlike the
+  // release region, this path owns no malloc'd state at this point.
+  enter_js_entry(data);
   return rb_ensure(body, arg, evals_in_flight_release, (VALUE)data);
 }
 
@@ -1793,6 +1865,7 @@ static VALUE vm_m_evalCode(int argc, VALUE *argv, VALUE r_self)
 
   check_disposed(data);
   check_oom_poisoned(data);
+  check_js_entry_owner(data);
 
   VALUE r_code, r_opts;
   rb_scan_args(argc, argv, "1:", &r_code, &r_opts);
@@ -2003,6 +2076,7 @@ static VALUE vm_m_compile(int argc, VALUE *argv, VALUE r_self)
 
   check_disposed(data);
   check_oom_poisoned(data);
+  check_js_entry_owner(data);
 
   VALUE r_code, r_opts;
   rb_scan_args(argc, argv, "1:", &r_code, &r_opts);
@@ -2102,6 +2176,7 @@ static VALUE vm_m_compileModule(VALUE r_self, VALUE r_code, VALUE r_name)
 
   check_disposed(data);
   check_oom_poisoned(data);
+  check_js_entry_owner(data);
   Check_Type(r_code, T_STRING);
   Check_Type(r_name, T_STRING);
 
@@ -2171,6 +2246,7 @@ static VALUE vm_m_preloadModuleBytecode(VALUE r_self, VALUE r_bytecode, VALUE r_
 
   check_disposed(data);
   check_oom_poisoned(data);
+  check_js_entry_owner(data);
 
   // Strict String rather than StringValue's coercion, matching
   // vm_m_evalBytecode: bytecode is a binary blob, so there's no sensible
@@ -2269,6 +2345,7 @@ static VALUE vm_m_evalBytecode(VALUE r_self, VALUE r_bytecode)
 
   check_disposed(data);
   check_oom_poisoned(data);
+  check_js_entry_owner(data);
 
   if (!RB_TYPE_P(r_bytecode, T_STRING))
   {
@@ -2353,6 +2430,7 @@ static VALUE vm_m_loadPolyfillBytecode(VALUE r_self, VALUE r_bytecode)
 
   check_disposed(data);
   check_oom_poisoned(data);
+  check_js_entry_owner(data);
 
   // "Unbudgeted" needs enforcing, not just skipping arm_eval_timer: the
   // interrupt handler installed by a previous eval stays armed with that
@@ -2554,6 +2632,7 @@ static VALUE vm_m_defineGlobalFunction(int argc, VALUE *argv, VALUE r_self)
   TypedData_Get_Struct(r_self, VMData, &vm_type, data);
 
   check_disposed(data);
+  check_js_entry_owner(data);
   check_no_gvl_release_in_flight(data);
 
   struct define_function_call call = {
@@ -2715,6 +2794,7 @@ static VALUE vm_m_callGlobalFunction(int argc, VALUE *argv, VALUE r_self)
 
   check_disposed(data);
   check_oom_poisoned(data);
+  check_js_entry_owner(data);
 
   // evals_in_flight stays elevated for the whole call, not just the
   // JS_Eval / JS_Call moments: the body holds live JSValues across Ruby
@@ -2876,6 +2956,7 @@ static VALUE vm_m_import(int argc, VALUE *argv, VALUE r_self)
 
   check_disposed(data);
   check_oom_poisoned(data);
+  check_js_entry_owner(data);
 
   // Module top-level code is user JS like any eval — budget it. Without
   // this, import ran under whatever handler the previous entry point
@@ -2932,6 +3013,7 @@ static VALUE vm_m_memoryUsage(VALUE r_self)
   VMData *data;
   TypedData_Get_Struct(r_self, VMData, &vm_type, data);
   check_disposed(data);
+  check_js_entry_owner(data);
   JSMemoryUsage s;
   JS_ComputeMemoryUsage(JS_GetRuntime(data->context), &s);
   VALUE h = rb_hash_new();
@@ -2955,6 +3037,7 @@ static VALUE vm_m_runGC(VALUE r_self)
   VMData *data;
   TypedData_Get_Struct(r_self, VMData, &vm_type, data);
   check_disposed(data);
+  check_js_entry_owner(data);
   JS_RunGC(JS_GetRuntime(data->context));
   return Qnil;
 }
@@ -2983,6 +3066,7 @@ static VALUE vm_m_drainJobs(VALUE r_self)
 
   check_disposed(data);
   check_oom_poisoned(data);
+  check_js_entry_owner(data);
 
   if (!JS_IsJobPending(JS_GetRuntime(data->context)))
     return INT2NUM(0);

--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -26,6 +26,7 @@ const int num_native_errors = sizeof(native_errors) / sizeof(native_errors[0]);
 
 static int dispatch_log(VMData *data, const char *severity, VALUE r_row);
 static void check_disposed(VMData *data);
+static void check_js_entry_owner(VMData *data);
 static void run_gvl_release_region(VMData *data, void *(*job_run)(void *), void *job, JSValue *j_result, void *owned_buf0, void *owned_buf1);
 // Defined below, next to the stack-bounds query it depends on; enter_js_entry
 // above needs it.
@@ -1263,6 +1264,16 @@ static VALUE vm_m_initialize(int argc, VALUE *argv, VALUE r_self)
 
   VMData *data;
   TypedData_Get_Struct(r_self, VMData, &vm_type, data);
+
+  // Reachable only through send, since initialize is private, but reachable:
+  // everything below here writes to the runtime, so this is a JS entry point
+  // in all but name and was the one place not saying so. Disposed first,
+  // because JS_SetContextOpaque on the next line dereferences a context that
+  // dispose! has already freed, which segfaults rather than raising. Then the
+  // owner, because the same writes landing beside another thread's in-flight
+  // JS_Eval is the corruption this whole file is arranged to refuse.
+  check_disposed(data);
+  check_js_entry_owner(data);
 
   data->eval_time->limit_ms = (int64_t)NUM2UINT(r_timeout_msec);
   JS_SetContextOpaque(data->context, data);

--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -2115,6 +2115,9 @@ static VALUE vm_m_compile(int argc, VALUE *argv, VALUE r_self)
   // a semantics change that deserves its own PR rather than a ride on this
   // one.
   check_disposed(data);
+  // Same re-check as vm_m_evalCode, for the same reason: parsing yielded, so
+  // the owner may have changed since the check at entry.
+  check_js_entry_owner(data);
   if (data->evals_in_flight == 0)
     arm_eval_timer(data);
 
@@ -2175,6 +2178,15 @@ static JSModuleDef *quickjsrb_stub_module_loader(JSContext *ctx, const char *mod
 // Quickjs._compile_registered_module honors that by compiling on a disposable
 // VM it owns; exposing this publicly would let a compile race an import on a
 // shared VM and resolve it against stubs.
+struct compile_module_job
+{
+  VMData *data;
+  VALUE r_code;
+  const char *name;
+};
+
+static VALUE compile_module_body(VALUE p);
+
 static VALUE vm_m_compileModule(VALUE r_self, VALUE r_code, VALUE r_name)
 {
   VMData *data;
@@ -2198,17 +2210,36 @@ static VALUE vm_m_compileModule(VALUE r_self, VALUE r_code, VALUE r_name)
   const char *name = StringValueCStr(r_name);
 
   check_disposed(data);
+  // Re-checked after the coercion above yields, and then immediately turned
+  // into a claim by run_held_js_entry below: unlike the other compile paths,
+  // the runtime work here is a full JS_Eval plus a runtime-level loader swap,
+  // so a check that recorded nothing would leave both of those exposed to a
+  // second thread passing the same idle check.
+  check_js_entry_owner(data);
   // Guarded for the reason spelled out in vm_m_compile: only the outermost
   // JS entry point owns the timeout budget. Nesting can't happen on this
   // path today — it is private and both callers compile on a disposable VM
   // they own — but the two compile entry points arming differently would be
   // a difference with no reason behind it.
+  // Armed before the claim below, not after: the condition reads the counter
+  // that run_held_js_entry is about to raise, so claiming first would skip
+  // the arm on every outermost compile.
   if (data->evals_in_flight == 0)
     arm_eval_timer(data);
 
-  // The JS_Eval below is inline rather than routed through either counting
-  // choke point, so it takes the re-base itself.
-  rebase_stack_limit(data);
+  struct compile_module_job job = {
+      .data = data,
+      .r_code = r_code,
+      .name = name,
+  };
+  return run_held_js_entry(data, compile_module_body, (VALUE)&job);
+}
+
+static VALUE compile_module_body(VALUE p)
+{
+  struct compile_module_job *job = (struct compile_module_job *)p;
+  VMData *data = job->data;
+  VALUE r_code = job->r_code;
 
   JS_SetModuleLoaderFunc2(JS_GetRuntime(data->context), NULL, quickjsrb_stub_module_loader,
                           js_module_check_attributes, NULL);
@@ -2220,7 +2251,7 @@ static VALUE vm_m_compileModule(VALUE r_self, VALUE r_code, VALUE r_name)
   // lexer's comment and regexp scanners test for the NUL before the end
   // pointer, so a buffer without one would let a source ending mid-comment
   // read on into whatever follows it in memory.
-  JSValue j_mod = JS_Eval(data->context, RSTRING_PTR(r_code), RSTRING_LEN(r_code), name,
+  JSValue j_mod = JS_Eval(data->context, RSTRING_PTR(r_code), RSTRING_LEN(r_code), job->name,
                           JS_EVAL_TYPE_MODULE | JS_EVAL_FLAG_COMPILE_ONLY);
   register_module_loader_funcs(data);
   if (JS_IsException(j_mod))

--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -1887,6 +1887,12 @@ static VALUE vm_m_evalCode(int argc, VALUE *argv, VALUE r_self)
   // already refused a non-String), and dispose! refuses once either of those
   // has counted us, so re-checking here closes the window on both paths.
   check_disposed(data);
+  // Ownership needs the same re-check as disposal, and for the same reason:
+  // the parsing above yields, so another thread can have taken the VM since
+  // the check at entry. arm_eval_timer writes the shared eval_time, so
+  // without this it would reset the budget of the eval that thread is
+  // already running — the counted regions below refuse, but only after.
+  check_js_entry_owner(data);
   arm_eval_timer(data);
 
   StringValue(r_code);
@@ -2605,11 +2611,14 @@ static VALUE define_global_function_body(VALUE p)
 }
 
 // Registering a function is a JS entry point like any other, and was the one
-// that never said so. The body resolves the path with JS_Eval and
-// JS_GetPropertyStr, either of which can land on an accessor property and run
-// user JS that calls a bridge — and it interleaves that with rb_funcall(to_s)
-// on caller-supplied objects, which yields the GVL. With evals_in_flight left
-// at zero throughout, dispose! did not refuse:
+// that never said so. Two independent problems land on this call, and routing
+// the body through run_held_js_entry is what closes both.
+//
+// Lifetime: the body resolves the path with JS_Eval and JS_GetPropertyStr,
+// either of which can land on an accessor property and run user JS that calls
+// a bridge — and it interleaves that with rb_funcall(to_s) on caller-supplied
+// objects, which yields the GVL. With evals_in_flight left at zero throughout,
+// dispose! did not refuse:
 //
 //   vm.define_function('boom') { vm.dispose!; 1 }
 //   vm.eval_code("Object.defineProperty(globalThis, 'myLib', { get() { boom(); return {}; } }); 0")
@@ -2619,6 +2628,22 @@ static VALUE define_global_function_body(VALUE p)
 // JS_GetPropertyStr and JS_FreeValue against a freed JSContext. Elevating the
 // counter for the whole body is what every other JS entry point already does,
 // and it turns that into the ThreadError dispose! owes the caller.
+//
+// Concurrency: that same GVL yield lets a second thread in. A bare owner check
+// would pass on an idle VM and record nothing, so the second thread passes the
+// same idle check and walks into JS_Eval alongside the traversal. Only
+// claiming the VM closes that.
+//
+// Neither reason subsumes the other — one is a single thread freeing the
+// context under its own traversal, the other is two threads inside JS_Eval at
+// once — so retiring one of them is not grounds for unwinding the routing.
+//
+// The absent check_js_entry_owner beside check_disposed is deliberate, not the
+// oversight it looks like next to the other six entry points: this is the one
+// where nothing touches the runtime before the counted region, so the claim
+// inside run_held_js_entry is the whole guard. check_no_gvl_release_in_flight
+// and rb_scan_args above it read no runtime state; anything added there that
+// does needs the explicit check back.
 static VALUE vm_m_defineGlobalFunction(int argc, VALUE *argv, VALUE r_self)
 {
   rb_need_block();
@@ -2632,7 +2657,6 @@ static VALUE vm_m_defineGlobalFunction(int argc, VALUE *argv, VALUE r_self)
   TypedData_Get_Struct(r_self, VMData, &vm_type, data);
 
   check_disposed(data);
-  check_js_entry_owner(data);
   check_no_gvl_release_in_flight(data);
 
   struct define_function_call call = {
@@ -2813,6 +2837,12 @@ static VALUE vm_m_set_module_loader(VALUE r_self, VALUE r_loader)
   if (!NIL_P(r_loader) && !rb_obj_is_kind_of(r_loader, rb_cProc))
     rb_raise(rb_eTypeError, "module_loader must be a Proc or nil");
 
+  // register_module_loader_funcs below dereferences the context, so a
+  // disposed VM was a use-after-free here, and a VM being evaluated by
+  // another thread means swapping the loader out from under a running
+  // import. Neither was checked.
+  check_disposed(data);
+  check_js_entry_owner(data);
   check_no_gvl_release_in_flight(data);
   data->module_loader = r_loader;
   // Stale entries from the previous loader's policy would survive the

--- a/ext/quickjsrb/quickjsrb.h
+++ b/ext/quickjsrb/quickjsrb.h
@@ -100,6 +100,18 @@ typedef struct VMData
   // mid-eval. Only mutated while holding the GVL, so plain int accesses
   // are race-free.
   int evals_in_flight;
+  // The Ruby thread that opened the outermost in-flight JS entry, or Qnil
+  // when evals_in_flight is 0. A second thread entering while this is set
+  // to someone else is the "one VM, one thread at a time" rule being
+  // broken, and QuickJS contexts have no internal locking, so it is refused
+  // (ThreadError) rather than left to corrupt the heap.
+  //
+  // Keyed on the owner rather than the counter because same-thread nesting
+  // is legitimate and common: an on_log listener or a define_function proc
+  // re-entering the VM elevates evals_in_flight without any concurrency.
+  // Comparing the owner lets that through and catches only the real thing.
+  // Only mutated while holding the GVL.
+  VALUE owner_thread;
   // Number of GVL-release regions currently open on this VM (a subset of
   // evals_in_flight). Bridge-registration APIs (define_function,
   // module_loader=, on_unhandled_rejection) refuse (ThreadError) while
@@ -182,6 +194,10 @@ static void vm_mark(void *ptr)
   rb_gc_mark_movable(data->module_resolution_cache);
   rb_gc_mark_movable(data->module_source_cache);
   rb_gc_mark_movable(data->preloaded_module_names);
+  // Pinned rather than movable: it is compared by identity against
+  // rb_thread_current(), and it is only ever set for the duration of a JS
+  // entry, so there is nothing to gain from letting it move.
+  rb_gc_mark(data->owner_thread);
 }
 
 static void vm_compact(void *ptr)
@@ -237,6 +253,7 @@ static VALUE vm_alloc(VALUE r_self)
   data->disposed = false;
   data->gvl_released_js = false;
   data->evals_in_flight = 0;
+  data->owner_thread = Qnil;
   data->gvl_release_regions = 0;
   data->has_native_ruby_bridge = false;
 

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -384,6 +384,18 @@ describe Quickjs::VM do
   end
 
   describe "Dispose" do
+# initialize writes to the runtime from its second line on, starting with
+# JS_SetContextOpaque, and had no disposed check. On a disposed VM that
+# dereferenced a context dispose! had already freed, so
+# `vm.dispose!; vm.send(:initialize)` took the process down with SIGSEGV
+# rather than raising. Private, so it needs send to reach, but reachable.
+it "refuses re-initialization of a disposed VM instead of touching the freed context" do
+  vm = Quickjs::VM.new
+  vm.dispose!
+
+  _ { vm.send(:initialize) }.must_raise Quickjs::RuntimeError
+end
+
     it "dispose! returns nil and flips disposed?" do
       vm = Quickjs::VM.new
       _(vm.disposed?).must_equal false
@@ -571,6 +583,10 @@ describe Quickjs::VM do
       _ { vm.drain_jobs! }.must_raise ThreadError
       _ { vm.import('X', from: 'export default 1;') }.must_raise ThreadError
       _ { vm.define_function('another') { 1 } }.must_raise ThreadError
+      # Private, so only send reaches it, but every line of it writes to the
+      # runtime: a second thread re-running it beside live JS is the same
+      # corruption as any other entry.
+      _ { vm.send(:initialize) }.must_raise ThreadError
       # Not JS entries, but they walk the same runtime: JS_RunGC beside live
       # JS is a heap corruptor, and the usage read races the allocator.
       _ { vm.gc! }.must_raise ThreadError

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -518,6 +518,16 @@ describe Quickjs::VM do
   end
 
   describe "one VM, one thread at a time" do
+    # Every wait below is bounded. A runner thread that dies before it reaches
+    # the bridge never signals, and an unbounded pop turns that into a six hour
+    # CI hang rather than a failure: #82 kills these threads on Linux with a
+    # false stack overflow, and the suite sat at the GitHub job limit three
+    # times before the cause was visible.
+    def await(queue, what)
+      queue.pop(timeout: 10) ||
+        flunk("timed out waiting for #{what}; a thread likely died before signalling (see #82)")
+    end
+
     # QuickJS contexts have no internal locking, so two threads inside JS on
     # one VM corrupt the heap. The bridge blocking on a Queue is what makes
     # this deterministic: the proc yields the GVL while it waits, so the
@@ -528,12 +538,12 @@ describe Quickjs::VM do
       release = Queue.new
       vm.define_function('pause') do
         entered << :in
-        release.pop
+        release.pop(timeout: 30)
         1
       end
 
       runner = Thread.new { vm.eval_code('pause(); 42') }
-      entered.pop
+      await(entered, "the bridge to be entered")
 
       err = _ { vm.eval_code('1 + 1') }.must_raise ThreadError
       _(err.message).must_match(/from two threads at once/)
@@ -548,13 +558,13 @@ describe Quickjs::VM do
       release = Queue.new
       vm.define_function('pause') do
         entered << :in
-        release.pop
+        release.pop(timeout: 30)
         1
       end
       vm.eval_code('globalThis.noop = () => 1')
 
       runner = Thread.new { vm.eval_code('pause(); 42') }
-      entered.pop
+      await(entered, "the bridge to be entered")
 
       _ { vm.compile('1 + 1') }.must_raise ThreadError
       _ { vm.call('noop') }.must_raise ThreadError
@@ -597,7 +607,7 @@ describe Quickjs::VM do
       release = Queue.new
       vm.define_function('gate') do
         in_getter << :in
-        release.pop
+        release.pop(timeout: 30)
         1
       end
       vm.eval_code(<<~JS)
@@ -607,7 +617,7 @@ describe Quickjs::VM do
       JS
 
       definer = Thread.new { vm.define_function(%w[myLib hello]) { 42 } }
-      in_getter.pop # provably inside JS_Eval on the path's first segment
+      await(in_getter, "the path getter to be entered") # inside JS_Eval on the first segment
 
       _ { vm.eval_code('1 + 1') }.must_raise ThreadError
 
@@ -624,12 +634,12 @@ describe Quickjs::VM do
       release = Queue.new
       vm.define_function('pause') do
         entered << :in
-        release.pop
+        release.pop(timeout: 30)
         1
       end
 
       runner = Thread.new { vm.eval_code('pause(); 42') }
-      entered.pop
+      await(entered, "the bridge to be entered")
 
       _ { vm.module_loader = ->(_s, _i) { nil } }.must_raise ThreadError
 

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -587,6 +587,65 @@ describe Quickjs::VM do
       _(vm.eval_code('3 + 3')).must_equal 6
     end
 
+    # define_function resolves an array path with JS_Eval, so it holds the VM
+    # for real work. A check that only refused when someone else was already
+    # in flight would pass on an idle VM and claim nothing, letting a second
+    # thread pass the same idle check and land in JS_Eval alongside it.
+    it "claims the VM while resolving a define_function path, not just checks" do
+      vm = Quickjs::VM.new(timeout_msec: 30_000)
+      in_getter = Queue.new
+      release = Queue.new
+      vm.define_function('gate') do
+        in_getter << :in
+        release.pop
+        1
+      end
+      vm.eval_code(<<~JS)
+        globalThis._lib = {};
+        Object.defineProperty(globalThis, 'myLib', { get: () => { gate(); return _lib; } });
+        0
+      JS
+
+      definer = Thread.new { vm.define_function(%w[myLib hello]) { 42 } }
+      in_getter.pop # provably inside JS_Eval on the path's first segment
+
+      _ { vm.eval_code('1 + 1') }.must_raise ThreadError
+
+      release << :go
+      definer.join
+      _(vm.eval_code('_lib.hello()')).must_equal 42
+    end
+
+    # module_loader= swaps the loader on the live runtime, so doing it while
+    # another thread imports would change resolution mid-flight.
+    it "refuses module_loader= while another thread is evaluating" do
+      vm = Quickjs::VM.new(timeout_msec: 30_000)
+      entered = Queue.new
+      release = Queue.new
+      vm.define_function('pause') do
+        entered << :in
+        release.pop
+        1
+      end
+
+      runner = Thread.new { vm.eval_code('pause(); 42') }
+      entered.pop
+
+      _ { vm.module_loader = ->(_s, _i) { nil } }.must_raise ThreadError
+
+      release << :go
+      _(runner.value).must_equal 42
+    end
+
+    # register_module_loader_funcs dereferences the context, so this was a
+    # use-after-free rather than an exception.
+    it "refuses module_loader= on a disposed VM" do
+      vm = Quickjs::VM.new
+      vm.dispose!
+
+      _ { vm.module_loader = ->(_s, _i) { nil } }.must_raise Quickjs::RuntimeError
+    end
+
     # A stranded owner would lock the VM to one thread for good, the same way
     # a stranded counter would refuse dispose! forever.
     it "releases ownership when the entry ends by raising" do

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -517,6 +517,86 @@ describe Quickjs::VM do
     end
   end
 
+  describe "one VM, one thread at a time" do
+    # QuickJS contexts have no internal locking, so two threads inside JS on
+    # one VM corrupt the heap. The bridge blocking on a Queue is what makes
+    # this deterministic: the proc yields the GVL while it waits, so the
+    # second thread genuinely runs while the first is mid-entry.
+    it "refuses a second thread while a JS entry is in flight" do
+      vm = Quickjs::VM.new(timeout_msec: 30_000)
+      entered = Queue.new
+      release = Queue.new
+      vm.define_function('pause') do
+        entered << :in
+        release.pop
+        1
+      end
+
+      runner = Thread.new { vm.eval_code('pause(); 42') }
+      entered.pop
+
+      err = _ { vm.eval_code('1 + 1') }.must_raise ThreadError
+      _(err.message).must_match(/from two threads at once/)
+
+      release << :go
+      _(runner.value).must_equal 42
+    end
+
+    it "refuses every entry point, not just eval_code" do
+      vm = Quickjs::VM.new(timeout_msec: 30_000)
+      entered = Queue.new
+      release = Queue.new
+      vm.define_function('pause') do
+        entered << :in
+        release.pop
+        1
+      end
+      vm.eval_code('globalThis.noop = () => 1')
+
+      runner = Thread.new { vm.eval_code('pause(); 42') }
+      entered.pop
+
+      _ { vm.compile('1 + 1') }.must_raise ThreadError
+      _ { vm.call('noop') }.must_raise ThreadError
+      _ { vm.drain_jobs! }.must_raise ThreadError
+      _ { vm.import('X', from: 'export default 1;') }.must_raise ThreadError
+      _ { vm.define_function('another') { 1 } }.must_raise ThreadError
+      # Not JS entries, but they walk the same runtime: JS_RunGC beside live
+      # JS is a heap corruptor, and the usage read races the allocator.
+      _ { vm.gc! }.must_raise ThreadError
+      _ { vm.memory_usage }.must_raise ThreadError
+
+      release << :go
+      _(runner.value).must_equal 42
+    end
+
+    # The counter alone cannot express the rule: same-thread nesting elevates
+    # it too, and a bridge re-entering its own VM is a supported shape.
+    it "still allows the owning thread to re-enter from a bridge" do
+      vm = Quickjs::VM.new
+      vm.define_function('nested') { vm.eval_code('1 + 1') }
+
+      _(vm.eval_code('nested()')).must_equal 2
+    end
+
+    it "still allows a VM to move between threads when nothing is in flight" do
+      vm = Quickjs::VM.new
+
+      _(Thread.new { vm.eval_code('1 + 1') }.value).must_equal 2
+      _(Thread.new { vm.eval_code('2 + 2') }.value).must_equal 4
+      _(vm.eval_code('3 + 3')).must_equal 6
+    end
+
+    # A stranded owner would lock the VM to one thread for good, the same way
+    # a stranded counter would refuse dispose! forever.
+    it "releases ownership when the entry ends by raising" do
+      vm = Quickjs::VM.new
+      _ { vm.eval_code('nope()') }.must_raise Quickjs::ReferenceError
+
+      _(Thread.new { vm.eval_code('1 + 1') }.value).must_equal 2
+    end
+  end
+
   it "accepts some options to constrain its resource" do
     vm = Quickjs::VM.new(
       memory_limit: 1024 * 1024,


### PR DESCRIPTION
Closes #78.

"One VM, one thread at a time" was documented but unenforced. QuickJS contexts have no internal locking, so breaking the rule corrupted the heap instead of raising, and since `eval_code` releases the GVL on a pure VM, two threads genuinely run inside `JS_Eval` at the same time rather than interleaving by accident.

Four threads evaluating on one VM, 200 iterations each:

| | result |
| --- | --- |
| `main` | SIGSEGV / ABRT, 3 runs of 3 |
| this branch | `ok=200 refused=600`, process survives, 3 of 3 |

## Ownership, not a lock

The VM records the Ruby thread that opened the outermost JS entry, and clears it when that entry closes. A second thread entering while it is set to someone else raises `ThreadError`.

A mutex would be the wrong instrument twice over, and both failures are worth stating because the mutex shape is the obvious first idea:

- **Held across the GVL release it deadlocks.** The unlock lands after `rb_thread_call_without_gvl` re-acquires the GVL, so a second thread blocks in `pthread_mutex_lock` *while holding the GVL*, and the first thread can never get back in to reach the unlock.
- **A plain mutex self-deadlocks on nesting.** An `on_log` listener or a `define_function` proc re-entering the same VM is the same thread taking the lock twice, and that shape is supported and tested here.

Comparing the owner has neither problem: it lets nesting through by construction and needs no lock at all. `evals_in_flight` could not express this on its own for the same reason, since same-thread nesting elevates it too.

## Where the check sits

Two places, deliberately:

- `enter_js_entry` / `leave_js_entry` wrap the two counting choke points (`run_held_js_entry` and `run_gvl_release_region`), so the owner is set for exactly as long as `evals_in_flight` is elevated.
- `check_js_entry_owner` sits beside `check_disposed` at each entry point, because several of them touch runtime state *before* reaching a counted region: `JS_IsJobPending` in `drain_jobs!`, `arm_eval_timer` almost everywhere, `JS_SetModuleLoaderFunc2` in `compile_module`. Without this, `drain_jobs!` from a second thread sailed through and broke the first thread's eval, which is how the test caught it.

`gc!` and `memory_usage` are guarded too. They run no JS, but `JS_RunGC` beside live JS is a heap corruptor and the usage read races the allocator.

One ordering detail: in `run_gvl_release_region` the refusal has to happen before the input buffers are handed to the region, since the `rb_ensure` that would free them is not armed yet. It shares the existing disposed bail-out block for that reason.

## What stays allowed

- Sequential handoff between threads, which pool warmers depend on. Ownership is only held for the duration of a call.
- A bridge re-entering its own VM on the same thread.
- Separate VMs on separate threads, untouched.

## Tests

Five cases in a new `describe`, made deterministic by a `define_function` proc blocking on a `Queue`: the proc yields the GVL while it waits, so the second thread provably runs while the first is mid-entry, with no sleeps.

Covers the refusal itself, refusal across every entry point (`compile`, `call`, `drain_jobs!`, `import`, `define_function`, `gc!`, `memory_usage`), same-thread re-entry still working, sequential handoff still working, and ownership clearing when an entry ends by raising, so a stranded owner cannot lock a VM to one thread for good.

573 runs, 926 assertions, 0 failures locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
