### PR TITLE
Run the musl leg on both ends of the supported range

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,11 @@ on:
 
   pull_request:
 
+# The repository default is already read, but the default is a setting
+# somebody can change; every job here only builds and tests.
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,11 +39,20 @@ jobs:
   # mapped part of the stack rather than what RLIMIT_STACK allows. A change to
   # the stack-limit handling that is fine on both matrix legs above can still
   # make every eval on Alpine raise "stack overflow", which is what happened
-  # while #92 was being worked on. One job is enough to catch that shape.
+  # while #92 was being worked on.
   musl:
     runs-on: ubuntu-latest
-    name: Ruby 3.4 on alpine (musl)
-    container: ruby:3.4-alpine
+    name: Ruby ${{ matrix.ruby }} on alpine (musl)
+    container: ruby:${{ matrix.ruby }}-alpine
+    strategy:
+      matrix:
+        # Newest and oldest supported. Everything between is already covered
+        # four times over on glibc and macos, so what this leg adds is the
+        # libc; pinning it to a single Ruby would decide which end of the
+        # supported range never meets musl at all.
+        ruby:
+          - "4.0"
+          - "3.2"
 
     steps:
       - name: Install build dependencies


### PR DESCRIPTION
The Alpine job I added in #94 pinned Ruby 3.4. That is the version the matrix already covers four times over on glibc and macos, so it was the one choice that added the least: what this leg contributes is the libc, and pinning it to a single Ruby decided which end of the supported range never meets musl at all.

Newest and oldest instead. Verified locally against this tree, aarch64-linux-musl:

| image | ruby | result |
|---|---|---|
| `ruby:4.0-alpine` | 4.0.6 | 590 runs, 0 failures |
| `ruby:3.2-alpine` | 3.2.11 | 588 runs, 0 failures |

The run counts differ because 4.0 was measured with #95 applied and 3.2 against `main`.

Worth recording alongside this: the Alpine job flaked once on its first real run, on `ParallelEval#compiles concurrently with measurable speedup`, at 0.817 against a 0.8 threshold. A re-run passed, and the same test passes three times out of three in a local Alpine container, so it reads as scheduling noise on a two-core runner rather than anything about musl. Doubling the leg doubles the exposure to that, which is the one cost here. If it recurs, excluding the timing comparisons under a container is the obvious handle, and it would be worth doing with the reason stated rather than as a bare skip.
