### PR TITLE
Share converted objects instead of nilling every repeat

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,6 +500,18 @@ The rules for sharing VMs across threads:
 | `File` | → | `Quickjs::File` — `.name`, `.last_modified` + Blob attrs | requires `POLYFILL_FILE` |
 | `File` proxy | ← | `::File` | requires `POLYFILL_FILE`; applies to `define_function` return values |
 
+An object reached more than once within a single conversion becomes one Ruby object, mirroring the graph JavaScript built. Mutating one occurrence is therefore visible through the others:
+
+```rb
+result = Quickjs.eval_code('const o = {a: 1}; [o, o]')
+result[0].equal?(result[1]) #=> true
+
+result[0]['a'] = 999
+result #=> [{ 'a' => 999 }, { 'a' => 999 }]
+```
+
+A cycle has no Ruby equivalent, so the reference that closes it converts to `nil`.
+
 ## Extending: registering polyfills
 
 `Quickjs.register_polyfill(name, source:, init: nil)` adds a polyfill to a process-wide registry. Any VM constructed with `name` in its `features:` list runs the registered bundle on top of the JS runtime. Companion gems use this hook to ship additional polyfills (e.g. `Intl.Collator`, `DisplayNames`) without bundling them into the main gem.

--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -34,7 +34,8 @@ static void rebase_stack_limit(VMData *data);
 
 JSValue to_js_value(JSContext *ctx, VALUE r_value);
 VALUE to_rb_value(JSContext *ctx, JSValue j_val);
-static VALUE to_rb_value_inner(JSContext *ctx, JSValue j_val, VALUE r_visited);
+typedef struct ConvState ConvState;
+static VALUE to_rb_value_inner(JSContext *ctx, JSValue j_val, ConvState *conv);
 static VALUE vm_m_memoryUsage(VALUE r_self);
 static VALUE vm_m_runGC(VALUE r_self);
 static VALUE vm_m_memoryPoisoned(VALUE r_self);
@@ -259,7 +260,52 @@ static int js_is_plain_object(JSContext *ctx, JSValue j_val)
   return result;
 }
 
-static VALUE js_array_to_rb(JSContext *ctx, JSValue j_val, VALUE r_visited)
+#define CONV_PINNED_INLINE 8
+
+// State threaded through the conversion of one JS object graph.
+//
+// `r_seen` maps an object's address either to CONV_IN_PROGRESS, meaning the
+// object is an ancestor of the one being converted, or to the Ruby value it
+// finished converting to. The first case is a cycle and becomes nil; the second
+// is a shared subgraph, which converts once and stays shared on the Ruby side.
+// Only the containers this conversion builds are kept — see the toJSON branch.
+//
+// Every tracked object is pinned with JS_DupValue until the whole conversion
+// finishes. Property getters and toJSON run guest JS, which can drop the last
+// reference to an object and let a new one be allocated at the same address;
+// without the pin the map would answer for an object that no longer exists.
+struct ConvState
+{
+  JSContext *ctx;
+  JSValue j_root;
+  VALUE r_seen;
+  JSValue *pinned;
+  long pinned_count;
+  long pinned_capacity;
+  JSValue pinned_inline[CONV_PINNED_INLINE];
+};
+
+// The map is private to one conversion, so using it as its own marker cannot
+// collide with any value an object could convert to.
+#define CONV_IN_PROGRESS(conv) ((conv)->r_seen)
+
+static void conv_pin(ConvState *conv, JSValue j_val)
+{
+  if (conv->pinned_count == conv->pinned_capacity)
+  {
+    long capacity = conv->pinned_capacity * 2;
+    JSValue *pinned = xmalloc2(capacity, sizeof(JSValue));
+    JSValue *previous = conv->pinned;
+    memcpy(pinned, previous, conv->pinned_count * sizeof(JSValue));
+    conv->pinned = pinned;
+    conv->pinned_capacity = capacity;
+    if (previous != conv->pinned_inline)
+      xfree(previous);
+  }
+  conv->pinned[conv->pinned_count++] = JS_DupValue(conv->ctx, j_val);
+}
+
+static VALUE js_array_to_rb(JSContext *ctx, JSValue j_val, ConvState *conv)
 {
   JSValue j_length = JS_GetPropertyStr(ctx, j_val, "length");
   uint32_t length = 0;
@@ -270,13 +316,13 @@ static VALUE js_array_to_rb(JSContext *ctx, JSValue j_val, VALUE r_visited)
   for (uint32_t i = 0; i < length; i++)
   {
     JSValue j_elem = JS_GetPropertyUint32(ctx, j_val, i);
-    rb_ary_push(r_array, to_rb_value_inner(ctx, j_elem, r_visited));
+    rb_ary_push(r_array, to_rb_value_inner(ctx, j_elem, conv));
     JS_FreeValue(ctx, j_elem);
   }
   return r_array;
 }
 
-static VALUE js_plain_object_to_rb(JSContext *ctx, JSValue j_val, VALUE r_visited)
+static VALUE js_plain_object_to_rb(JSContext *ctx, JSValue j_val, ConvState *conv)
 {
   JSPropertyEnum *ptab;
   uint32_t plen;
@@ -288,7 +334,7 @@ static VALUE js_plain_object_to_rb(JSContext *ctx, JSValue j_val, VALUE r_visite
   {
     const char *key = JS_AtomToCString(ctx, ptab[i].atom);
     JSValue j_prop = JS_GetProperty(ctx, j_val, ptab[i].atom);
-    rb_hash_aset(r_hash, rb_str_new2(key), to_rb_value_inner(ctx, j_prop, r_visited));
+    rb_hash_aset(r_hash, rb_str_new2(key), to_rb_value_inner(ctx, j_prop, conv));
     JS_FreeCString(ctx, key);
     JS_FreeValue(ctx, j_prop);
   }
@@ -296,12 +342,36 @@ static VALUE js_plain_object_to_rb(JSContext *ctx, JSValue j_val, VALUE r_visite
   return r_hash;
 }
 
-VALUE to_rb_value(JSContext *ctx, JSValue j_val)
+static VALUE conv_run(VALUE r_conv)
 {
-  return to_rb_value_inner(ctx, j_val, Qnil);
+  ConvState *conv = (ConvState *)r_conv;
+  return to_rb_value_inner(conv->ctx, conv->j_root, conv);
 }
 
-static VALUE to_rb_value_inner(JSContext *ctx, JSValue j_val, VALUE r_visited)
+static VALUE conv_release(VALUE r_conv)
+{
+  ConvState *conv = (ConvState *)r_conv;
+  for (long i = 0; i < conv->pinned_count; i++)
+    JS_FreeValue(conv->ctx, conv->pinned[i]);
+  if (conv->pinned != conv->pinned_inline)
+    xfree(conv->pinned);
+  return Qnil;
+}
+
+VALUE to_rb_value(JSContext *ctx, JSValue j_val)
+{
+  // Only object graphs need the bookkeeping, and only they can recurse, so
+  // primitives convert straight through rather than paying for the state and
+  // the ensure. Every recursive call therefore has a non-NULL `conv`.
+  if (JS_VALUE_GET_NORM_TAG(j_val) != JS_TAG_OBJECT)
+    return to_rb_value_inner(ctx, j_val, NULL);
+
+  ConvState conv = {ctx, j_val, rb_hash_new(), NULL, 0, CONV_PINNED_INLINE};
+  conv.pinned = conv.pinned_inline;
+  return rb_ensure(conv_run, (VALUE)&conv, conv_release, (VALUE)&conv);
+}
+
+static VALUE to_rb_value_inner(JSContext *ctx, JSValue j_val, ConvState *conv)
 {
   switch (JS_VALUE_GET_NORM_TAG(j_val))
   {
@@ -396,38 +466,64 @@ static VALUE to_rb_value_inner(JSContext *ctx, JSValue j_val, VALUE r_visited)
         return r_maybe_file;
     }
 
-    // Below this point, conversion recurses into own properties / elements
-    // via to_rb_value_inner. Track JS object pointers to break cycles —
-    // re-entering the same object returns nil instead of blowing the stack.
-    if (NIL_P(r_visited))
-      r_visited = rb_hash_new();
-    VALUE r_visit_key = ULL2NUM((uintptr_t)JS_VALUE_GET_PTR(j_val));
-    if (RTEST(rb_hash_lookup(r_visited, r_visit_key)))
+    // Below this point, conversion recurses into own properties / elements via
+    // to_rb_value_inner. An object that is still on the current path is a cycle
+    // and becomes nil; one that finished converting earlier is a shared
+    // reference and yields the very same Ruby object again.
+    VALUE r_key = ULL2NUM((uintptr_t)JS_VALUE_GET_PTR(j_val));
+    VALUE r_seen = rb_hash_lookup2(conv->r_seen, r_key, Qundef);
+    if (r_seen == CONV_IN_PROGRESS(conv))
       return Qnil;
-    rb_hash_aset(r_visited, r_visit_key, Qtrue);
+    if (r_seen != Qundef)
+      return r_seen;
 
+    conv_pin(conv, j_val);
+    rb_hash_aset(conv->r_seen, r_key, CONV_IN_PROGRESS(conv));
+
+    VALUE r_result;
+    int memoize = 1;
     if (JS_IsArray(ctx, j_val))
-      return js_array_to_rb(ctx, j_val, r_visited);
-
-    if (js_is_plain_object(ctx, j_val))
-      return js_plain_object_to_rb(ctx, j_val, r_visited);
-
-    // Non-plain objects (Date, RegExp, Map, class instances, etc.).
-    // If the object opts in to a JSON representation via toJSON (e.g. Date),
-    // honour it — recurse on the returned value. Otherwise dump own enumerable
-    // string-keyed properties; this is faster than the JSON round-trip and
-    // preserves `undefined` values nested inside class instances.
-    JSValue j_toJSON = JS_GetPropertyStr(ctx, j_val, "toJSON");
-    if (JS_IsFunction(ctx, j_toJSON))
     {
-      JSValue j_jsonValue = JS_Call(ctx, j_toJSON, j_val, 0, NULL);
-      JS_FreeValue(ctx, j_toJSON);
-      VALUE r_result = to_rb_value_inner(ctx, j_jsonValue, r_visited);
-      JS_FreeValue(ctx, j_jsonValue);
-      return r_result;
+      r_result = js_array_to_rb(ctx, j_val, conv);
     }
-    JS_FreeValue(ctx, j_toJSON);
-    return js_plain_object_to_rb(ctx, j_val, r_visited);
+    else if (js_is_plain_object(ctx, j_val))
+    {
+      r_result = js_plain_object_to_rb(ctx, j_val, conv);
+    }
+    else
+    {
+      // Non-plain objects (Date, RegExp, Map, class instances, etc.).
+      // If the object opts in to a JSON representation via toJSON (e.g. Date),
+      // honour it — recurse on the returned value. Otherwise dump own enumerable
+      // string-keyed properties; this is faster than the JSON round-trip and
+      // preserves `undefined` values nested inside class instances.
+      JSValue j_toJSON = JS_GetPropertyStr(ctx, j_val, "toJSON");
+      if (JS_IsFunction(ctx, j_toJSON))
+      {
+        JSValue j_jsonValue = JS_Call(ctx, j_toJSON, j_val, 0, NULL);
+        JS_FreeValue(ctx, j_toJSON);
+        r_result = to_rb_value_inner(ctx, j_jsonValue, conv);
+        JS_FreeValue(ctx, j_jsonValue);
+        // A toJSON representation is recomputed for every occurrence instead of
+        // being shared. It is the object's stand-in value rather than a
+        // container this conversion built, so memoizing it would hand out the
+        // same mutable String for a Date reached twice, and would claim
+        // identity between two distinct JS objects whose toJSON returns the
+        // same thing. JSON.stringify also calls toJSON once per occurrence.
+        memoize = 0;
+      }
+      else
+      {
+        JS_FreeValue(ctx, j_toJSON);
+        r_result = js_plain_object_to_rb(ctx, j_val, conv);
+      }
+    }
+
+    if (memoize)
+      rb_hash_aset(conv->r_seen, r_key, r_result);
+    else
+      rb_hash_delete(conv->r_seen, r_key);
+    return r_result;
   }
   case JS_TAG_NULL:
     return Qnil;

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -143,6 +143,96 @@ describe Quickjs do
       assert_code("const a = [1, 2]; a.push(a); a", [1, 2, nil])
     end
 
+    it "shared reference converts to the same Ruby object, not nil" do
+      result = ::Quickjs.eval_code("const o = {a: 1}; [o, o]")
+      _(result).must_equal [{'a' => 1}, {'a' => 1}]
+      _(result[0]).must_be_same_as result[1]
+    end
+
+    it "shared reference under distinct keys keeps both branches" do
+      assert_code("const o = {a: 1}; ({x: o, y: o})", {'x' => {'a' => 1}, 'y' => {'a' => 1}})
+    end
+
+    it "object that is both a cycle and a share keeps the cycle marker in every occurrence" do
+      result = ::Quickjs.eval_code("const o = {n: 1}; o.self = o; [o, o]")
+      _(result).must_equal [{'n' => 1, 'self' => nil}, {'n' => 1, 'self' => nil}]
+      _(result[0]).must_be_same_as result[1]
+    end
+
+    it "share whose first occurrence is nested deeper than its second" do
+      result = ::Quickjs.eval_code("const o = {n: 1}; [{deep: {o}}, o]")
+      _(result).must_equal [{'deep' => {'o' => {'n' => 1}}}, {'n' => 1}]
+      _(result[0]['deep']['o']).must_be_same_as result[1]
+    end
+
+    it "shared reference through an array element stays shared" do
+      result = ::Quickjs.eval_code("const a = [1]; ({x: a, y: a})")
+      _(result).must_equal({'x' => [1], 'y' => [1]})
+      _(result['x']).must_be_same_as result['y']
+    end
+
+    it "a DAG converts every branch instead of nilling repeats" do
+      # Each level references the same child twice, so the old visited set nil'd
+      # every right-hand branch. Sharing keeps one hash per level, and keeps the
+      # graph from being duplicated into ~2M hashes on the way.
+      result = ::Quickjs.eval_code(<<~JS)
+        let cur = {leaf: 1};
+        for (let i = 0; i < 20; i++) { cur = {l: cur, r: cur}; }
+        cur;
+      JS
+      _(result['l']).must_be_same_as result['r']
+
+      depth = 0
+      node = result
+      until node.key?('leaf')
+        node = node['r']
+        depth += 1
+      end
+      _(depth).must_equal 20
+    end
+
+    it "toJSON representation is recomputed per occurrence, not shared" do
+      # Sharing it would hand the same mutable String to both slots.
+      result = ::Quickjs.eval_code("const d = new Date(0); [d, d]")
+      _(result).must_equal ['1970-01-01T00:00:00.000Z'] * 2
+      _(result[0]).wont_be_same_as result[1]
+    end
+
+    it "toJSON returning another object shares that object's conversion" do
+      # The instance itself is not memoized, but its stand-in is `inner`, so
+      # both slots legitimately describe the same JS object.
+      result = ::Quickjs.eval_code(<<~JS)
+        const inner = {v: 1};
+        class C { toJSON() { return inner } }
+        [new C(), inner];
+      JS
+      _(result).must_equal [{'v' => 1}, {'v' => 1}]
+      _(result[0]).must_be_same_as result[1]
+    end
+
+    it "an object freed by a getter cannot be mistaken for an earlier one" do
+      # Conversion keys objects by address, so it pins every one it has seen:
+      # without that, dropping `holder[0]` frees it and the object minted by the
+      # getter can land on the same address and hit the earlier entry.
+      assert_code(<<~JS, {'a' => {'tag' => 'DEAD'}, 'b' => {'tag' => 'FRESH'}})
+        const holder = [{tag: 'DEAD'}];
+        const o = {
+          a: holder[0],
+          get b() { holder.length = 0; delete o.a; return {tag: 'FRESH'} },
+        };
+        o;
+      JS
+    end
+
+    it "a share reached first through a cycle keeps the truncated shape" do
+      # `b` is not part of a cycle at the top level, but it converted under `a`
+      # where it was, so both occurrences carry the same nil marker. The
+      # truncation point follows traversal order.
+      result = ::Quickjs.eval_code("const a = {n: 1}; const b = {a}; a.b = b; [{x: a}, b]")
+      _(result).must_equal [{'x' => {'n' => 1, 'b' => {'a' => nil}}}, {'a' => nil}]
+      _(result[0]['x']['b']).must_be_same_as result[1]
+    end
+
     it "circular non-plain object via vm.call returns the same shape" do
       vm = Quickjs::VM.new
       vm.eval_code(<<~JS)


### PR DESCRIPTION
Fixes #90.

The visited set added for cycle detection was never unwound, so it answered "have I ever seen this object?" rather than "is this object an ancestor of the one I am converting?". Every object reached twice became `nil`, whether or not a cycle was involved.

```ruby
Quickjs.eval_code('const o = {a: 1}; [o, o]')            # before: [{"a"=>1}, nil]
Quickjs.eval_code('const o = {a: 1}; ({x: o, y: o})')    # before: {"x"=>{"a"=>1}, "y"=>nil}
```

Now both branches convert, and the two occurrences are the *same* Ruby object — which is what the guest built.

## What changed

An object's address maps either to a marker meaning "still converting, so this occurrence is a cycle" or to the Ruby value it finished producing. One map serves both roles; using it as its own marker cannot collide with any value an object could convert to.

Cycles are unaffected — the existing tests from #33 pass untouched. Deep DAGs stop expanding: the 20-level example from the issue goes from losing every right-hand branch to converting in 0.2 ms with one hash per level.

**Pinning.** The map is keyed by raw addresses, and getters and `toJSON` run guest JS that can free an object and let a new one land on the same address. Every tracked object is pinned with `JS_DupValue` and released in an `rb_ensure`. This is load-bearing rather than defensive: removing the pin makes the new `an object freed by a getter cannot be mistaken for an earlier one` test fail with the recycled object's value.

**`toJSON` results are not memoized.** They are the object's stand-in rather than a container this conversion built. Sharing them handed both slots of `[d, d]` the same unfrozen `String` for a `Date`, where `<<` on one rewrites the other. Recomputing per occurrence also matches `JSON.stringify`. When `toJSON` returns another object, that object's conversion is still shared — correctly, since the stand-in genuinely is that object.

## Two properties worth knowing

Both are discussed at more length [in the issue](https://github.com/hmsk/quickjs.rb/issues/90#issuecomment-5436051791).

- **One snapshot per object.** A getter that mutates the graph mid-conversion is not observed, because the mutated object may already have converted. Observing it means converting each occurrence independently, which is the amplification the memo exists to prevent.
- **A cycle's truncation point follows traversal order** and is then shared by every occurrence of the truncated object. The repair — skipping the memo for subtrees that truncated — puts the exponential expansion one line of guest JS away (`cur.self = cur`), so the memo is unconditional and the asymmetry is pinned by a test instead.

## Review

Two adversarial reviews, on memory safety and on behaviour. Findings applied here: `toJSON` results excluded from the memo, `conv_pin` publishing the new buffer before freeing the old one, the address-reuse regression test, and a misleading comment on the DAG test. The reviews found no GC-safety defect (`ConvState` is stack-resident, so conservative scanning pins it; verified under `GC.compact` from inside getters and `GC.stress`), no leak on the pin path, and proved the NULL-`conv` fast path cannot reach the object branch.

Pre-existing issues they turned up are filed separately: #98 (revoked `Proxy` converts to `[]`) and #99 (conversion leaks JS objects when it raises — same walk, worth deciding alongside this).

Note on #81: releasing the pins issues refcount writes at the end of a conversion, so a `dispose!` from a getter now lands a few more writes in freed storage. The extra writes are new, the use-after-free is not, and #81's fix removes both.

## Benchmark

100k conversions, median of three runs:

| | before | after |
|---|---|---|
| primitive | 77 ms | 77 ms |
| small plain object | 176 ms | 184 ms |
| class instance | 140 ms | 147 ms |
| 50-key object | 132 ms | 132 ms |

A second measurement on larger payloads (20 × a 20k-element array of objects) came out at 0.292 s → 0.311 s, i.e. within the same range. The cost is the `rb_ensure` and one extra hash write per object; primitives skip the machinery entirely. Two separate maps cost twice as much, which is why there is one.

579 runs, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
