### PR TITLE
Probe the stack once, and stop breaking musl

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,3 +33,25 @@ jobs:
           bundler-cache: true
       - name: Run the default task
         run: bundle exec rake
+
+  # musl reports the stack differently from glibc, and the difference is not
+  # cosmetic: pthread_attr_getstack on the main thread returns the currently
+  # mapped part of the stack rather than what RLIMIT_STACK allows. A change to
+  # the stack-limit handling that is fine on both matrix legs above can still
+  # make every eval on Alpine raise "stack overflow", which is what happened
+  # while #92 was being worked on. One job is enough to catch that shape.
+  musl:
+    runs-on: ubuntu-latest
+    name: Ruby 3.4 on alpine (musl)
+    container: ruby:3.4-alpine
+
+    steps:
+      - name: Install build dependencies
+        run: apk add --no-cache build-base linux-headers git
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Install gems
+        run: bundle install
+      - name: Run the default task
+        run: bundle exec rake

--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -1286,6 +1286,7 @@ static VALUE vm_m_initialize(int argc, VALUE *argv, VALUE r_self)
   register_module_loader_funcs(data);
   JS_SetHostPromiseRejectionTracker(runtime, quickjsrb_promise_rejection_tracker, NULL);
   js_std_init_handlers(runtime);
+  data->std_handlers_installed = true;
 
   JSValue j_global = JS_GetGlobalObject(data->context);
 
@@ -3200,9 +3201,16 @@ static VALUE vm_m_memoryPoisoned(VALUE r_self)
 // progressing. Safe to release because nothing in the teardown path calls
 // back into Ruby: module_loader, console, and define_function callbacks
 // only fire during JS execution, not during free.
+struct teardown_job
+{
+  JSContext *context;
+  bool std_handlers_installed;
+};
+
 static void *vm_dispose_no_gvl(void *p)
 {
-  vm_teardown_context((JSContext *)p);
+  struct teardown_job *job = (struct teardown_job *)p;
+  vm_teardown_context(job->context, job->std_handlers_installed);
   return NULL;
 }
 
@@ -3233,7 +3241,8 @@ static VALUE vm_m_dispose(VALUE r_self)
   // disposed=true and skips its own teardown.
   data->disposed = true;
 
-  rb_thread_call_without_gvl(vm_dispose_no_gvl, data->context, NULL, NULL);
+  struct teardown_job job = {data->context, data->std_handlers_installed};
+  rb_thread_call_without_gvl(vm_dispose_no_gvl, &job, NULL, NULL);
 
   // Drop references to user-supplied closures so Ruby GC can reclaim them
   // (and anything they captured) before the wrapping VM object itself is

--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -1618,44 +1618,73 @@ static VALUE gvl_release_region_cleanup(VALUE p)
   return Qnil;
 }
 
-// How much stack the calling thread still has below this frame, or 0 when the
-// platform won't say. Both calls are non-POSIX, and the two the CI matrix
-// covers are the two spelled out here; anywhere else answers 0, which
-// rebase_stack_limit reads as "leave this VM alone".
-static size_t current_thread_stack_headroom(void)
+// The bounds of the calling thread's stack, probed once and remembered. They
+// do not move for the life of the thread, and the probe is far too expensive
+// to repeat: on glibc the main thread takes the path that opens
+// /proc/self/maps and parses it line by line looking for the vma holding
+// __libc_stack_end, which in a Ruby process with its many mappings measured
+// at ~68us. That was landing on every outermost entry, against a bare
+// eval_code('1+1') of ~2.5us.
+//
+// Probing once and answering from the cache also settles the fiber case for
+// free. A Ruby Fiber (and Enumerator, and every fiber scheduler) runs on its
+// own mmap'd stack outside these bounds, so a frame pointer that falls
+// outside them is not on this thread's stack and there is nothing to
+// measure; that answer needs no syscall once the bounds are known.
+struct thread_stack_bounds
 {
-  uintptr_t sp = (uintptr_t)__builtin_frame_address(0);
-  uintptr_t low = 0, high = 0;
+  uintptr_t low;
+  uintptr_t high;
+  bool probed;
+};
+
+static void probe_thread_stack_bounds(struct thread_stack_bounds *bounds)
+{
+  bounds->probed = true;
+  bounds->low = 0;
+  bounds->high = 0;
 #if defined(__APPLE__)
   pthread_t self = pthread_self();
   // Apple reports the address one past the top of the stack, growing down.
-  high = (uintptr_t)pthread_get_stackaddr_np(self);
+  uintptr_t high = (uintptr_t)pthread_get_stackaddr_np(self);
   size_t size = pthread_get_stacksize_np(self);
   if (high == 0 || size == 0 || size > high)
-    return 0;
-  low = high - size;
+    return;
+  bounds->low = high - size;
+  bounds->high = high;
 #elif defined(__linux__)
   pthread_attr_t attr;
   if (pthread_getattr_np(pthread_self(), &attr) != 0)
-    return 0;
+    return;
   void *base;
   size_t size;
   int rc = pthread_attr_getstack(&attr, &base, &size);
   pthread_attr_destroy(&attr);
   if (rc != 0 || base == NULL || size == 0)
-    return 0;
-  low = (uintptr_t)base;
-  high = low + size;
-#else
-  return 0;
+    return;
+  bounds->low = (uintptr_t)base;
+  bounds->high = bounds->low + size;
 #endif
-  // Both bounds, not just the lower one. A Ruby Fiber runs on its own mmap'd
-  // stack, and where the allocator puts it relative to the thread stack is not
-  // ours to predict: below it, sp <= low and the old check already answered 0;
-  // above it, sp - low measures across unrelated mappings and reports headroom
-  // that is not there. Believing it would re-base onto the fiber with a budget
-  // sized for another stack, which is the crash this function exists to avoid.
-  return (sp > low && sp < high) ? (size_t)(sp - low) : 0;
+}
+
+// How much stack the calling thread still has below this frame, or 0 when
+// that cannot be answered: the platform has neither call, the probe failed,
+// or the frame is not on this thread's stack at all. rebase_stack_limit
+// reads 0 as "leave this VM alone".
+static size_t current_thread_stack_headroom(void)
+{
+  static __thread struct thread_stack_bounds bounds;
+  if (!bounds.probed)
+    probe_thread_stack_bounds(&bounds);
+  if (bounds.high == 0)
+    return 0;
+
+  // Both bounds, not just the lower one. Where the allocator puts a fiber's
+  // stack relative to the thread's is not ours to predict: below it, sp <= low
+  // and a lower-bound check already answered 0; above it, sp - low measures
+  // across unrelated mappings and reports headroom that is not there.
+  uintptr_t sp = (uintptr_t)__builtin_frame_address(0);
+  return (sp > bounds.low && sp < bounds.high) ? (size_t)(sp - bounds.low) : 0;
 }
 
 // Room left for QuickJS to report the overflow and for Ruby to unwind through

--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -1727,8 +1727,21 @@ static void rebase_stack_limit(VMData *data)
     return;
 
   size_t headroom = current_thread_stack_headroom();
-  if (headroom == 0)
-    return; // cannot measure this stack, so do not start describing it
+
+  // A headroom under the margin is not a small budget, it is an unusable
+  // answer: there would be no room left to report the overflow with. musl
+  // makes that the normal case rather than a corner one, because its
+  // main-thread pthread_attr_getstack reports only the currently mapped part
+  // of the stack rather than what RLIMIT_STACK allows, so early on the answer
+  // is a few pages. Clamping to what is left there set stack_limit one byte
+  // below stack_top and every eval raised "stack overflow", 1 + 1 included.
+  //
+  // So this joins the zero case: an answer we cannot use leaves the VM exactly
+  // as it was, latched to its creating thread. Cross-thread handoff stays
+  // broken on such a platform, which is the pre-existing behaviour, rather
+  // than the platform breaking outright.
+  if (headroom <= QUICKJSRB_STACK_MARGIN)
+    return;
 
   JSRuntime *runtime = JS_GetRuntime(data->context);
   JS_UpdateStackTop(runtime);
@@ -1736,10 +1749,7 @@ static void rebase_stack_limit(VMData *data)
   if (data->requested_max_stack_size == 0)
     return; // caller asked for no limit; honour it
 
-  // Below the margin there is no budget worth granting: clamping to what is
-  // left makes the first check fire and raise, which beats running on into
-  // the guard page.
-  size_t usable = headroom > QUICKJSRB_STACK_MARGIN ? headroom - QUICKJSRB_STACK_MARGIN : 1;
+  size_t usable = headroom - QUICKJSRB_STACK_MARGIN;
   JS_SetMaxStackSize(runtime, usable < data->requested_max_stack_size ? usable : data->requested_max_stack_size);
 }
 

--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -1255,6 +1255,14 @@ static VALUE vm_m_initialize(int argc, VALUE *argv, VALUE r_self)
   VALUE r_max_stack_size = rb_hash_aref(r_opts, ID2SYM(rb_intern("max_stack_size")));
   if (NIL_P(r_max_stack_size))
     r_max_stack_size = UINT2NUM(1024 * 1024 * 4);
+  // NUM2ULL reads a negative as SIZE_MAX, which is not a large budget but a
+  // broken one: stack_limit lands above stack_top and every eval raises
+  // "stack overflow", and only where the headroom clamp happens to catch it
+  // first does that stay hidden. Refuse it here, where the caller can still
+  // see what they typed.
+  if (!RB_INTEGER_TYPE_P(r_max_stack_size) ||
+      RTEST(rb_funcall(r_max_stack_size, rb_intern("negative?"), 0)))
+    rb_raise(rb_eArgError, "max_stack_size must be a non-negative Integer");
   VALUE r_features = rb_hash_aref(r_opts, ID2SYM(rb_intern("features")));
   if (NIL_P(r_features))
     r_features = rb_ary_new();

--- a/ext/quickjsrb/quickjsrb.h
+++ b/ext/quickjsrb/quickjsrb.h
@@ -125,7 +125,13 @@ typedef struct VMData
   // re-apply it on each outermost entry: the budget is re-derived per entry
   // from the running thread's real headroom, and the request is the ceiling
   // it clamps down from. Zero keeps QuickJS's documented "no limit".
-  size_t requested_max_stack_size;
+size_t requested_max_stack_size;
+// Whether initialize ran. Quickjs::VM.allocate is public on every Ruby
+// class, and an object allocated but never initialized still reaches
+// vm_free, which used to hand js_std_free_handlers a runtime whose
+// handlers js_std_init_handlers had never set up. That segfaulted at
+// process exit. Teardown consults this instead of assuming.
+bool std_handlers_installed;
   // Latched by quickjsrb_new_ruby_bridge whenever a C function that calls
   // into Ruby synchronously (rb_funcall & friends) WITHOUT honoring
   // gvl_released_js is installed into this context. While true,
@@ -153,11 +159,12 @@ static inline JSValue quickjsrb_new_ruby_bridge(JSContext *ctx, JSCFunction *fun
   return JS_NewCFunction(ctx, func, name, length);
 }
 
-static void vm_teardown_context(JSContext *ctx)
+static void vm_teardown_context(JSContext *ctx, bool std_handlers_installed)
 {
   JSRuntime *runtime = JS_GetRuntime(ctx);
   JS_SetInterruptHandler(runtime, NULL, NULL);
-  js_std_free_handlers(runtime);
+  if (std_handlers_installed)
+    js_std_free_handlers(runtime);
   JS_FreeContext(ctx);
   JS_FreeRuntime(runtime);
 }
@@ -172,7 +179,7 @@ static void vm_free(void *ptr)
     if (!JS_IsUndefined(data->j_file_proxy_creator))
       JS_FreeValue(data->context, data->j_file_proxy_creator);
 
-    vm_teardown_context(data->context);
+    vm_teardown_context(data->context, data->std_handlers_installed);
   }
 
   xfree(ptr);
@@ -254,6 +261,8 @@ static VALUE vm_alloc(VALUE r_self)
   data->gvl_released_js = false;
   data->evals_in_flight = 0;
   data->owner_thread = Qnil;
+  data->requested_max_stack_size = 0;
+  data->std_handlers_installed = false;
   data->gvl_release_regions = 0;
   data->has_native_ruby_bridge = false;
 

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -384,6 +384,17 @@ describe Quickjs::VM do
   end
 
   describe "Dispose" do
+# allocate is public on every Ruby class, and an object allocated but never
+# initialized still reaches vm_free. That handed js_std_free_handlers a
+# runtime whose handlers js_std_init_handlers had never set up, and the
+# process died in the GC at exit rather than anywhere a backtrace would
+# point at.
+it "survives an allocated VM that was never initialized" do
+  Quickjs::VM.allocate
+
+  _(Quickjs::VM.new.eval_code('1 + 1')).must_equal 2
+end
+
 # initialize writes to the runtime from its second line on, starting with
 # JS_SetContextOpaque, and had no disposed check. On a disposed VM that
 # dereferenced a context dispose! had already freed, so

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -758,7 +758,11 @@ end
   end
 
   describe "StackLimitFollowsTheEvaluatingThread" do
-    RUNAWAY = 'function f(n){ return 1 + f(n + 1); } f(0)'
+    # A constant here would resolve to ::RUNAWAY and leak onto Object for
+    # anything that loads the suite.
+    def runaway_js
+      'function f(n){ return 1 + f(n + 1); } f(0)'
+    end
 
     # A thread that never finishes would hang the suite rather than fail it,
     # and the failure mode being fixed here is exactly one that used to hang.
@@ -803,7 +807,7 @@ end
     it "still stops runaway recursion on the thread that built the VM" do
       vm = Quickjs::VM.new(timeout_msec: 10_000)
 
-      _ { vm.eval_code(RUNAWAY) }.must_raise Quickjs::RuntimeError
+      _ { vm.eval_code(runaway_js) }.must_raise Quickjs::RuntimeError
     end
 
     # A Ruby thread's machine stack is a fraction of the main thread's, so a
@@ -816,7 +820,7 @@ end
 
       err = value_within(20) do
         begin
-          vm.eval_code(RUNAWAY)
+          vm.eval_code(runaway_js)
         rescue => e
           e
         end
@@ -839,7 +843,7 @@ it "does not run off the end of a Fiber's stack" do
 
   raised = Fiber.new do
     begin
-      vm.eval_code(RUNAWAY)
+      vm.eval_code(runaway_js)
       nil
     rescue Exception => e
       e
@@ -849,6 +853,42 @@ it "does not run off the end of a Fiber's stack" do
   _(raised).must_be_kind_of Exception
   _(raised).wont_be_kind_of SystemStackError
 end
+
+    # NUM2ULL reads a negative as SIZE_MAX, which puts stack_limit above
+    # stack_top and makes every eval raise "stack overflow". Only the headroom
+    # clamp hid that, and only where the stack can be measured at all.
+    it "refuses a negative max_stack_size" do
+      _ { Quickjs::VM.new(max_stack_size: -1) }.must_raise ArgumentError
+    end
+
+    # The guard is only observable where the request wins the clamp, which is
+    # the main thread: headroom there is far above max_stack_size, so the budget
+    # is the request and a nested re-base would restart it from a deeper frame.
+    #
+    # Asserted through the shape rather than an absolute depth, which is machine
+    # specific. Sharing the outermost budget makes the reachable nesting depth
+    # scale with the option; restarting it per entry makes the machine stack the
+    # only bound, and the depth stops responding to the option at all. Measured
+    # while writing this: 22 and 44 with the guard, 1361 and 1361 without it.
+    it "makes a nested entry share the outermost budget rather than restart it" do
+      reached = lambda do |size|
+        vm = Quickjs::VM.new(timeout_msec: 20_000, max_stack_size: size)
+        depth = 0
+        vm.define_function('again') { depth += 1; vm.eval_code('again()') }
+        begin
+          vm.eval_code('again()')
+        rescue StandardError
+          nil
+        end
+        depth
+      end
+
+      small = reached.call(128 * 1024)
+      large = reached.call(256 * 1024)
+
+      _(small).must_be :>, 0
+      _(large.to_f / small).must_be :>, 1.5
+    end
 
     # A bridge re-entering its own VM is deeper on the same stack, so it must
     # keep the outermost entry's budget. Handing it a fresh one would remove the


### PR DESCRIPTION
Closes #92. All six items, plus a segfault and a broken platform found while measuring them.

Two of these are regressions #87 introduced and has not shipped yet, which is the reason to take them before the next release rather than after.

## The main-thread eval was 27x slower on Linux

#87 put `current_thread_stack_headroom` on every outermost JS entry. On glibc's main thread that call opens `/proc/self/maps` and parses it line by line looking for the vma holding `__libc_stack_end`, and a Ruby process has enough mappings for that to dominate. Measured in a Linux container, aarch64, `ruby:3.4`:

| | before | after |
|---|---|---|
| `eval_code('1+1')` main thread | **71.10us** | **2.61us** |
| `eval_code('1+1')` spawned thread | 2.45us | 2.26us |

So 96% of a trivial eval. The spawned-thread leg was always cheap, because glibc knows that stack without asking the kernel, which is why nothing showed up until the main thread was measured.

A thread's stack bounds do not move, so they are probed once into thread-local storage. That also answers the fiber case without a syscall: a frame pointer outside the cached bounds is not on this thread's stack, and once the bounds are known that comparison is the whole answer.

## Alpine was completely broken

The issue listed musl as reasoned from the sources and unverified. Verified now, and it is worse than the guess. Before this PR, on Alpine, at every `max_stack_size` from 8K to 4096K:

```
same thread   stack overflow
main->thread  ok
thread->main  stack overflow
```

`1 + 1` included. musl's main-thread `pthread_attr_getstack` reports only the currently mapped part of the stack rather than what `RLIMIT_STACK` allows, so early on the honest answer is a few pages. The clamp read that as a tiny budget, set `stack_limit` one byte under `stack_top`, and every check tripped.

An unusable measurement now joins the unmeasurable one and leaves the VM latched where it was. Cross-thread handoff stays broken on such a platform, which is what it was before #87, rather than the platform breaking outright. Alpine now reports ok in all three directions at every size, 2.34us per eval, green suite.

**A musl CI job comes with it.** Neither existing matrix leg can see this shape, and this would have shipped.

## `Quickjs::VM.allocate` was a segfault

Not in the issue; found while checking the zeroed-field item.

```rb
Quickjs::VM.allocate
```

Teardown called `js_std_free_handlers` on a runtime whose handlers `js_std_init_handlers` had never installed, so the process died in the GC at exit, in a finaliser rather than anywhere a backtrace points at. `allocate` is public on every Ruby class. This one predates #87.

## The rest

- **Negative `max_stack_size`** is refused at construction. `NUM2ULL` read it as `SIZE_MAX`, which puts `stack_limit` above `stack_top` so every eval raises; only the clamp hid it, and only where the stack can be measured.
- **The "outermost entry only" guard now has a test that can fail.** It had none: removing it left every #87 test passing, because where the clamp works the headroom shrinks with depth and nesting is self-limiting. It is visible on the main thread, where the request wins the clamp. Asserted through shape rather than depth, which is machine specific: sharing the outermost budget makes reachable nesting depth scale with `max_stack_size`, restarting it per entry makes the machine stack the only bound. 22 and 44 with the guard here, against 1361 and 1361 without it.
- **`RUNAWAY`** was defining `::RUNAWAY` on `Object` for anything loading the suite.

## Verified

588 runs, 0 failures on macOS arm64, glibc Linux aarch64, and Alpine musl aarch64. Each commit compiles on its own.

Not addressed: `memory_limit` takes the same unvalidated path as `max_stack_size` did, which is worth a separate look.
