### PR TITLE
Read memory_limit as the size_t it is handed to

### DIFF
--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -1242,6 +1242,20 @@ static void finish_polyfill_load(VMData *data, JSValue j_result)
   JS_FreeValue(data->context, j_result);
 }
 
+// Both size options are read straight into a size_t, where a negative turns
+// into SIZE_MAX rather than an error: for max_stack_size that puts
+// stack_limit above stack_top so every eval raises "stack overflow", and for
+// memory_limit it reads as an enormous budget. Neither is what the caller
+// typed, so both are refused here, by name, while the name still means
+// something to them.
+static size_t size_option(VALUE r_value, const char *name)
+{
+  if (!RB_INTEGER_TYPE_P(r_value) || RTEST(rb_funcall(r_value, rb_intern("negative?"), 0)))
+    rb_raise(rb_eArgError, "%s must be a non-negative Integer", name);
+
+  return NUM2SIZET(r_value);
+}
+
 static VALUE vm_m_initialize(int argc, VALUE *argv, VALUE r_self)
 {
   VALUE r_opts;
@@ -1255,14 +1269,6 @@ static VALUE vm_m_initialize(int argc, VALUE *argv, VALUE r_self)
   VALUE r_max_stack_size = rb_hash_aref(r_opts, ID2SYM(rb_intern("max_stack_size")));
   if (NIL_P(r_max_stack_size))
     r_max_stack_size = UINT2NUM(1024 * 1024 * 4);
-  // NUM2ULL reads a negative as SIZE_MAX, which is not a large budget but a
-  // broken one: stack_limit lands above stack_top and every eval raises
-  // "stack overflow", and only where the headroom clamp happens to catch it
-  // first does that stay hidden. Refuse it here, where the caller can still
-  // see what they typed.
-  if (!RB_INTEGER_TYPE_P(r_max_stack_size) ||
-      RTEST(rb_funcall(r_max_stack_size, rb_intern("negative?"), 0)))
-    rb_raise(rb_eArgError, "max_stack_size must be a non-negative Integer");
   VALUE r_features = rb_hash_aref(r_opts, ID2SYM(rb_intern("features")));
   if (NIL_P(r_features))
     r_features = rb_ary_new();
@@ -1287,8 +1293,8 @@ static VALUE vm_m_initialize(int argc, VALUE *argv, VALUE r_self)
   JS_SetContextOpaque(data->context, data);
   JSRuntime *runtime = JS_GetRuntime(data->context);
 
-  JS_SetMemoryLimit(runtime, NUM2UINT(r_memory_limit));
-  data->requested_max_stack_size = (size_t)NUM2ULL(r_max_stack_size);
+  JS_SetMemoryLimit(runtime, size_option(r_memory_limit, "memory_limit"));
+  data->requested_max_stack_size = size_option(r_max_stack_size, "max_stack_size");
   JS_SetMaxStackSize(runtime, data->requested_max_stack_size);
 
   register_module_loader_funcs(data);

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -854,6 +854,24 @@ it "does not run off the end of a Fiber's stack" do
   _(raised).wont_be_kind_of SystemStackError
 end
 
+# JS_SetMemoryLimit takes a size_t, but the option was read with NUM2UINT,
+# so the ceiling was 4GB and the error naming 'unsigned int' never said
+# which option had gone wrong.
+it "accepts a memory_limit that does not fit in 32 bits" do
+  vm = Quickjs::VM.new(memory_limit: 8 * 1024**3)
+
+  _(vm.memory_usage[:malloc_limit]).must_equal 8 * 1024**3
+  _(vm.eval_code('1 + 1')).must_equal 2
+end
+
+# NUM2UINT wrapped it to UINT_MAX, so -1 was a silent 4GB cap. QuickJS uses
+# -1 for "no limit" itself, which is exactly the confusion to refuse.
+it "refuses a negative memory_limit, by name" do
+  err = _ { Quickjs::VM.new(memory_limit: -1) }.must_raise ArgumentError
+
+  _(err.message).must_match(/memory_limit/)
+end
+
     # NUM2ULL reads a negative as SIZE_MAX, which puts stack_limit above
     # stack_top and makes every eval raise "stack overflow". Only the headroom
     # clamp hid that, and only where the stack can be measured at all.


### PR DESCRIPTION
Stacked on #94, which named this as the loose end it was not addressing. Base is `fix/cache-stack-bounds`, so this shows one commit; GitHub retargets it to `main` when #94 merges.

`JS_SetMemoryLimit` takes a `size_t` (`quickjs.h:372`). The option was read with `NUM2UINT`.

| `memory_limit:` | before | after |
|---|---|---|
| `-1` | silently `4294967295`, a 4GB cap | `ArgumentError: memory_limit must be a non-negative Integer` |
| `2 ** 31` | ok | ok |
| `2 ** 32` | `RangeError: integer 4294967296 too big to convert to 'unsigned int'` | ok |
| `8 * 1024**3` | same `RangeError` | ok |
| `2 ** 62` | same `RangeError` | ok |

Two separate problems behind that.

**The ceiling was 4GB**, on a 64-bit API, with an error that named `unsigned int` and not the option that caused it. A caller reading that message has no way to know which of the four options they passed was the problem.

**A negative wrapped to `UINT_MAX`.** QuickJS spells "no limit" as `-1` itself (`quickjs.c:2074` initialises `malloc_limit` that way), so `-1` is the reading a caller is most likely to bring to this option, and it quietly gave them a 4GB cap instead.

Both size options now go through one validator that refuses a negative by name and converts with `NUM2SIZET`. `max_stack_size` keeps the behaviour it gained in #94 and loses its own copy of the check.

## Deliberately not in scope

`memory_limit` and `max_stack_size` still disagree about zero:

| option | `0` means |
|---|---|
| `max_stack_size` | no limit, since `update_stack_limit` sets `stack_limit = 0` |
| `memory_limit` | zero bytes, so every eval raises |

Two options in the same hash where zero means opposite things. Fixing it is an API decision rather than a conversion bug, so it wants its own discussion. Worth noting there is currently no way to ask for an unlimited memory budget at all.

590 runs, 0 failures.
