### PR TITLE
Pin the actions to commit SHAs, and give Dependabot the job of moving them

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+
+updates:
+  # Actions are pinned to commit SHAs in the workflows, which is what makes
+  # this file necessary rather than nice to have: a pinned SHA never picks up
+  # an upstream fix on its own, so without something to move it the pin trades
+  # supply-chain risk for staleness. Dependabot moves it and writes the new
+  # version into the trailing comment.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+
+# Deliberately not covered: the ruby:*-alpine images the musl legs run in.
+# Those legs exist to test the newest and oldest supported Ruby against musl,
+# and a pinned digest would quietly turn "newest supported" into "whatever was
+# newest on the day it was pinned", which is the coverage they are there for.
+# They are Docker Official Images, which is a weaker exposure than the actions
+# above: those are third-party repositories, and they run in every job.

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -5,17 +5,21 @@ on:
     branches:
       - main
 
+# This job only reads the repository and prints numbers.
+permissions:
+  contents: read
+
 jobs:
   benchmark:
     runs-on: ubuntu-latest
     name: Polyfill overhead benchmark
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           submodules: true
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
           ruby-version: "3.4"
           bundler-cache: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,11 +28,11 @@ jobs:
           - macos-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           submodules: true
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
@@ -62,7 +62,7 @@ jobs:
     steps:
       - name: Install build dependencies
         run: apk add --no-cache build-base linux-headers git
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           submodules: true
       - name: Install gems


### PR DESCRIPTION
Closes #97.

Every third-party thing CI runs was referenced by a mutable tag. `actions/checkout` and `ruby/setup-ruby` are the interesting two: third-party repositories rather than Docker Library images, and they run in every job, so a retag or a compromised upstream build puts code in the runner before anything of ours executes.

| | before | after |
|---|---|---|
| `actions/checkout` | `@v4` | `@11d5960a...` `# v4.4.0` |
| `ruby/setup-ruby` | `@v1` | `@95ef2b04...` `# v1.321.0` |

**The two halves are not separable**, which is the reason `dependabot.yml` is in this PR rather than a later one. A pinned SHA never picks up an upstream fix by itself, so pinning without automation swaps a supply-chain risk for staleness, and staleness on a security-relevant dependency is not obviously the better trade. Dependabot moves the pin weekly and rewrites the trailing version comment.

`benchmark.yml` gets the `permissions: contents: read` block that `main.yml` gained in #96. The repository default is already `read`, so nothing changes today; it stops the posture depending on a setting somebody can change.

## Container images stay on tags

Recorded in `dependabot.yml` next to the thing it explains, rather than only here. The musl legs exist to test the newest and oldest supported Ruby against musl, and a pinned digest turns "newest supported" into "whatever was newest the day it was pinned", quietly. The freshness is the coverage. They are also Docker Official Images, which is a weaker exposure than two third-party repositories running in every job.

Worth revisiting if Dependabot's coverage of `container:` references is confirmed, which I have not verified.

## Not in scope, but noticed

`actions/checkout` is on the `v4` major and the latest is `v7.0.1`. This pins the current `v4` head rather than moving major versions, since that is a compatibility question rather than a supply-chain one. Dependabot will start proposing the major bump once this lands, which seems like the right place to decide it.
