### PR TITLE
Stop skipping the blocking tests on Linux

### DIFF
--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -2122,10 +2122,6 @@ describe "Quickjs::Blocking" do
     _(run_threads(&block)).must_equal %w(t1 t1 t1 t2)
   end
 
-  def pend_on_ubuntu
-    skip('unresolved stack overflow on Ubuntu of GitHub Actions') unless RUBY_PLATFORM.match(/darwin/)
-  end
-
   describe "ProcessBlocking" do
     before do
       @vm = Quickjs::VM.new(timeout_msec: 500, features: [::Quickjs::MODULE_OS])
@@ -2138,7 +2134,6 @@ describe "Quickjs::Blocking" do
     end
 
     it "ensure Kernel#sleep via a provided function is fine" do
-      pend_on_ubuntu
       @vm.define_function 'rbsleep' do |n|
         sleep n
       end
@@ -2156,28 +2151,24 @@ describe "Quickjs::Blocking" do
     # blocking-looking calls (os.sleep, os.setTimeout, os.sleepAsync) no
     # longer hold up sibling Ruby threads.
     it "os.sleep does not block other threads" do
-      pend_on_ubuntu
       assert_sleep_a_sec_within_thread do
         @vm.eval_code('os.sleep(200);')
       end
     end
 
     it "awaiting os.setTimeout does not block other threads" do
-      pend_on_ubuntu
       assert_sleep_a_sec_within_thread do
         @vm.eval_code('await new Promise(resolve => os.setTimeout(resolve, 200));')
       end
     end
 
     it "awaiting async function which wraps os.setTimeout does not block other threads" do
-      pend_on_ubuntu
       assert_sleep_a_sec_within_thread do
         @vm.eval_code('async function top () { await new Promise(resolve => os.setTimeout(resolve, 200)); } await top();')
       end
     end
 
     it "awaiting os.sleepAsync does not block other threads" do
-      pend_on_ubuntu
       assert_sleep_a_sec_within_thread do
         @vm.eval_code('async function top () { await os.sleepAsync(200); } await top();')
       end
@@ -2190,7 +2181,6 @@ describe "Quickjs::Blocking" do
     end
 
     it "awaiting setTimeout does not block other threads" do
-      pend_on_ubuntu
       assert_sleep_a_sec_within_thread do
         @vm.eval_code('await new Promise(resolve => setTimeout(resolve, 200));')
       end
@@ -2356,7 +2346,6 @@ describe "Quickjs::Blocking" do
     # path must keep the GVL held when FEATURE_TIMEOUT is enabled, otherwise
     # those Ruby APIs run without the GVL and crash.
     it "tolerates setTimeout in JS without crashing the interpreter" do
-      pend_on_ubuntu
       vm = Quickjs::VM.new(features: [::Quickjs::FEATURE_TIMEOUT])
 
       begin


### PR DESCRIPTION
Stacked on #87. Base is `fix/stack-top-per-thread`, so this shows one commit; GitHub retargets it to `main` when #87 merges.

`pend_on_ubuntu` (`test/quickjs_test.rb:2101`) has skipped seven tests everywhere but macOS since f8004ee:

```rb
def pend_on_ubuntu
  skip('unresolved stack overflow on Ubuntu of GitHub Actions') unless RUBY_PLATFORM.match(/darwin/)
end
```

The unresolved stack overflow was #82. `run_threads` evaluates inside a thread while the VM was built on the main one:

```rb
t2 = Thread.new(queue) {|q| block.call; q << 't2' }
```

which is the latched-stack-limit handoff exactly, so every one of those evals raised on Linux. With the re-base in #87 all seven pass on Ubuntu, on all four Rubies. Ubuntu skips go from 8 to 1, and the remaining one is #88.

## What comes back

These are the tests that assert the GVL-release work does what it claims, and none of it has ever been verified on Linux:

- `ensure Kernel#sleep via a provided function is fine`
- `os.sleep does not block other threads`
- `awaiting os.setTimeout does not block other threads`
- `awaiting async function which wraps os.setTimeout does not block other threads`
- `awaiting os.sleepAsync does not block other threads`
- `awaiting setTimeout does not block other threads`
- `tolerates setTimeout in JS without crashing the interpreter`

## Verified

Pushed as a trial branch on top of #87 before opening this: all eight jobs green, and the Ubuntu 4.0 job reports `575 runs, 919 assertions, 0 failures, 0 errors, 1 skips` where it previously reported 8 skips.
