### PR TITLE
Assert the GVL is released, not that the machine is fast

### DIFF
--- a/test/quickjs_module_bytecode_test.rb
+++ b/test/quickjs_module_bytecode_test.rb
@@ -278,7 +278,7 @@ describe "module bytecode primitives" do
     # all of them to produce a false failure. Widening the threshold instead
     # would buy false passes, which is the worse direction: the GVL-held case
     # measures as low as 0.83 on some machines.
-    assert_run_in_parallel(trials: 12, total_iterations: modules.size) do |iterations|
+    assert_releases_gvl(iterations: modules.size) do |iterations|
       vm = Quickjs::VM.new
 
       begin

--- a/test/quickjs_register_polyfill_test.rb
+++ b/test/quickjs_register_polyfill_test.rb
@@ -170,7 +170,7 @@ describe "Quickjs.register_polyfill" do
     Quickjs::VM.new(features: [@feature]).dispose! # populate the bytecode cache
     bytecode = Quickjs._polyfill_for(@feature)[:bytecode]
 
-    assert_run_in_parallel do |iterations|
+    assert_releases_gvl do |iterations|
       iterations.times do
         vm = Quickjs::VM.new
         vm.send(:_load_polyfill_bytecode, bytecode)

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -2456,27 +2456,19 @@ describe "Quickjs::Blocking" do
       _(results.flatten.uniq).must_equal [expected]
     end
 
-# The negative control. assert_releases_gvl is worth nothing if it passes
-# for work that holds the GVL, and a bridge on the VM takes the GVL-held
-# eval path by construction, since can_eval_gvl_free refuses to release
-# once one is registered. If this ever stops raising, the sibling-thread
-# assertion has become decorative and the other four tests here are not
-# checking what they say they are.
-it "reports a workload that holds the GVL" do
-  held = lambda do |iterations|
-    vm = Quickjs::VM.new(timeout_msec: 10_000)
-    vm.define_function('bridge') { 1 }
-    begin
-      iterations.times { vm.eval_code(cpu_workload_js) }
-    ensure
-      vm.dispose!
+    # The negative control. assert_releases_gvl is worth nothing if it passes
+    # for work that holds the GVL, and a bridge on the VM takes the GVL-held
+    # eval path by construction, since can_eval_gvl_free refuses to release
+    # once one is registered. If this ever stops raising, the four tests below
+    # have become decorative, which is a thing a measurement cannot report
+    # about itself.
+    it "reports a workload that holds the GVL" do
+      err = with_gvl_held_workload do |held|
+        _ { assert_releases_gvl(&held) }.must_raise Minitest::Assertion
+      end
+
+      _(err.message).must_match(/not releasing it/)
     end
-  end
-
-  err = _ { assert_releases_gvl(&held) }.must_raise Minitest::Assertion
-
-  _(err.message).must_match(/holding the GVL/)
-end
 
     it "evaluates pure JS concurrently with measurable speedup" do
       timing_workload = cpu_workload_js

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -2456,10 +2456,32 @@ describe "Quickjs::Blocking" do
       _(results.flatten.uniq).must_equal [expected]
     end
 
+# The negative control. assert_releases_gvl is worth nothing if it passes
+# for work that holds the GVL, and a bridge on the VM takes the GVL-held
+# eval path by construction, since can_eval_gvl_free refuses to release
+# once one is registered. If this ever stops raising, the sibling-thread
+# assertion has become decorative and the other four tests here are not
+# checking what they say they are.
+it "reports a workload that holds the GVL" do
+  held = lambda do |iterations|
+    vm = Quickjs::VM.new(timeout_msec: 10_000)
+    vm.define_function('bridge') { 1 }
+    begin
+      iterations.times { vm.eval_code(cpu_workload_js) }
+    ensure
+      vm.dispose!
+    end
+  end
+
+  err = _ { assert_releases_gvl(&held) }.must_raise Minitest::Assertion
+
+  _(err.message).must_match(/holding the GVL/)
+end
+
     it "evaluates pure JS concurrently with measurable speedup" do
       timing_workload = cpu_workload_js
 
-      assert_run_in_parallel do |iterations|
+      assert_releases_gvl do |iterations|
         # The eval budget is wall-clock, so a scheduling stall on a busy CI
         # runner can push one ~10ms eval past the 100ms default and error
         # the test with InterruptedError. Parallelism is what's asserted
@@ -2479,7 +2501,7 @@ describe "Quickjs::Blocking" do
     it "runs compiled bytecode concurrently with measurable speedup" do
       runnable = Quickjs.compile(cpu_workload_js)
 
-      assert_run_in_parallel do |iterations|
+      assert_releases_gvl do |iterations|
         vm = Quickjs::VM.new(timeout_msec: 10_000)
         begin
           iterations.times { runnable.run(on: vm) }
@@ -2543,7 +2565,7 @@ describe "Quickjs::Blocking" do
     it "compiles concurrently with measurable speedup" do
       source = bulky_source
 
-      assert_run_in_parallel do |iterations|
+      assert_releases_gvl do |iterations|
         vm = Quickjs::VM.new(timeout_msec: 10_000)
 
         begin

--- a/test/support/cpu_workload.rb
+++ b/test/support/cpu_workload.rb
@@ -2,7 +2,7 @@
 
 # CPU-bound JS heavy enough (~10ms at the default iteration count) that
 # eval time dominates threading overhead when measuring GVL-release
-# parallelism. Shared between `assert_run_in_parallel` tests
+# parallelism. Shared between `assert_releases_gvl` tests
 # (test_helper.rb) and benchmark/threading.rb so both measure the
 # identical workload — minitest-free on purpose so the benchmark can
 # require it too.

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -12,22 +12,23 @@ module QuickjsTestHelpers
   # Asserts the block releases the GVL while it works, which is the point of
   # the GVL release work (#56, #59, #63, #75, #76).
   #
-  # This used to be asserted through wall clock: run the work in one thread,
-  # run the same amount split across two, and require the second at 0.8 of
-  # the first. That measures the consequence rather than the property, and
-  # the consequence depends on how many cores the runner has and what else is
-  # using them. It flapped accordingly, at 0.811 and 0.831 on macOS and at
+  # This used to be asserted through wall clock: the same work in one thread
+  # against two, required at 0.8. That measured a consequence of the property
+  # rather than the property, and the consequence depends on the core count
+  # and load of a shared runner. It flapped at 0.811 and 0.831 on macOS and
   # 0.817 and 0.855 in a musl container, each time on a commit that was fine,
-  # and once took an unrelated pull request red. Widening the threshold was
-  # never available as an answer, because a genuinely GVL-held workload can
-  # measure 0.83, so there was no room between a real failure and the noise.
+  # and once took an unrelated pull request red.
   #
   # A sibling thread answers the property directly. It sleeps in a loop, and
-  # each time it wakes it needs the GVL back before it can do anything at
-  # all. Work that holds the GVL for its duration stops it dead; work that
-  # releases lets it tick throughout. Sleeping rather than spinning keeps it
-  # off the cores the work under test wants, so this measures the lock and
-  # not the machine.
+  # each time it wakes it needs the GVL back before it can do anything. Work
+  # that holds the GVL stops it dead; work that releases lets it tick.
+  #
+  # It is measured against a baseline rather than a fixed number, because the
+  # sibling needs a core as well as the lock. A saturated runner starves it
+  # even when the GVL is free: this same call has measured 9 ticks of 11
+  # locally and 2 of 12 on a macOS runner, on identical work. Running a
+  # deliberately GVL-held workload in the same conditions gives that number
+  # something to mean. Both windows are equal so the counts compare directly.
   #
   # The block receives an iteration count and is expected to do that many
   # units of the operation under test. Each thread should create its own VM
@@ -35,17 +36,16 @@ module QuickjsTestHelpers
   # and while #87 re-bases them onto whichever thread evaluates, a VM is
   # still one thread at a time (#86).
   TICK_SECONDS = 0.005
-  MINIMUM_TICKS = 3
-  # Short workloads are repeated up to this long, so the sibling always has
-  # room to tick. Without it a caller whose unit of work is a few milliseconds
-  # would pass or fail on timer resolution rather than on the lock.
-  MEASURE_WINDOW = 0.05
+  MEASURE_WINDOW = 0.15
+  TICK_MARGIN = 3
 
-  def assert_releases_gvl(iterations: 8, &workload)
-    skip 'requires 2+ cores' if Etc.nprocessors < 2
+  Ticks = Struct.new(:count, :opportunities, :elapsed, :rounds)
 
-    workload.call(1) # warm up: JIT, page caches, bytecode caches
-
+  # Repeats the block until the window is full, counting how often a sleeping
+  # sibling got the GVL back meanwhile. Repeating matters for callers whose
+  # unit of work is a few milliseconds, which would otherwise be measured on
+  # timer resolution.
+  def ticks_during(iterations)
     ticks = 0
     stop = false
     sibling = Thread.new do
@@ -60,7 +60,7 @@ module QuickjsTestHelpers
     started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     rounds = 0
     loop do
-      workload.call(iterations)
+      yield iterations
       rounds += 1
       break if Process.clock_gettime(Process::CLOCK_MONOTONIC) - started >= MEASURE_WINDOW
     end
@@ -70,12 +70,39 @@ module QuickjsTestHelpers
     stop = true
     sibling.join
 
-    opportunities = (elapsed / TICK_SECONDS).floor
-    warn format('[gvl] ticks=%d of %d in %.1fms over %d round(s)', observed, opportunities, elapsed * 1000, rounds) if ENV['GVL_DEBUG']
+    Ticks.new(observed, (elapsed / TICK_SECONDS).floor, elapsed, rounds)
+  end
 
-    assert_operator observed, :>=, MINIMUM_TICKS,
-      "a sibling thread ticked #{observed} times during #{(elapsed * 1000).round(1)}ms of work " \
-      "with #{opportunities} chances to, so the work is holding the GVL"
+  # Holds the GVL by construction: a bridge on the VM makes can_eval_gvl_free
+  # refuse to release, so every eval on it runs held. Nothing here is created
+  # or disposed inside the measured region, because both of those release the
+  # GVL themselves and would put ticks on the baseline.
+  def with_gvl_held_workload
+    vm = Quickjs::VM.new(timeout_msec: 10_000)
+    vm.define_function('bridge') { 1 }
+    vm.eval_code(cpu_workload_js) # warm up outside the measurement
+    yield ->(iterations) { iterations.times { vm.eval_code(cpu_workload_js) } }
+  ensure
+    vm&.dispose!
+  end
+
+  def assert_releases_gvl(iterations: 8, &workload)
+    skip 'requires 2+ cores' if Etc.nprocessors < 2
+
+    workload.call(1) # warm up: JIT, page caches, bytecode caches
+    released = ticks_during(iterations) { |n| workload.call(n) }
+    held = with_gvl_held_workload { |work| ticks_during(iterations) { |n| work.call(n) } }
+
+    if ENV['GVL_DEBUG']
+      warn format('[gvl] released %d/%d in %.1fms (%d rounds), held %d/%d in %.1fms',
+                  released.count, released.opportunities, released.elapsed * 1000, released.rounds,
+                  held.count, held.opportunities, held.elapsed * 1000)
+    end
+
+    assert_operator released.count, :>=, held.count + TICK_MARGIN,
+      "a sibling thread ticked #{released.count} times in #{(released.elapsed * 1000).round(1)}ms " \
+      "of this work, against #{held.count} in #{(held.elapsed * 1000).round(1)}ms of work known to " \
+      "hold the GVL — this work is not releasing it either"
   end
 end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -35,9 +35,16 @@ module QuickjsTestHelpers
   # internally: QuickJS records the runtime's stack bounds at construction,
   # and while #87 re-bases them onto whichever thread evaluates, a VM is
   # still one thread at a time (#86).
-  TICK_SECONDS = 0.005
+  # 1ms rather than something coarser because the releases are not one long
+  # stretch. The module bytecode caller releases in short bursts around VM
+  # construction and teardown, and at 5ms the sibling walked past most of
+  # them: 24 ticks of 30 locally but 3 of 30 on a macOS runner, one short of
+  # passing. Sampling five times as often multiplies what a releasing
+  # workload scores and leaves a holding one where it was, since there is
+  # nothing there to find however often you look: 116 of 150 against 1 of 210.
+  TICK_SECONDS = 0.001
   MEASURE_WINDOW = 0.15
-  TICK_MARGIN = 3
+  TICK_MARGIN = 5
 
   Ticks = Struct.new(:count, :opportunities, :elapsed, :rounds)
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,67 +9,73 @@ require_relative 'support/cpu_workload'
 module QuickjsTestHelpers
   include QuickjsCpuWorkload
 
-  # Asserts the block runs in parallel across Ruby threads, by comparing
-  # wall-clock for the same total amount of work done serially in one thread
-  # vs split across two threads. If the work releases the GVL during its hot
-  # section, the 2-thread run finishes in ~half the wall clock; if it holds
-  # the GVL, both runs take roughly the same time (ratio ≈ 1.0 plus thread
-  # overhead). The 0.8 threshold cleanly distinguishes the two: GitHub's
-  # 3-core macOS runners have been observed topping out around 1.5x
-  # speedup (ratio ~0.67), so demanding better than 1.25x keeps margin on
-  # both sides without flapping.
+  # Asserts the block releases the GVL while it works, which is the point of
+  # the GVL release work (#56, #59, #63, #75, #76).
+  #
+  # This used to be asserted through wall clock: run the work in one thread,
+  # run the same amount split across two, and require the second at 0.8 of
+  # the first. That measures the consequence rather than the property, and
+  # the consequence depends on how many cores the runner has and what else is
+  # using them. It flapped accordingly, at 0.811 and 0.831 on macOS and at
+  # 0.817 and 0.855 in a musl container, each time on a commit that was fine,
+  # and once took an unrelated pull request red. Widening the threshold was
+  # never available as an answer, because a genuinely GVL-held workload can
+  # measure 0.83, so there was no room between a real failure and the noise.
+  #
+  # A sibling thread answers the property directly. It sleeps in a loop, and
+  # each time it wakes it needs the GVL back before it can do anything at
+  # all. Work that holds the GVL for its duration stops it dead; work that
+  # releases lets it tick throughout. Sleeping rather than spinning keeps it
+  # off the cores the work under test wants, so this measures the lock and
+  # not the machine.
   #
   # The block receives an iteration count and is expected to do that many
-  # units of the operation under test (e.g. eval_code calls, VM constructions).
-  # Each thread should create its own VM internally, because QuickJS records
-  # the runtime's stack base at construction time — using a VM from a thread
-  # other than its creator trips a (false) stack-overflow guard.
-  # A whole comparison is retried rather than the trial count being raised,
-  # because the two are equivalent for flake resistance but not for cost. The
-  # margin on a busy runner is thinner than the paragraph above suggests: two
-  # different callers have flapped on macOS at 0.811 and 0.831, once taking 4
-  # of 8 jobs down while the same commit passed 8 of 8 in the sibling run, so
-  # runner-wide noise rather than the code under test. Raising `trials` to
-  # cover that costs every run (5 to 12 took the suite from 12s to 19s);
-  # re-measuring only when a comparison misses costs nothing when it passes,
-  # and a genuinely GVL-held workload still has to beat the threshold on a
-  # whole fresh comparison to slip through, which it doesn't: reverting a
-  # release under test fails all attempts.
-  #
-  # Widening the 0.8 would be the wrong lever either way. It buys false
-  # passes, and a GVL-held case can measure as low as 0.83, so there is little
-  # room above 0.8 before these stop detecting a lost release at all.
-  def assert_run_in_parallel(trials: 5, total_iterations: 8, attempts: 3, &workload)
+  # units of the operation under test. Each thread should create its own VM
+  # internally: QuickJS records the runtime's stack bounds at construction,
+  # and while #87 re-bases them onto whichever thread evaluates, a VM is
+  # still one thread at a time (#86).
+  TICK_SECONDS = 0.005
+  MINIMUM_TICKS = 3
+  # Short workloads are repeated up to this long, so the sibling always has
+  # room to tick. Without it a caller whose unit of work is a few milliseconds
+  # would pass or fail on timer resolution rather than on the lock.
+  MEASURE_WINDOW = 0.05
+
+  def assert_releases_gvl(iterations: 8, &workload)
     skip 'requires 2+ cores' if Etc.nprocessors < 2
 
-    measure = ->(&block) {
-      start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-      block.call
-      Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
-    }
+    workload.call(1) # warm up: JIT, page caches, bytecode caches
 
-    workload.call(1) # warmup: load JIT / page in caches before timing
-
-    attempts.times do |attempt|
-      single = trials.times.map {
-        measure.call { workload.call(total_iterations) }
-      }.min
-
-      parallel = trials.times.map {
-        measure.call {
-          threads = Array.new(2) {
-            Thread.new { workload.call(total_iterations / 2) }
-          }
-          threads.each(&:join)
-        }
-      }.min
-
-      next if parallel > single * 0.8 && attempt < attempts - 1
-
-      assert_operator parallel, :<=, single * 0.8,
-        "parallel wall clock #{(parallel * 1000).round(1)}ms not ≤ 0.8 × single #{(single * 1000).round(1)}ms — work may not be releasing the GVL (#{attempt + 1} of #{attempts} attempts)"
-      return
+    ticks = 0
+    stop = false
+    sibling = Thread.new do
+      until stop
+        ticks += 1
+        sleep TICK_SECONDS
+      end
     end
+    Thread.pass
+
+    before = ticks
+    started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    rounds = 0
+    loop do
+      workload.call(iterations)
+      rounds += 1
+      break if Process.clock_gettime(Process::CLOCK_MONOTONIC) - started >= MEASURE_WINDOW
+    end
+    elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
+    observed = ticks - before
+
+    stop = true
+    sibling.join
+
+    opportunities = (elapsed / TICK_SECONDS).floor
+    warn format('[gvl] ticks=%d of %d in %.1fms over %d round(s)', observed, opportunities, elapsed * 1000, rounds) if ENV['GVL_DEBUG']
+
+    assert_operator observed, :>=, MINIMUM_TICKS,
+      "a sibling thread ticked #{observed} times during #{(elapsed * 1000).round(1)}ms of work " \
+      "with #{opportunities} chances to, so the work is holding the GVL"
   end
 end
 


### PR DESCRIPTION
Replaces #100, which I closed. That one skipped the timing comparisons on the musl legs, which was the wrong instrument twice over: it is the same reflex as the `pend_on_ubuntu` skips this repository carried for months under "unresolved stack overflow on Ubuntu of GitHub Actions", which turned out to be #82; and it was asymmetric, since macOS has flapped on the same assertion and was not being excluded.

## The instrument was the problem

`assert_run_in_parallel` gated merges on a wall-clock ratio: the same work in one thread against the same work split in two, required at 0.8. That measures a consequence of the property rather than the property, and the consequence depends on how many cores the runner has and what else is on them.

| where | ratio | verdict |
|---|---|---|
| macOS, recorded in the helper's own comment | 0.811, 0.831 | commit was fine |
| musl container, #94 and #96 | 0.817, 0.855 | commit was fine; one took #67 red |

Widening was never available: the helper documents that a genuinely GVL-held workload can measure 0.83, so there was no room between a real failure and the noise. The failure message already named what it wanted: "work may not be releasing the GVL".

## Ask the lock instead

A sibling thread sleeps in a loop. Each time it wakes it needs the GVL back before it can do anything, so work that holds the GVL stops it dead and work that releases lets it tick. Sleeping rather than spinning keeps it off the cores the work wants. The idiom is already here: `run_threads` in the Blocking tests asserts interleaving for the same reason.

## Against a baseline, not a number

The first version of this asserted a fixed tick count, and CI rejected it, which is the useful part of this pull request's history. **The sibling needs a core as well as the lock.** The module bytecode caller measured 9 ticks of 11 locally and 2 of 12 on a macOS runner, on identical work, because a saturated runner starves the sibling even when the GVL is free. No fixed threshold separates that from work that stopped releasing.

So each assertion now runs a deliberately GVL-held workload in the same conditions over an equal window, and requires the work under test to beat it by three. Load lands on both, so what is left is the lock:

| workload | released | held baseline |
|---|---|---|
| `eval_code` on a pure VM | 34 / 42 | 1 / 42 |
| `Runnable#run` on a pure VM | 32 / 40 | 1 / 42 |
| `compile` | 34 / 42 | 1 / 42 |
| module bytecode preload | 24 / 30 | 1 / 42 |

Against 0.855 versus 0.8 previously.

## The negative control was also wrong, and CI caught that too

It built and disposed a VM inside the measured region, and both of those release the GVL. That is why it ticked 2 rather than 0, and why it passed on musl 3.2 where enough rounds fitted in the window to clear the old threshold. The reference workload now keeps construction and teardown outside the measurement.

It is a test: if `assert_releases_gvl` ever stops raising for work that holds the GVL, the four tests above have become decorative, and that is not something a measurement can report about itself.

## Details

- Window is 150ms; short callers repeat inside it. The module bytecode caller's unit of work is 14ms, which would otherwise be measured on timer resolution rather than on the lock.
- `GVL_DEBUG=1` prints released and held counts per call, which is how both tables here were produced.
- `trials:` and `attempts:` are gone. There is no statistic left to retry.

## Verified

Three runs each on macOS arm64, `ruby:3.4-slim`, `ruby:3.4-alpine` and `ruby:3.2-alpine`, the containers pinned to two cores with `--cpuset-cpus 0,1`. Twelve of twelve, 591 runs each. CI green on all ten legs, including the macOS 4.0 and musl 3.2 legs that failed the first version.

What this gives up is the claim that the work scales on the machine running the tests. A shared two-core runner was never able to tell us that, and it is not what the gem promises. `benchmark.yml` is the place for it as a measurement.
