### PR TITLE
Take only what the exception bridge parked, not what the proxies did

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,9 +407,12 @@ vm.memory_usage
 vm.gc!             # trigger a QuickJS GC cycle; returns nil
 
 vm.memory_poisoned? #=> false (true once the VM has hit out-of-memory)
+vm.poisoned?        #=> false (true when the VM has stopped accepting work, for any reason)
 ```
 
 When the JS heap exhausts its memory limit, QuickJS enters a fragile state where further evaluation can segfault the process. `memory_poisoned?` flips to `true` after such an event, and subsequent `eval_code` / `call` calls raise `Quickjs::RuntimeError` immediately instead of risking a crash. Rescue it and recreate the VM.
+
+A VM can also stop accepting work for a reason recreating it will not fix. `poisoned?` answers for any of them, `memory_poisoned?` only for out-of-memory, so the recycle path below tests the narrower one on purpose: if `poisoned?` is true while `memory_poisoned?` is false, a new VM will refuse in the same way and the failure belongs to the host. The one case today is `SecureRandom.random_number` no longer returning distinct integers, which leaves objects crossing into JS with no handle a guest cannot guess; the raised message says so.
 
 ```rb
 vm = Quickjs::VM.new(memory_limit: 256 * 1024 * 1024)

--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -289,11 +289,32 @@ VALUE find_ruby_error(JSContext *ctx, JSValue j_error)
   // a throw some earlier unchecked read left set looks exactly like one our own
   // read just caused, and an unrelated conversion is handed the host exception
   // it carried.
-  bool was_pending = JS_HasException(ctx);
+  // Held, not just noted: a trap that throws during the read replaces what was
+  // pending, and JS_Throw frees the old one, so asking "was something pending"
+  // afterwards cannot tell a throw we caused from one that was already there.
+  // Comparing the values can.
+  JSValue j_was_pending = JS_HasException(ctx) ? JS_GetException(ctx) : JS_UNINITIALIZED;
+  bool was_pending = !JS_IsUninitialized(j_was_pending);
+  if (was_pending)
+    JS_Throw(ctx, JS_DupValue(ctx, j_was_pending));
 
   VALUE r_error = find_ruby_error_at(ctx, j_error);
-  if (!NIL_P(r_error) || was_pending || !JS_HasException(ctx))
+  if (!NIL_P(r_error) || !JS_HasException(ctx))
+  {
+    JS_FreeValue(ctx, j_was_pending);
     return r_error;
+  }
+
+  JSValue j_now = JS_GetException(ctx);
+  if (was_pending && JS_VALUE_GET_PTR(j_now) == JS_VALUE_GET_PTR(j_was_pending))
+  {
+    // The same throw is still sitting there, so it is not ours to take.
+    JS_Throw(ctx, j_now);
+    JS_FreeValue(ctx, j_was_pending);
+    return r_error;
+  }
+  JS_FreeValue(ctx, j_was_pending);
+  JS_Throw(ctx, j_now);
 
   // The read was answered by a Proxy's descriptor trap, and the trap threw.
   // That throw is taken rather than left for an unrelated evaluation, and asked
@@ -1205,12 +1226,17 @@ static VALUE to_rb_value_inner(JSContext *ctx, JSValue j_val, ConvState *conv)
 
     // Check for Ruby object proxy (e.g., File proxy with rb_object_id on target)
     {
-      JSValue j_rb_id = JS_GetPropertyStr(ctx, j_val, "rb_object_id");
-      // The read is a getter's to answer, so it can throw, and what it throws
+      // Own data only, like the other two readers: through the prototype chain
+      // an accessor on Object.prototype answers for every object crossing back,
+      // and one line of guest setup turns a returned Hash into whichever host
+      // File or CryptoKey the guest already holds a handle for.
+      JSValue j_rb_id = JS_UNDEFINED;
+      bool has_handle = j_read_own_handle(ctx, j_val, &j_rb_id);
+      // A Proxy trap can still answer that read and throw, and what it throws
       // can be a bridge reporting a host failure.
-      if (JS_IsException(j_rb_id))
+      if (!has_handle && JS_IsException(j_rb_id))
         quickjsrb_drain_pending(ctx);
-      else if (JS_VALUE_GET_NORM_TAG(j_rb_id) == JS_TAG_INT || JS_VALUE_GET_NORM_TAG(j_rb_id) == JS_TAG_FLOAT64)
+      else if (has_handle && (JS_VALUE_GET_NORM_TAG(j_rb_id) == JS_TAG_INT || JS_VALUE_GET_NORM_TAG(j_rb_id) == JS_TAG_FLOAT64))
       {
         int64_t object_id;
         JS_ToInt64(ctx, &object_id, j_rb_id);
@@ -1676,6 +1702,12 @@ static JSValue js_quickjsrb_call_global(JSContext *ctx, JSValueConst _this, int 
     if (sadnessHappened)
     {
       VALUE r_error = rb_errinfo();
+      // Cleared, like every other recovery site here. Left set, it survives
+      // eval_code returning normally: a guest that merely catches the throw
+      // leaves the host's $! holding it, later raises chain to it through
+      // cause (#126), and a script that does nothing else exits 1 with a
+      // printed backtrace it never raised.
+      rb_set_errinfo(Qnil);
       j_result = j_error_from_ruby_error(ctx, r_error);
       // Rejecting with the sentinel would hand the guest a value it cannot
       // name, so the promise is left unsettled and the throw that produced it,
@@ -1721,6 +1753,7 @@ static JSValue js_quickjsrb_call_global(JSContext *ctx, JSValueConst _this, int 
     if (sadnessHappened)
     {
       VALUE r_error = rb_errinfo();
+      rb_set_errinfo(Qnil);
       JSValue j_error = j_error_from_ruby_error(ctx, r_error);
       if (JS_IsException(j_error))
         return JS_EXCEPTION;

--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -194,15 +194,13 @@ JSValue to_js_value(JSContext *ctx, VALUE r_value)
     return JS_NewFloat64(ctx, NUM2DBL(r_value));
   case T_BIGNUM:
   {
+    // strtod on the decimal we just produced, rather than calling globalThis's
+    // Number: that name is the guest's to delete or replace with a shim that
+    // throws, and a Bignum crossing over is not something it gets to answer
+    // for. The value is the same one Number(str) would have produced, since
+    // this is the conversion Number(str) performs.
     VALUE r_str = rb_funcall(r_value, rb_intern("to_s"), 0);
-    JSValue j_str = JS_NewStringLen(ctx, RSTRING_PTR(r_str), RSTRING_LEN(r_str));
-    JSValue j_global = JS_GetGlobalObject(ctx);
-    JSValue j_numberClass = JS_GetPropertyStr(ctx, j_global, "Number");
-    JSValue j_num = JS_Call(ctx, j_numberClass, JS_UNDEFINED, 1, (JSValueConst *)&j_str);
-    JS_FreeValue(ctx, j_str);
-    JS_FreeValue(ctx, j_numberClass);
-    JS_FreeValue(ctx, j_global);
-    return j_num;
+    return JS_NewFloat64(ctx, rb_str_to_dbl(r_str, FALSE));
   }
   case T_STRING:
     return JS_NewStringLen(ctx, RSTRING_PTR(r_value), RSTRING_LEN(r_value));
@@ -3905,14 +3903,15 @@ static VALUE call_global_function_run(VALUE p)
   // Converted first, under a clock of its own. Mostly this is Ruby work —
   // inspect on the caller's objects, allocation, a GVL yield to another thread
   // — and none of it is the guest's to pay for, which is why the arm above the
-  // resolution below starts the budget over. But two conversions run JS: a
-  // File argument calls the proxy creator and a Bignum calls Number(), and
-  // each polls the interrupt handler on the way, so without an arm here they
-  // ran on whatever clock the previous entry left — a lapsed one interrupts
-  // the conversion at random and hands the function a JS_EXCEPTION for an
-  // argument. Two arms, but not the two budgets the previous commit had: no
-  // guest-written JS runs between them unless the guest has replaced Proxy or
-  // Number, and then it is bounded rather than unbounded.
+  // resolution below starts the budget over. But a conversion can still run JS:
+  // a File argument calls the proxy creator, which polls the interrupt handler
+  // on the way, so without an arm here it ran on whatever clock the previous
+  // entry left — a lapsed one interrupts the conversion at random and hands the
+  // function a JS_EXCEPTION for an argument. Two arms, but not the two budgets
+  // the previous commit had: no guest-written JS runs between them unless the
+  // guest has replaced Proxy, and then it is bounded rather than unbounded.
+  // (A Bignum used to call Number() here too; it converts without asking the
+  // guest for anything now.)
   arm_eval_timer(data);
   for (int i = 0; i < args->nargs; i++)
   {
@@ -4407,6 +4406,11 @@ static VALUE vm_m_dispose(VALUE r_self)
   {
     JS_FreeValue(data->context, data->j_file_proxy_creator);
     data->j_file_proxy_creator = JS_UNDEFINED;
+  }
+  if (!JS_IsUndefined(data->j_blob_ctor))
+  {
+    JS_FreeValue(data->context, data->j_blob_ctor);
+    data->j_blob_ctor = JS_UNDEFINED;
   }
 
   // Mark disposed before releasing the GVL so a concurrent dfree finds

--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -39,26 +39,107 @@ static VALUE to_rb_value_inner(JSContext *ctx, JSValue j_val, ConvState *conv);
 static VALUE raise_js_exception(JSContext *ctx);
 static VALUE vm_m_memoryUsage(VALUE r_self);
 static VALUE vm_m_runGC(VALUE r_self);
+static VALUE vm_m_poisoned(VALUE r_self);
 static VALUE vm_m_memoryPoisoned(VALUE r_self);
 static VALUE vm_m_dispose(VALUE r_self);
 static VALUE vm_m_disposed(VALUE r_self);
 static VALUE vm_m_drainJobs(VALUE r_self);
 
+VALUE quickjsrb_secure_random = Qnil;
+VALUE quickjsrb_handle_limit = Qnil;
+
+void quickjsrb_init_handle_source(void)
+{
+  quickjsrb_secure_random = rb_const_get(rb_cObject, rb_intern("SecureRandom"));
+  rb_gc_register_address(&quickjsrb_secure_random);
+
+  // Built without allocating, and so without a window where the global holds a
+  // value nothing roots yet: 2 ** 48 is a Fixnum here but a Bignum where a long
+  // is 32 bits, and the second call could have collected the first.
+  quickjsrb_handle_limit = LL2NUM(((int64_t)1 << QUICKJSRB_HANDLE_BITS) - 1);
+  rb_gc_register_address(&quickjsrb_handle_limit);
+}
+
 JSValue j_error_from_ruby_error(JSContext *ctx, VALUE r_error)
 {
-  JSValue j_error = JS_NewError(ctx); // may wanna have custom error class to determine in JS' end
-
-  VALUE r_object_id = rb_funcall(r_error, rb_intern("object_id"), 0);
-  int objectId = NUM2INT(r_object_id);
-  JS_SetPropertyStr(ctx, j_error, "rb_object_id", JS_NewInt32(ctx, objectId));
-
-  // Keep the error alive in VMData to prevent GC before find_ruby_error retrieves it
-  VMData *data = JS_GetContextOpaque(ctx);
-  rb_hash_aset(data->alive_objects, r_object_id, r_error);
-
+  // Everything that can raise happens before anything is registered. Asking
+  // the exception for its message runs Ruby the host wrote, and a String with
+  // a null byte makes StringValueCStr raise; either longjmps out of here, and
+  // an entry made first would be parked in both tables for the life of the VM
+  // with nothing left pointing at it.
   VALUE r_exception_message = rb_funcall(r_error, rb_intern("message"), 0);
   const char *errorMessage = StringValueCStr(r_exception_message);
-  JS_SetPropertyStr(ctx, j_error, "message", JS_NewString(ctx, errorMessage));
+
+  // The draw is here with them, not below: it calls SecureRandom and writes two
+  // hashes, any of which can raise, and a raise after the allocations would
+  // longjmp out of a JSCFunction leaving them, and the promise capability of
+  // whichever caller is mid-flight, unreleased.
+  VMData *data = JS_GetContextOpaque(ctx);
+  // Taken before the draw, so the rollback below does not dispatch from inside
+  // a JSCFunction on its way out.
+  VALUE r_error_object_id = rb_obj_id(r_error);
+  bool registered_here = false;
+  VALUE r_object_id = alive_objects_register(data, r_error, &registered_here);
+  if (NIL_P(r_object_id))
+    // No handle means no way to hand this exception back out, so the guest gets
+    // an error of its own rather than one that looks bridged and is not.
+    return JS_ThrowInternalError(ctx, "quickjs: could not publish a handle for a host exception");
+
+  JSValue j_error = JS_NewError(ctx); // may wanna have custom error class to determine in JS' end
+  JSValue j_message = JS_NewString(ctx, errorMessage);
+  // Both are allocations, and either answers JS_EXCEPTION on a heap that has
+  // run out. Storing the sentinel would put it on the error as an ordinary
+  // value and mask the throw that produced it, so neither is published and the
+  // caller is told instead.
+  if (JS_IsException(j_error) || JS_IsException(j_message))
+  {
+    if (registered_here)
+      alive_objects_unregister(data, r_object_id, r_error_object_id);
+    JS_FreeValue(ctx, j_error);
+    JS_FreeValue(ctx, j_message);
+    return JS_EXCEPTION;
+  }
+
+  // Defined, not set: JS_SetPropertyStr walks the prototype chain, so an
+  // accessor a guest installs on Error.prototype absorbs the write and no own
+  // property is ever created, while the reader insists on an own data one.
+  // Every host exception would then be both unreportable and permanently
+  // parked, on one line of guest setup. Non-enumerable for the same reason the
+  // File and CryptoKey writers are: the handle is not part of the error.
+  //
+  // The message is defined for the same reason, and is non-enumerable with it,
+  // which is a change: assignment made it enumerable, so a bridged error was
+  // the one Error in the runtime whose message showed up in JSON.stringify and
+  // Object.keys. Errors the guest makes itself do not, because that is what the
+  // Error constructor does, and a bridged one is not special enough to differ.
+  if (JS_DefinePropertyValueStr(ctx, j_error, "rb_object_id",
+                                JS_NewInt64(ctx, NUM2LL(r_object_id)),
+                                JS_PROP_WRITABLE | JS_PROP_CONFIGURABLE) < 0)
+  {
+    // Only the row this call made. The registrar reuses one when the same
+    // object is bridged twice, and tearing that down would unanchor the error
+    // an earlier crossing is still holding.
+    if (registered_here)
+    {
+      rb_hash_delete(data->alive_objects, r_object_id);
+      rb_hash_delete(data->alive_handles, rb_obj_id(r_error));
+    }
+    JS_FreeValue(ctx, j_message);
+    JS_FreeValue(ctx, j_error);
+    return JS_EXCEPTION;
+  }
+
+  if (JS_DefinePropertyValueStr(ctx, j_error, "message", j_message,
+                                JS_PROP_WRITABLE | JS_PROP_CONFIGURABLE) < 0)
+  {
+    if (registered_here)
+    {
+      rb_hash_delete(data->alive_objects, r_object_id);
+      rb_hash_delete(data->alive_handles, rb_obj_id(r_error));
+    }
+    JS_FreeValue(ctx, j_error);
+    return JS_EXCEPTION;
+  }
 
   return j_error;
 }
@@ -67,6 +148,7 @@ typedef struct
 {
   JSContext *ctx;
   JSValue j_obj;
+  bool failed;
 } RbHashToJsArg;
 
 static int rb_hash_entry_to_js(VALUE r_key, VALUE r_val, VALUE extra)
@@ -86,7 +168,17 @@ static int rb_hash_entry_to_js(VALUE r_key, VALUE r_val, VALUE extra)
     VALUE r_key_str = rb_funcall(r_key, rb_intern("to_s"), 0);
     key_cstr = StringValueCStr(r_key_str);
   }
-  JS_SetPropertyStr(arg->ctx, arg->j_obj, key_cstr, to_js_value(arg->ctx, r_val));
+  JSValue j_val = to_js_value(arg->ctx, r_val);
+  // A member that could not be built is not stored as the sentinel: doing so
+  // makes any later read of that slot behave as though an exception were
+  // pending. The walk stops and the caller is told.
+  if (JS_IsException(j_val))
+  {
+    arg->failed = true;
+    return ST_STOP;
+  }
+
+  JS_SetPropertyStr(arg->ctx, arg->j_obj, key_cstr, j_val);
   return ST_CONTINUE;
 }
 
@@ -138,15 +230,29 @@ JSValue to_js_value(JSContext *ctx, VALUE r_value)
     JSValue j_arr = JS_NewArray(ctx);
     for (int i = 0; i < len; i++)
     {
-      JS_SetPropertyUint32(ctx, j_arr, (uint32_t)i, to_js_value(ctx, RARRAY_AREF(r_value, i)));
+      JSValue j_element = to_js_value(ctx, RARRAY_AREF(r_value, i));
+      // See rb_hash_entry_to_js: an element that could not be built is not
+      // stored as the sentinel.
+      if (JS_IsException(j_element))
+      {
+        JS_FreeValue(ctx, j_arr);
+        return JS_EXCEPTION;
+      }
+
+      JS_SetPropertyUint32(ctx, j_arr, (uint32_t)i, j_element);
     }
     return j_arr;
   }
   case T_HASH:
   {
     JSValue j_obj = JS_NewObject(ctx);
-    RbHashToJsArg arg = {ctx, j_obj};
+    RbHashToJsArg arg = {ctx, j_obj, false};
     rb_hash_foreach(r_value, rb_hash_entry_to_js, (VALUE)&arg);
+    if (arg.failed)
+    {
+      JS_FreeValue(ctx, j_obj);
+      return JS_EXCEPTION;
+    }
     return j_obj;
   }
   default:
@@ -159,7 +265,7 @@ JSValue to_js_value(JSContext *ctx, VALUE r_value)
     }
     if (rb_obj_is_kind_of(r_value, rb_eException))
     {
-      return j_error_from_ruby_error(ctx, r_value);
+      return j_error_from_ruby_error(ctx, r_value); // JS_EXCEPTION propagates to the caller
     }
     VALUE r_inspect_str = rb_funcall(r_value, rb_intern("inspect"), 0);
     char *str = StringValueCStr(r_inspect_str);
@@ -169,7 +275,44 @@ JSValue to_js_value(JSContext *ctx, VALUE r_value)
   }
 }
 
+static VALUE find_ruby_error_at(JSContext *ctx, JSValue j_error);
+
+static bool js_is_proxy(JSContext *ctx, JSValue j_val)
+{
+  VMData *data = JS_GetContextOpaque(ctx);
+  return JS_IsObject(j_val) && data->proxy_class_id != 0 && JS_GetClassID(j_val) == data->proxy_class_id;
+}
+
 VALUE find_ruby_error(JSContext *ctx, JSValue j_error)
+{
+  // Whether anything was already pending before we read anything. Without it,
+  // a throw some earlier unchecked read left set looks exactly like one our own
+  // read just caused, and an unrelated conversion is handed the host exception
+  // it carried.
+  bool was_pending = JS_HasException(ctx);
+
+  VALUE r_error = find_ruby_error_at(ctx, j_error);
+  if (!NIL_P(r_error) || was_pending || !JS_HasException(ctx))
+    return r_error;
+
+  // The read was answered by a Proxy's descriptor trap, and the trap threw.
+  // That throw is taken rather than left for an unrelated evaluation, and asked
+  // once whether it carries a host exception, because a bridge reached from the
+  // trap parks one and only this takes it back out.
+  //
+  // Once, and not if what it threw is itself a Proxy: asking that would run
+  // another trap, which is a chain the guest chooses the length of. Refusing at
+  // this level costs a bridged error wrapped in a Proxy thrown by a trap, and
+  // keeps one wrapped in a Proxy thrown directly, which is the shape that
+  // reaches here in practice.
+  JSValue j_trap_threw = JS_GetException(ctx);
+  if (!js_is_proxy(ctx, j_trap_threw))
+    r_error = find_ruby_error_at(ctx, j_trap_threw);
+  JS_FreeValue(ctx, j_trap_threw);
+  return r_error;
+}
+
+static VALUE find_ruby_error_at(JSContext *ctx, JSValue j_error)
 {
   // Most callers know they hold an Error before they ask, but the one that
   // inspects a failed conversion's throw cannot: `throw null` and `throw 1` are
@@ -180,18 +323,68 @@ VALUE find_ruby_error(JSContext *ctx, JSValue j_error)
   if (!JS_IsObject(j_error))
     return Qnil;
 
-  JSValue j_errorOriginalRubyObjectId = JS_GetPropertyStr(ctx, j_error, "rb_object_id");
-  int errorOriginalRubyObjectId = 0;
-  if (JS_VALUE_GET_NORM_TAG(j_errorOriginalRubyObjectId) == JS_TAG_INT)
+  // Read as an own data property, never through a getter: all three writers
+  // define it that way, so nothing legitimate is missed, and a getter on a
+  // thrown object would otherwise reach a bridge from inside the lookup that
+  // exists to take a bridged exception back out.
+  //
+  // Not quite "runs no guest code", which is what this said before: a Proxy's
+  // getOwnPropertyDescriptor trap answers this read too, and a trap that
+  // throws makes JS_GetOwnProperty answer -1 with its throw left pending.
+  // That is a different answer from "no such property" and is kept apart from
+  // it, because folding the two left the trap's throw set and its parked
+  // exception unreachable.
+  JSAtom handle_atom = JS_NewAtom(ctx, "rb_object_id");
+  JSPropertyDescriptor desc;
+  int found = JS_GetOwnProperty(ctx, &desc, j_error, handle_atom);
+  JS_FreeAtom(ctx, handle_atom);
+  // A trap that threw leaves its throw pending, which find_ruby_error takes.
+  if (found <= 0)
+    return Qnil;
+  if ((desc.flags & JS_PROP_TMASK) != JS_PROP_NORMAL)
   {
-    JS_ToInt32(ctx, &errorOriginalRubyObjectId, j_errorOriginalRubyObjectId);
+    JS_FreeValue(ctx, desc.value);
+    JS_FreeValue(ctx, desc.getter);
+    JS_FreeValue(ctx, desc.setter);
+    return Qnil;
+  }
+  JS_FreeValue(ctx, desc.getter);
+  JS_FreeValue(ctx, desc.setter);
+  JSValue j_errorOriginalRubyObjectId = desc.value;
+  int64_t errorOriginalRubyObjectId = 0;
+  // FLOAT64 as well as INT: the handle is drawn from a range wider than a
+  // tagged int, so QuickJS carries most of them as doubles.
+  if (JS_VALUE_GET_NORM_TAG(j_errorOriginalRubyObjectId) == JS_TAG_INT || JS_VALUE_GET_NORM_TAG(j_errorOriginalRubyObjectId) == JS_TAG_FLOAT64)
+  {
+    JS_ToInt64(ctx, &errorOriginalRubyObjectId, j_errorOriginalRubyObjectId);
     JS_FreeValue(ctx, j_errorOriginalRubyObjectId);
     if (errorOriginalRubyObjectId > 0)
     {
       VMData *data = JS_GetContextOpaque(ctx);
-      VALUE r_key = INT2NUM(errorOriginalRubyObjectId);
+      VALUE r_key = LL2NUM(errorOriginalRubyObjectId);
       VALUE r_error = rb_hash_aref(data->alive_objects, r_key);
+      // alive_objects anchors three unrelated things: a bridged exception,
+      // waiting to be thrown back, and the Ruby objects behind a File or a
+      // CryptoKey proxy, which stay reachable for as long as the guest holds
+      // the proxy. Only the first is this function's to take. The id is an
+      // ordinary property the guest can write, so without the check a script
+      // that copies a live proxy's id onto anything throwable severs that
+      // proxy: the entry is deleted, and every property of the File it stood
+      // for reads back as undefined while the object still passes
+      // `instanceof File`. Leaving a foreign entry anchored is the same
+      // answer as never having matched.
+      if (!rb_obj_is_kind_of(r_error, rb_eException))
+        return Qnil;
+      // Both rows, and the reverse one's key taken before either delete:
+      // rb_obj_id rather than the object_id method, which a subclass may
+      // override and which may allocate, so asking after the first delete
+      // could unanchor the exception and then lose it on the way to the
+      // second. The reverse row is only there so an object bridged twice keeps
+      // one handle, and once the entry is gone there is nothing for it to
+      // point at.
+      VALUE r_error_object_id = rb_obj_id(r_error);
       rb_hash_delete(data->alive_objects, r_key);
+      rb_hash_delete(data->alive_handles, r_error_object_id);
       return r_error;
     }
   }
@@ -200,6 +393,38 @@ VALUE find_ruby_error(JSContext *ctx, JSValue j_error)
     JS_FreeValue(ctx, j_errorOriginalRubyObjectId);
   }
   return Qnil;
+}
+
+// Takes a throw nobody is going to report, without losing what it carries. A
+// read that runs the guest's own code can reach a Ruby bridge, and the bridge
+// parks the host's exception in alive_objects on the way out; find_ruby_error
+// is the only thing that takes one back out, so a reader that merely frees the
+// JS_EXCEPTION pins one per call, at a rate the guest picks. The exception
+// itself is still lost, which is the caller's business to say.
+void quickjsrb_drain_pending(JSContext *ctx)
+{
+  // One pass here. The reader it calls can run a Proxy's descriptor trap, and
+  // takes what that throws itself, so a drain can run guest code and this is
+  // not the pure cleanup it looks like.
+  //
+  // A budget that lapsed inside one of those getters goes with the rest, and
+  // that is not right: the sibling drain in js_hold_cstring_or_null latches it.
+  // Latching here does not help on its own, though. Re-throwing the interrupt
+  // leaves it pending for a caller that carries on regardless, which is how the
+  // guest's own error is lost too. Both want the refusal path in #130, and
+  // both are the same on main.
+  //
+  // Unparking here and not in j_rethrow_the_guests_own is deliberate, and the
+  // difference is what happens to the throw. That one hands it back to the
+  // guest, so it can still travel out and be reported as the host exception it
+  // was, and taking the entry would break that. This one drops it, so nothing
+  // will carry it out and an anchor left behind is only a leak. What it costs
+  // is a guest that kept its own reference: rethrowing that later reports the
+  // message but a generic class, since the handle it carries no longer
+  // resolves.
+  JSValue j_pending = JS_GetException(ctx);
+  find_ruby_error(ctx, j_pending);
+  JS_FreeValue(ctx, j_pending);
 }
 
 VALUE r_try_json_parse(VALUE r_str)
@@ -583,6 +808,11 @@ static const char *js_hold_own_cstring(JsHold *hold, const char *str)
 static bool eval_budget_lapsed(VMData *data)
 {
   return data->eval_timer_armed && eval_elapsed_ms(data->eval_time) >= data->eval_time->limit_ms;
+}
+
+bool eval_budget_lapsed_now(JSContext *ctx)
+{
+  return eval_budget_lapsed(JS_GetContextOpaque(ctx));
 }
 
 // JS_ToCString converts through the value's own toString, so it answers NULL
@@ -976,7 +1206,11 @@ static VALUE to_rb_value_inner(JSContext *ctx, JSValue j_val, ConvState *conv)
     // Check for Ruby object proxy (e.g., File proxy with rb_object_id on target)
     {
       JSValue j_rb_id = JS_GetPropertyStr(ctx, j_val, "rb_object_id");
-      if (JS_VALUE_GET_NORM_TAG(j_rb_id) == JS_TAG_INT || JS_VALUE_GET_NORM_TAG(j_rb_id) == JS_TAG_FLOAT64)
+      // The read is a getter's to answer, so it can throw, and what it throws
+      // can be a bridge reporting a host failure.
+      if (JS_IsException(j_rb_id))
+        quickjsrb_drain_pending(ctx);
+      else if (JS_VALUE_GET_NORM_TAG(j_rb_id) == JS_TAG_INT || JS_VALUE_GET_NORM_TAG(j_rb_id) == JS_TAG_FLOAT64)
       {
         int64_t object_id;
         JS_ToInt64(ctx, &object_id, j_rb_id);
@@ -984,7 +1218,7 @@ static VALUE to_rb_value_inner(JSContext *ctx, JSValue j_val, ConvState *conv)
         if (object_id > 0)
         {
           VMData *data = JS_GetContextOpaque(ctx);
-          VALUE r_obj = rb_hash_aref(data->alive_objects, LONG2NUM(object_id));
+          VALUE r_obj = rb_hash_aref(data->alive_objects, LL2NUM(object_id));
           if (!NIL_P(r_obj) && !rb_obj_is_kind_of(r_obj, rb_eException))
             return r_obj;
         }
@@ -1149,6 +1383,9 @@ static char *quickjsrb_module_normalize(JSContext *ctx, const char *base_name, c
     VALUE r_error = rb_errinfo();
     rb_set_errinfo(Qnil);
     JSValue j_error = j_error_from_ruby_error(ctx, r_error);
+    // JS_Throw would replace the throw that made this fail with the sentinel.
+    if (JS_IsException(j_error))
+      return NULL;
     JS_Throw(ctx, j_error);
     return NULL;
   }
@@ -1440,12 +1677,35 @@ static JSValue js_quickjsrb_call_global(JSContext *ctx, JSValueConst _this, int 
     {
       VALUE r_error = rb_errinfo();
       j_result = j_error_from_ruby_error(ctx, r_error);
+      // Rejecting with the sentinel would hand the guest a value it cannot
+      // name, so the promise is left unsettled and the throw that produced it,
+      // already pending, is what the caller gets. Freed on the way out with
+      // everything else this block holds: returning from here directly would
+      // leak the capability and keep its resolving functions alive for the
+      // life of the runtime.
+      if (JS_IsException(j_result))
+      {
+        JS_FreeValue(ctx, promise);
+        JS_FreeValue(ctx, resolving_funcs[0]);
+        JS_FreeValue(ctx, resolving_funcs[1]);
+        return JS_EXCEPTION;
+      }
       ret_val = JS_Call(ctx, resolving_funcs[1], JS_UNDEFINED,
                         1, (JSValueConst *)&j_result);
     }
     else
     {
       j_result = to_js_value(ctx, r_result);
+      // Resolving with the sentinel would put it inside the promise; the throw
+      // that produced it is pending for the caller instead.
+      if (JS_IsException(j_result))
+      {
+        JS_FreeValue(ctx, promise);
+        JS_FreeValue(ctx, resolving_funcs[0]);
+        JS_FreeValue(ctx, resolving_funcs[1]);
+        return JS_EXCEPTION;
+      }
+
       ret_val = JS_Call(ctx, resolving_funcs[0], JS_UNDEFINED,
                         1, (JSValueConst *)&j_result);
     }
@@ -1462,6 +1722,8 @@ static JSValue js_quickjsrb_call_global(JSContext *ctx, JSValueConst _this, int 
     {
       VALUE r_error = rb_errinfo();
       JSValue j_error = j_error_from_ruby_error(ctx, r_error);
+      if (JS_IsException(j_error))
+        return JS_EXCEPTION;
       return JS_Throw(ctx, j_error);
     }
     else
@@ -1653,6 +1915,8 @@ static JSValue js_quickjsrb_log_inner(JSContext *ctx, int argc, JSValueConst *ar
     VALUE r_error = rb_errinfo();
     rb_set_errinfo(Qnil);
     JSValue j_error = j_error_from_ruby_error(ctx, r_error);
+    if (JS_IsException(j_error))
+      return JS_EXCEPTION;
     return JS_Throw(ctx, j_error);
   }
   return JS_UNDEFINED;
@@ -1929,6 +2193,21 @@ static VALUE vm_m_initialize(int argc, VALUE *argv, VALUE r_self)
 
   data->eval_time->limit_ms = (int64_t)NUM2UINT(r_timeout_msec);
   JS_SetContextOpaque(data->context, data);
+  // Learned here, before the first line of guest code: the constructor is read
+  // off the global, and a script that reassigns or deletes Proxy would
+  // otherwise choose what every reader below treats as one.
+  // Once per VM. initialize is private but reachable through send, and by then
+  // the guest may have replaced the constructor this reads.
+  if (data->proxy_class_id == 0)
+  {
+    static const char probe[] = "new Proxy({}, {})";
+    JSValue j_probe = JS_Eval(data->context, probe, sizeof(probe) - 1, "<probe>", JS_EVAL_TYPE_GLOBAL);
+    if (JS_IsException(j_probe))
+      JS_FreeValue(data->context, JS_GetException(data->context));
+    else
+      data->proxy_class_id = JS_GetClassID(j_probe);
+    JS_FreeValue(data->context, j_probe);
+  }
   JSRuntime *runtime = JS_GetRuntime(data->context);
 
   JS_SetMemoryLimit(runtime, size_option(r_memory_limit, "memory_limit"));
@@ -2074,8 +2353,24 @@ static VALUE to_rb_return_value(JSContext *ctx, JSValue j_val)
   return rb_ensure(to_rb_return_value_body, (VALUE)&owned, to_rb_return_value_release, (VALUE)&owned);
 }
 
-static void check_oom_poisoned(VMData *data)
+static void check_vm_poisoned(VMData *data)
 {
+  if (!NIL_P(data->r_registrar_error))
+  {
+    // Handed back as itself: a Timeout::Error the host asked for is theirs, and
+    // it was only held this long because raising it where it landed would have
+    // unwound through QuickJS.
+    VALUE r_error = data->r_registrar_error;
+    data->r_registrar_error = Qnil;
+    rb_exc_raise(r_error);
+  }
+
+  if (data->handle_source_broken)
+  {
+    VALUE r_msg = rb_str_new2("VM is poisoned: SecureRandom.random_number stopped answering with distinct usable integers, so an object could not be given a handle a guest cannot guess. A new VM will refuse in the same way, so fix the source rather than recycling: it is usually a test double still in place.");
+    rb_exc_raise(rb_funcall(QUICKJSRB_ERROR_FOR(QUICKJSRB_ROOT_RUNTIME_ERROR), rb_intern("new"), 2, r_msg, Qnil));
+  }
+
   if (data->oom_poisoned)
   {
     VALUE r_msg = rb_str_new2("VM is poisoned: a previous evaluation hit out-of-memory; further evaluation may segfault. Recreate the Quickjs::VM.");
@@ -2634,7 +2929,7 @@ static VALUE vm_m_evalCode(int argc, VALUE *argv, VALUE r_self)
   TypedData_Get_Struct(r_self, VMData, &vm_type, data);
 
   check_disposed(data);
-  check_oom_poisoned(data);
+  check_vm_poisoned(data);
   check_js_entry_owner(data);
 
   VALUE r_code, r_opts;
@@ -2851,7 +3146,7 @@ static VALUE vm_m_compile(int argc, VALUE *argv, VALUE r_self)
   TypedData_Get_Struct(r_self, VMData, &vm_type, data);
 
   check_disposed(data);
-  check_oom_poisoned(data);
+  check_vm_poisoned(data);
   check_js_entry_owner(data);
 
   VALUE r_code, r_opts;
@@ -2965,7 +3260,7 @@ static VALUE vm_m_compileModule(VALUE r_self, VALUE r_code, VALUE r_name)
   TypedData_Get_Struct(r_self, VMData, &vm_type, data);
 
   check_disposed(data);
-  check_oom_poisoned(data);
+  check_vm_poisoned(data);
   check_js_entry_owner(data);
   Check_Type(r_code, T_STRING);
   Check_Type(r_name, T_STRING);
@@ -3054,7 +3349,7 @@ static VALUE vm_m_preloadModuleBytecode(VALUE r_self, VALUE r_bytecode, VALUE r_
   TypedData_Get_Struct(r_self, VMData, &vm_type, data);
 
   check_disposed(data);
-  check_oom_poisoned(data);
+  check_vm_poisoned(data);
   check_js_entry_owner(data);
 
   // Strict String rather than StringValue's coercion, matching
@@ -3160,7 +3455,7 @@ static VALUE vm_m_evalBytecode(VALUE r_self, VALUE r_bytecode)
   TypedData_Get_Struct(r_self, VMData, &vm_type, data);
 
   check_disposed(data);
-  check_oom_poisoned(data);
+  check_vm_poisoned(data);
   check_js_entry_owner(data);
 
   if (!RB_TYPE_P(r_bytecode, T_STRING))
@@ -3245,7 +3540,7 @@ static VALUE vm_m_loadPolyfillBytecode(VALUE r_self, VALUE r_bytecode)
   }
 
   check_disposed(data);
-  check_oom_poisoned(data);
+  check_vm_poisoned(data);
   check_js_entry_owner(data);
 
   // "Unbudgeted" needs enforcing, not just skipping arm_eval_timer: the
@@ -3587,7 +3882,13 @@ static VALUE call_global_function_run(VALUE p)
   // Number, and then it is bounded rather than unbounded.
   arm_eval_timer(data);
   for (int i = 0; i < args->nargs; i++)
+  {
     args->j_args[i] = to_js_value(data->context, argv[i + 1]);
+    // An argument that could not be built is not handed to the call as the
+    // sentinel. The ensure that owns j_args releases what was built already.
+    if (JS_IsException(args->j_args[i]))
+      raise_js_exception(data->context); // raises
+  }
 
   JSValue j_this = JS_UNDEFINED;
   JSValue j_func;
@@ -3717,7 +4018,7 @@ static VALUE vm_m_callGlobalFunction(int argc, VALUE *argv, VALUE r_self)
   TypedData_Get_Struct(r_self, VMData, &vm_type, data);
 
   check_disposed(data);
-  check_oom_poisoned(data);
+  check_vm_poisoned(data);
   check_js_entry_owner(data);
 
   // evals_in_flight stays elevated for the whole call, not just the
@@ -3885,7 +4186,7 @@ static VALUE vm_m_import(int argc, VALUE *argv, VALUE r_self)
   TypedData_Get_Struct(r_self, VMData, &vm_type, data);
 
   check_disposed(data);
-  check_oom_poisoned(data);
+  check_vm_poisoned(data);
   check_js_entry_owner(data);
 
   // Module top-level code is user JS like any eval — budget it. Without
@@ -3907,6 +4208,7 @@ RUBY_FUNC_EXPORTED void Init_quickjsrb(void)
 {
   rb_require("json");
   rb_require("securerandom");
+  quickjsrb_init_handle_source();
 
   VALUE r_module_quickjs = rb_define_module("Quickjs");
   r_define_constants(r_module_quickjs);
@@ -3932,6 +4234,7 @@ RUBY_FUNC_EXPORTED void Init_quickjsrb(void)
   rb_define_method(r_class_vm, "memory_usage", vm_m_memoryUsage, 0);
   rb_define_method(r_class_vm, "gc!", vm_m_runGC, 0);
   rb_define_method(r_class_vm, "memory_poisoned?", vm_m_memoryPoisoned, 0);
+  rb_define_method(r_class_vm, "poisoned?", vm_m_poisoned, 0);
   rb_define_method(r_class_vm, "dispose!", vm_m_dispose, 0);
   rb_define_method(r_class_vm, "disposed?", vm_m_disposed, 0);
   rb_define_method(r_class_vm, "drain_jobs!", vm_m_drainJobs, 0);
@@ -3995,7 +4298,7 @@ static VALUE vm_m_drainJobs(VALUE r_self)
   TypedData_Get_Struct(r_self, VMData, &vm_type, data);
 
   check_disposed(data);
-  check_oom_poisoned(data);
+  check_vm_poisoned(data);
   check_js_entry_owner(data);
 
   if (!JS_IsJobPending(JS_GetRuntime(data->context)))
@@ -4012,6 +4315,24 @@ static VALUE vm_m_memoryPoisoned(VALUE r_self)
   TypedData_Get_Struct(r_self, VMData, &vm_type, data);
   return data->oom_poisoned ? Qtrue : Qfalse;
 }
+
+// Answers for either latch, where memory_poisoned? answers only for its own.
+// A VM whose handle source broke refuses every entry point while
+// memory_poisoned? says false, which leaves a host following the README's
+// recycle pattern holding one that looks healthy and does nothing. The two are
+// worth telling apart: recreating the VM clears an out-of-memory, and does not
+// clear a SecureRandom that is still returning nil.
+static VALUE vm_m_poisoned(VALUE r_self)
+{
+  VMData *data;
+  TypedData_Get_Struct(r_self, VMData, &vm_type, data);
+  // Only the latches, not the held exception. That one is handed back once and
+  // gone, and the VM is usable after it, so answering true for it would tell a
+  // host following the README's recycle path to throw away a healthy VM and go
+  // looking for a SecureRandom stub that does not exist.
+  return (data->oom_poisoned || data->handle_source_broken) ? Qtrue : Qfalse;
+}
+
 
 // JS_FreeContext + JS_FreeRuntime walk the entire heap to run finalisers.
 // On a VM with polyfills loaded this can be tens of milliseconds — run it
@@ -4067,6 +4388,7 @@ static VALUE vm_m_dispose(VALUE r_self)
   // collected. Matters for pool-rebuild workloads that dispose eagerly.
   data->defined_functions = rb_hash_new();
   data->alive_objects = rb_hash_new();
+  data->alive_handles = rb_hash_new();
   data->log_listener = Qnil;
   data->module_loader = Qnil;
 

--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -178,7 +178,20 @@ static int rb_hash_entry_to_js(VALUE r_key, VALUE r_val, VALUE extra)
     return ST_STOP;
   }
 
-  JS_SetPropertyStr(arg->ctx, arg->j_obj, key_cstr, j_val);
+  // Defined, not assigned, on an object we just built and are about to hand
+  // over: JS_SetPropertyStr walks the prototype chain, so a setter the guest
+  // installed on Object.prototype under this key receives the host's value and
+  // the object goes back with no own property of that name at all. It also
+  // keeps a "__proto__" key a key, rather than letting it reparent the object.
+  if (JS_DefinePropertyValueStr(arg->ctx, arg->j_obj, key_cstr, j_val, JS_PROP_C_W_E) < 0)
+  {
+    // Reported rather than shrugged off: the object would otherwise go back
+    // looking complete, missing that one key, with the throw the define set
+    // left for whatever asks next. A key the guest can then answer for with a
+    // prototype accessor is exactly what defining it was meant to prevent.
+    arg->failed = true;
+    return ST_STOP;
+  }
   return ST_CONTINUE;
 }
 
@@ -237,7 +250,14 @@ JSValue to_js_value(JSContext *ctx, VALUE r_value)
         return JS_EXCEPTION;
       }
 
-      JS_SetPropertyUint32(ctx, j_arr, (uint32_t)i, j_element);
+      // Defined for the same reason, which reaches elements too: any index
+      // property on Array.prototype costs the fast array path, and the write
+      // then walks the chain into the guest's setter.
+      if (JS_DefinePropertyValueUint32(ctx, j_arr, (uint32_t)i, j_element, JS_PROP_C_W_E) < 0)
+      {
+        JS_FreeValue(ctx, j_arr);
+        return JS_EXCEPTION;
+      }
     }
     return j_arr;
   }

--- a/ext/quickjsrb/quickjsrb.h
+++ b/ext/quickjsrb/quickjsrb.h
@@ -84,6 +84,9 @@ typedef struct VMData
   // ReferenceError when the loader doesn't know the name.
   VALUE preloaded_module_names;
   JSValue j_file_proxy_creator;
+  // Captured with it, at init, so slice does not build its result by calling
+  // a constructor the guest has had a chance to replace.
+  JSValue j_blob_ctor;
   // Once the runtime has hit JS-level "out of memory", the QuickJS heap is in
   // a fragile state where further evaluation can trigger a use-after-free in
   // the parser-error-during-OOM cascade (segfault inside js_shape_hash_unlink).
@@ -210,6 +213,8 @@ static void vm_free(void *ptr)
   {
     if (!JS_IsUndefined(data->j_file_proxy_creator))
       JS_FreeValue(data->context, data->j_file_proxy_creator);
+    if (!JS_IsUndefined(data->j_blob_ctor))
+      JS_FreeValue(data->context, data->j_blob_ctor);
 
     vm_teardown_context(data->context, data->std_handlers_installed);
   }
@@ -293,6 +298,7 @@ static VALUE vm_alloc(VALUE r_self)
   data->module_source_cache = rb_hash_new();
   data->preloaded_module_names = rb_hash_new();
   data->j_file_proxy_creator = JS_UNDEFINED;
+  data->j_blob_ctor = JS_UNDEFINED;
   data->proxy_class_id = 0;
   data->oom_poisoned = false;
   data->handle_source_broken = false;

--- a/ext/quickjsrb/quickjsrb.h
+++ b/ext/quickjsrb/quickjsrb.h
@@ -63,6 +63,9 @@ typedef struct VMData
   struct EvalTime *eval_time;
   VALUE log_listener;
   VALUE alive_objects;
+  // object_id -> handle, so an object bridged twice keeps one entry. Private:
+  // the guest is told the handle, never this key.
+  VALUE alive_handles;
   VALUE module_loader;
   VALUE on_unhandled_rejection;
   // Memoize (specifier, importer) → canonical so the user's loader Proc
@@ -87,6 +90,21 @@ typedef struct VMData
   // Trip this flag so subsequent eval_code/call calls refuse cleanly with a
   // Ruby exception instead of risking a process crash.
   bool oom_poisoned;
+  // Latched when the handle source stops giving out distinct values. Like
+  // oom_poisoned, it is reported from the next entry point rather than from
+  // wherever it was noticed, because that place is inside a JSCFunction.
+  bool handle_source_broken;
+  // What was raised at the registrar, when something was. rb_protect cannot
+  // tell a stubbed source apart from an Interrupt, a Timeout::Error or any
+  // other Thread#raise landing in that window, and discarding one of those
+  // loses it entirely. Kept instead, and re-raised from the next entry point,
+  // where there is no QuickJS frame to unwind through.
+  VALUE r_registrar_error;
+  // The class id a Proxy reports in this runtime, learned at init from a Proxy
+  // this extension builds, before any guest code can run. Read from the guest's
+  // own Proxy instead and a script that reassigns or deletes that global
+  // decides what the readers treat as a Proxy.
+  JSClassID proxy_class_id;
   // Whether interrupt_handler is currently installed. started_at belongs to
   // whichever evaluation armed it, so without this the elapsed time is read
   // off a stale clock — an unbudgeted polyfill load disarms deliberately and
@@ -210,6 +228,8 @@ static void vm_mark(void *ptr)
   rb_gc_mark_movable(data->defined_functions);
   rb_gc_mark_movable(data->log_listener);
   rb_gc_mark_movable(data->alive_objects);
+  rb_gc_mark_movable(data->alive_handles);
+  rb_gc_mark_movable(data->r_registrar_error);
   rb_gc_mark_movable(data->module_loader);
   rb_gc_mark_movable(data->on_unhandled_rejection);
   rb_gc_mark_movable(data->module_resolution_cache);
@@ -227,6 +247,8 @@ static void vm_compact(void *ptr)
   data->defined_functions = rb_gc_location(data->defined_functions);
   data->log_listener = rb_gc_location(data->log_listener);
   data->alive_objects = rb_gc_location(data->alive_objects);
+  data->alive_handles = rb_gc_location(data->alive_handles);
+  data->r_registrar_error = rb_gc_location(data->r_registrar_error);
   data->module_loader = rb_gc_location(data->module_loader);
   data->on_unhandled_rejection = rb_gc_location(data->on_unhandled_rejection);
   data->module_resolution_cache = rb_gc_location(data->module_resolution_cache);
@@ -264,13 +286,17 @@ static VALUE vm_alloc(VALUE r_self)
   data->defined_functions = rb_hash_new();
   data->log_listener = Qnil;
   data->alive_objects = rb_hash_new();
+  data->alive_handles = rb_hash_new();
   data->module_loader = Qnil;
   data->on_unhandled_rejection = Qnil;
   data->module_resolution_cache = rb_hash_new();
   data->module_source_cache = rb_hash_new();
   data->preloaded_module_names = rb_hash_new();
   data->j_file_proxy_creator = JS_UNDEFINED;
+  data->proxy_class_id = 0;
   data->oom_poisoned = false;
+  data->handle_source_broken = false;
+  data->r_registrar_error = Qnil;
   data->eval_timer_armed = false;
   data->disposed = false;
   data->gvl_released_js = false;
@@ -301,6 +327,217 @@ static VALUE vm_alloc(VALUE r_self)
 // shorter name than asked for the moment anyone raised the entropy.
 #define QUICKJSRB_GENERATED_NAME_LEN 12
 #define QUICKJSRB_GENERATED_NAME_SIZE (QUICKJSRB_GENERATED_NAME_LEN + 1)
+
+// The handle a bridged object is published to the guest under. It was the
+// Ruby object_id, which is a small sequential integer, and nothing ever leaves
+// alive_objects — so a script could walk 1..4000 and be handed back objects it
+// had never held: a File to read, a CryptoKey to sign with after every JS
+// reference to it was gone. Drawn from 2^48 instead, which stays exact in a JS
+// double and is not a space to walk. Collisions are re-drawn rather than
+// trusted to be unlikely, since one would hand two subsystems the same entry.
+#define QUICKJSRB_HANDLE_BITS 48
+#define QUICKJSRB_HANDLE_DRAW_LIMIT 16
+
+// Defined in quickjsrb.c. Declared here because the crypto reader needs it to
+// give back an exception a guest's getter parked on its way through.
+VALUE find_ruby_error(JSContext *ctx, JSValue j_error);
+// Also in quickjsrb.c: whether the evaluation has outrun the budget it was
+// armed with. Anything that hands a throw back to the guest has to ask, or a
+// deadline that fired inside a getter becomes catchable.
+bool eval_budget_lapsed_now(JSContext *ctx);
+// Also in quickjsrb.c: takes a throw a reader is about to drop, after giving
+// find_ruby_error the chance to unpark what it carries.
+void quickjsrb_drain_pending(JSContext *ctx);
+
+// The source the handle is drawn from, resolved once at Init and pinned rather
+// than looked up per registration: the registrar runs inside QuickJS native
+// callbacks with no rb_protect between them and the interpreter, which is the
+// hazard r_crypto_key_class is written around, and a constant lookup is exactly
+// the raise that hazard is about. The limit is 2^48 - 1 so the draw lands in
+// 1 .. 2^48 - 1, because every reader treats a zero handle as "no entry" and a
+// zero draw would strand the object.
+//
+// Narrowed rather than closed: the draw still calls into Ruby, so a
+// NoMemoryError or an entropy failure raises from the same place. Pre-resolving
+// takes the reachable cause off that path; the rest goes with the table, in
+// #114.
+//
+// Defined in quickjsrb.c rather than here, because a static in a header gives
+// every translation unit its own copy and only the one Init touched would be
+// set.
+extern VALUE quickjsrb_secure_random;
+extern VALUE quickjsrb_handle_limit;
+void quickjsrb_init_handle_source(void);
+
+// Both rows go together: alive_handles is only a way back to the handle, and a
+// handle left in alive_objects is what anchors the object for the life of the
+// VM.
+// Takes the handle rather than deriving it, so nothing here dispatches: these
+// run on unwind paths inside JSCFunctions, where a raise is #134, and the
+// registration side is under rb_protect for exactly that reason. rb_hash_delete
+// on an existing key allocates nothing.
+static inline void alive_objects_unregister(VMData *data, VALUE r_handle, VALUE r_object_id)
+{
+  rb_hash_delete(data->alive_objects, r_handle);
+  rb_hash_delete(data->alive_handles, r_object_id);
+}
+
+// Same, for a caller that has the object but not the handle it was given. A
+// miss is not an error: the object may never have been registered.
+static inline void alive_objects_forget(VMData *data, VALUE r_object)
+{
+  VALUE r_object_id = rb_obj_id(r_object);
+  VALUE r_handle = rb_hash_lookup2(data->alive_handles, r_object_id, Qnil);
+  if (!NIL_P(r_handle))
+    alive_objects_unregister(data, r_handle, r_object_id);
+}
+
+struct alive_register_work
+{
+  VMData *data;
+  VALUE r_object;
+  bool created;
+};
+
+static VALUE alive_objects_register_body(VALUE r_work)
+{
+  struct alive_register_work *work = (struct alive_register_work *)r_work;
+  VMData *data = work->data;
+  VALUE r_object = work->r_object;
+  bool *created = &work->created;
+
+  // One entry per object, not per crossing. The old handle was the object_id,
+  // so re-bridging the same File or exception overwrote its own row; drawing a
+  // fresh handle every time would instead add one, and nothing is ever removed,
+  // so `for (i = 0; i < 200000; i++) f()` would grow the table by 200000.
+  // rb_obj_id, not the method: a subclass can override object_id, and the two
+  // sides of this table have to agree on the key find_ruby_error will use.
+  VALUE r_object_id = rb_obj_id(r_object);
+  VALUE r_known = rb_hash_lookup2(data->alive_handles, r_object_id, Qnil);
+  // Reused only when the row still holds this object. Asking merely whether
+  // the handle is occupied would hand back one that a later draw had given to
+  // something else, since an object_id is only unique among live objects.
+  if (!NIL_P(r_known) && rb_hash_lookup2(data->alive_objects, r_known, Qnil) == r_object)
+  {
+    if (created != NULL)
+      *created = false;
+    return r_known;
+  }
+
+  // Bounded, because nothing can interrupt a C loop: no QuickJS interrupt is
+  // polled inside it, so timeout_msec cannot end it and only an outer
+  // Timeout.timeout would, by longjmping out of here through the JSCFunction
+  // frames this file warns about elsewhere. A host whose suite stubs the
+  // source flat (`SecureRandom.random_number` returning a constant is an
+  // ordinary test-double line) would otherwise spin forever on the second
+  // object it bridges. Sixteen draws against a 2^48 range only run out when
+  // the source is not random, so say that rather than degrade to a sequence a
+  // guest could walk.
+  //
+  // Refusing rather than raising also settles what the old note here worried
+  // about: there is no longjmp out of js_crypto_key_to_js past a promise
+  // capability it never allocated, because there is no longjmp at all.
+  VALUE r_handle;
+  int attempts = 0;
+  do
+  {
+    if (++attempts > QUICKJSRB_HANDLE_DRAW_LIMIT)
+    {
+      // Latched and handed back as a refusal, never raised from here. This runs
+      // inside a JSCFunction, and a longjmp out of one leaves the runtime's
+      // frame chain pointing at C stack that is gone: the next Error the guest
+      // builds walks it in build_backtrace and takes the process with it. The
+      // next entry point reports this instead, the way an out-of-memory is.
+      data->handle_source_broken = true;
+      if (created != NULL)
+        *created = false;
+      return Qnil;
+    }
+    r_handle = rb_funcall(quickjsrb_secure_random, rb_intern("random_number"), 1, quickjsrb_handle_limit);
+
+    // The draw is checked into an int64_t before anything uses it as a number.
+    // The bound above only catches a source that keeps returning the same
+    // value, and everything else a source can return raises here, inside the
+    // loop, before the bound is ever consulted: NUM2LL raises RangeError on a
+    // Bignum, dispatching + raises NoMethodError on nil, and a raise out of a
+    // JSCFunction is #134. rb_integer_pack answers the sign and reports a
+    // value too wide to fit rather than raising about it, and it does not
+    // dispatch, which a source could also answer for.
+    //
+    // Out of range is refused rather than clamped: a negative draw is stored
+    // under a key every reader treats as "no entry", so the object is anchored
+    // for the life of the VM and the exception it was bridging comes back as a
+    // generic Quickjs::RuntimeError instead of itself.
+    int64_t drawn = 0;
+    bool usable = RB_INTEGER_TYPE_P(r_handle);
+    if (usable)
+    {
+      // Asked only of an Integer: rb_integer_pack raises on anything else,
+      // which is the raise this check exists to avoid.
+      int sign = rb_integer_pack(r_handle, &drawn, 1, sizeof(int64_t), 0,
+                                 INTEGER_PACK_NATIVE_BYTE_ORDER | INTEGER_PACK_2COMP);
+      usable = sign >= 0 && sign <= 1 && drawn >= 0 && drawn < ((int64_t)1 << QUICKJSRB_HANDLE_BITS);
+    }
+    if (!usable)
+    {
+      data->handle_source_broken = true;
+      if (created != NULL)
+        *created = false;
+      return Qnil;
+    }
+    r_handle = LL2NUM(drawn + 1);
+  } while (!NIL_P(rb_hash_lookup2(data->alive_objects, r_handle, Qnil)));
+
+  rb_hash_aset(data->alive_objects, r_handle, r_object);
+  rb_hash_aset(data->alive_handles, r_object_id, r_handle);
+  if (created != NULL)
+    *created = true;
+  return r_handle;
+}
+
+// Answers the handle, and says through `created` whether this call is the one
+// that made the row: a caller that has to undo the registration must not undo
+// a row an earlier crossing of the same object is still relying on. Answers
+// Qnil, having latched handle_source_broken, when it cannot draw one.
+//
+// Protected, because the work it wraps runs inside a JSCFunction and a raise out
+// of one leaves QuickJS's frame chain pointing at C stack that is gone: the
+// next Error the guest builds walks it and takes the process with it (#134).
+// The draw is a Ruby dispatch this branch introduced, so it is this branch's
+// job not to open that door: a strict test double raises on an unexpected
+// invocation as readily as a loose one returns a constant, and rb_hash_aset can
+// raise NoMemoryError on the same path. A raise is treated as an unusable draw,
+// which is what it is.
+static inline VALUE alive_objects_register(VMData *data, VALUE r_object, bool *created)
+{
+  struct alive_register_work work = {data, r_object, false};
+  int state = 0;
+  VALUE r_handle = rb_protect(alive_objects_register_body, (VALUE)&work, &state);
+  if (state)
+  {
+    // Kept, not discarded. rb_protect catches everything, and most of what it
+    // can catch here is not a broken handle source: an Interrupt from Ctrl-C, a
+    // Timeout::Error from the host's own Timeout.timeout, anything a
+    // Thread#raise lands in this window. Swallowing one of those loses it with
+    // no trace and then blames a test double that does not exist. It is
+    // re-raised from the next entry point instead, with its own class and
+    // message, because here there is a QuickJS frame to unwind through and
+    // that is #134.
+    //
+    // Not latched, either: a Timeout::Error that arrived once says nothing
+    // about the handle source, and condemning the VM for it would be the wrong
+    // diagnosis twice over. The latch is for a source that answers badly, which
+    // is decided inside the body and does not come through here.
+    data->r_registrar_error = rb_errinfo();
+    rb_set_errinfo(Qnil);
+    if (created != NULL)
+      *created = false;
+    return Qnil;
+  }
+  if (created != NULL)
+    *created = work.created;
+  return r_handle;
+}
 
 static void random_filename(char buf[QUICKJSRB_GENERATED_NAME_SIZE])
 {

--- a/ext/quickjsrb/quickjsrb.h
+++ b/ext/quickjsrb/quickjsrb.h
@@ -338,6 +338,39 @@ static VALUE vm_alloc(VALUE r_self)
 #define QUICKJSRB_HANDLE_BITS 48
 #define QUICKJSRB_HANDLE_DRAW_LIMIT 16
 
+// Reads rb_object_id as an own data property, never through the prototype
+// chain and never through a getter, and answers whether there was one. All
+// three writers define it that way, so nothing legitimate is missed, and an
+// accessor a guest puts on Object.prototype otherwise answers for every object
+// that crosses back: one line of setup and a returned Hash becomes whichever
+// host File or CryptoKey the guest already holds a handle for.
+static inline bool j_read_own_handle(JSContext *ctx, JSValueConst j_val, JSValue *j_handle_out)
+{
+  JSAtom atom = JS_NewAtom(ctx, "rb_object_id");
+  JSPropertyDescriptor desc;
+  int found = JS_GetOwnProperty(ctx, &desc, j_val, atom);
+  JS_FreeAtom(ctx, atom);
+  if (found < 0)
+  {
+    // A Proxy trap answered and threw. The callers drain it.
+    *j_handle_out = JS_EXCEPTION;
+    return false;
+  }
+  if (found == 0)
+    return false;
+  if ((desc.flags & JS_PROP_TMASK) != JS_PROP_NORMAL)
+  {
+    JS_FreeValue(ctx, desc.value);
+    JS_FreeValue(ctx, desc.getter);
+    JS_FreeValue(ctx, desc.setter);
+    return false;
+  }
+  JS_FreeValue(ctx, desc.getter);
+  JS_FreeValue(ctx, desc.setter);
+  *j_handle_out = desc.value;
+  return true;
+}
+
 // Defined in quickjsrb.c. Declared here because the crypto reader needs it to
 // give back an exception a guest's getter parked on its way through.
 VALUE find_ruby_error(JSContext *ctx, JSValue j_error);

--- a/ext/quickjsrb/quickjsrb_crypto_subtle.c
+++ b/ext/quickjsrb/quickjsrb_crypto_subtle.c
@@ -61,6 +61,10 @@ static VALUE js_buffer_to_ruby_str(JSContext *ctx, JSValueConst j_val)
 }
 
 // Build a Ruby Array of strings from a JS array value.
+#define QUICKJSRB_MAX_KEY_USAGES 1024
+
+// Qnil when the list is longer than any usages list can be, which the
+// callers turn into a TypeError before they create a promise to reject.
 static VALUE js_usages_to_ruby_array(JSContext *ctx, JSValueConst j_usages)
 {
   // Every read here is a property of an object the guest handed in, answerable
@@ -83,6 +87,21 @@ static VALUE js_usages_to_ruby_array(JSContext *ctx, JSValueConst j_usages)
   }
   JS_FreeValue(ctx, j_len);
 
+  // The guest writes this length, and the loop below does a property read and
+  // a Ruby allocation per step without polling a QuickJS interrupt, so
+  // timeout_msec cannot end it: measured, a length of 10,000,000 runs 1.9s
+  // past a 100ms budget and leaves the VM out of memory, which a guest gets to
+  // choose by passing a number. There are eight key usages in the spec, so
+  // anything near this bound is not a usages list; refused rather than
+  // truncated, because a truncated one would be accepted as if the guest had
+  // asked for what is left.
+  // A negative length is an empty sequence, not too many entries: WebIDL's
+  // ToLength clamps it to 0, and main answered [] for it. JS_ToInt32 wraps, so
+  // 2**31 arrives here negative and means the same thing.
+  if (count < 0)
+    count = 0;
+  if (count > QUICKJSRB_MAX_KEY_USAGES)
+    return Qnil;
   for (int32_t i = 0; i < count; i++)
   {
     JSValue j_u = JS_GetPropertyUint32(ctx, j_usages, (uint32_t)i);
@@ -822,6 +841,8 @@ static JSValue js_subtle_generate_key(JSContext *ctx, JSValueConst this_val, int
   VALUE r_algo_hash = js_algo_to_ruby_hash(ctx, argv[0]);
   VALUE r_extractable = JS_ToBool(ctx, argv[1]) ? Qtrue : Qfalse;
   VALUE r_usages = js_usages_to_ruby_array(ctx, argv[2]);
+  if (NIL_P(r_usages))
+    return JS_ThrowTypeError(ctx, "SubtleCrypto: keyUsages has more entries than a key can have");
 
   JSValue promise, resolving_funcs[2];
   promise = JS_NewPromiseCapability(ctx, resolving_funcs);
@@ -914,6 +935,8 @@ static JSValue js_subtle_import_key(JSContext *ctx, JSValueConst this_val, int a
   VALUE r_algo_hash = js_algo_to_ruby_hash(ctx, argv[2]);
   VALUE r_extractable = JS_ToBool(ctx, argv[3]) ? Qtrue : Qfalse;
   VALUE r_usages = js_usages_to_ruby_array(ctx, argv[4]);
+  if (NIL_P(r_usages))
+    return JS_ThrowTypeError(ctx, "SubtleCrypto: keyUsages has more entries than a key can have");
 
   JSValue promise, resolving_funcs[2];
   promise = JS_NewPromiseCapability(ctx, resolving_funcs);
@@ -1263,6 +1286,8 @@ static JSValue js_subtle_derive_key(JSContext *ctx, JSValueConst this_val, int a
   VALUE r_derived_algo_hash = js_algo_to_ruby_hash(ctx, argv[2]);
   VALUE r_extractable = JS_ToBool(ctx, argv[3]) ? Qtrue : Qfalse;
   VALUE r_usages = js_usages_to_ruby_array(ctx, argv[4]);
+  if (NIL_P(r_usages))
+    return JS_ThrowTypeError(ctx, "SubtleCrypto: keyUsages has more entries than a key can have");
 
   JSValue promise, resolving_funcs[2];
   promise = JS_NewPromiseCapability(ctx, resolving_funcs);
@@ -1385,6 +1410,8 @@ static JSValue js_subtle_unwrap_key(JSContext *ctx, JSValueConst this_val, int a
   VALUE r_unwrapped_algo_hash = js_algo_to_ruby_hash(ctx, argv[4]);
   VALUE r_extractable = JS_ToBool(ctx, argv[5]) ? Qtrue : Qfalse;
   VALUE r_usages = js_usages_to_ruby_array(ctx, argv[6]);
+  if (NIL_P(r_usages))
+    return JS_ThrowTypeError(ctx, "SubtleCrypto: keyUsages has more entries than a key can have");
 
   JSValue promise, resolving_funcs[2];
   promise = JS_NewPromiseCapability(ctx, resolving_funcs);

--- a/ext/quickjsrb/quickjsrb_crypto_subtle.c
+++ b/ext/quickjsrb/quickjsrb_crypto_subtle.c
@@ -236,10 +236,16 @@ static VALUE r_find_alive_crypto_key(JSContext *ctx, JSValueConst j_key)
   // parked in alive_objects has to come back out: find_ruby_error is the only
   // thing that takes one out, so leaving it would pin one per call, at a rate
   // the guest picks.
-  JSValue j_handle = JS_GetPropertyStr(ctx, j_key, "rb_object_id");
-  if (JS_IsException(j_handle))
+  // Own data only, like the other two readers. Through the prototype chain an
+  // accessor on Object.prototype answers this, and then `{}` signs with a key
+  // it never carried a handle for, including one generated extractable: false.
+  JSValue j_handle = JS_UNDEFINED;
+  if (!j_read_own_handle(ctx, j_key, &j_handle))
   {
-    quickjsrb_drain_pending(ctx);
+    // A Proxy trap can answer the descriptor read and throw, and what it throws
+    // can be a bridge that parked a host exception on its way out.
+    if (JS_IsException(j_handle))
+      quickjsrb_drain_pending(ctx);
     return Qnil;
   }
 

--- a/ext/quickjsrb/quickjsrb_crypto_subtle.c
+++ b/ext/quickjsrb/quickjsrb_crypto_subtle.c
@@ -6,10 +6,29 @@
 static const char *js_get_algorithm_name(JSContext *ctx, JSValueConst j_algo)
 {
   if (JS_IsString(j_algo))
-    return JS_ToCString(ctx, j_algo);
+  {
+    // Drained like the reads below: a conversion that cannot allocate answers
+    // NULL with its throw still set, and the caller reports a missing
+    // algorithm name over the top of it.
+    const char *name = JS_ToCString(ctx, j_algo);
+    if (name == NULL)
+      quickjsrb_drain_pending(ctx);
+    return name;
+  }
+  // A getter answers this read, so it can throw, and a throw from a bridge
+  // carries a host exception that only find_ruby_error takes back out of
+  // alive_objects. Same for the conversion below, which runs toString.
   JSValue j_name = JS_GetPropertyStr(ctx, j_algo, "name");
+  if (JS_IsException(j_name))
+  {
+    quickjsrb_drain_pending(ctx);
+    return NULL;
+  }
+
   const char *name = JS_ToCString(ctx, j_name);
   JS_FreeValue(ctx, j_name);
+  if (name == NULL)
+    quickjsrb_drain_pending(ctx);
   return name;
 }
 
@@ -44,21 +63,71 @@ static VALUE js_buffer_to_ruby_str(JSContext *ctx, JSValueConst j_val)
 // Build a Ruby Array of strings from a JS array value.
 static VALUE js_usages_to_ruby_array(JSContext *ctx, JSValueConst j_usages)
 {
+  // Every read here is a property of an object the guest handed in, answerable
+  // by a getter that can reach a bridge, so each drains what it throws for the
+  // reason js_algo_read gives. What the operation then does with a usages list
+  // that could not be read is the refusal path nothing has yet: #130.
   VALUE r_usages = rb_ary_new();
   JSValue j_len = JS_GetPropertyStr(ctx, j_usages, "length");
+  if (JS_IsException(j_len))
+  {
+    quickjsrb_drain_pending(ctx);
+    return r_usages;
+  }
+
   int32_t count = 0;
-  JS_ToInt32(ctx, &count, j_len);
+  if (JS_ToInt32(ctx, &count, j_len) < 0)
+  {
+    quickjsrb_drain_pending(ctx);
+    count = 0;
+  }
   JS_FreeValue(ctx, j_len);
+
   for (int32_t i = 0; i < count; i++)
   {
     JSValue j_u = JS_GetPropertyUint32(ctx, j_usages, (uint32_t)i);
+    if (JS_IsException(j_u))
+    {
+      quickjsrb_drain_pending(ctx);
+      continue;
+    }
+
     const char *u_str = JS_ToCString(ctx, j_u);
     if (u_str)
       rb_ary_push(r_usages, rb_str_new_cstr(u_str));
+    else
+      quickjsrb_drain_pending(ctx);
     JS_FreeCString(ctx, u_str);
     JS_FreeValue(ctx, j_u);
   }
   return r_usages;
+}
+
+// Settles with the value, or rejects with whatever stopped it being built.
+// Never resolves with the sentinel: typeof reads "unknown" for it and the guest
+// has no way to name, catch or discard what it was handed. Always settles, so
+// no caller is left returning a promise nothing will ever resolve.
+static void js_settle_or_reject(JSContext *ctx, JSValueConst *resolving_funcs, JSValue j_key)
+{
+  JSValue j_settled;
+  if (JS_IsException(j_key))
+  {
+    // JS_GetException answers JS_UNINITIALIZED when nothing is set, and that
+    // is an internal sentinel, not a value to hand a guest. The slot can be
+    // empty here: a describe failure sets its throw, and a later step that
+    // takes a throw of its own unconditionally clears it on the way past.
+    if (!JS_HasException(ctx))
+      JS_ThrowInternalError(ctx, "quickjs: the operation failed without saying why");
+    JSValue j_thrown = JS_GetException(ctx);
+    j_settled = JS_Call(ctx, resolving_funcs[1], JS_UNDEFINED, 1, (JSValueConst *)&j_thrown);
+    JS_FreeValue(ctx, j_thrown);
+  }
+  else
+  {
+    j_settled = JS_Call(ctx, resolving_funcs[0], JS_UNDEFINED, 1, (JSValueConst *)&j_key);
+    JS_FreeValue(ctx, j_key);
+  }
+  JS_FreeValue(ctx, j_settled);
 }
 
 // Reject a promise with a plain JS Error built from Ruby exception info.
@@ -68,23 +137,166 @@ static void js_reject_with_ruby_error(JSContext *ctx, JSValueConst *resolving_fu
   rb_set_errinfo(Qnil);
   VALUE r_message = rb_funcall(r_error, rb_intern("message"), 0);
   JSValue j_err = JS_NewError(ctx);
-  JS_SetPropertyStr(ctx, j_err, "message", JS_NewString(ctx, StringValueCStr(r_message)));
+  if (JS_IsException(j_err))
+  {
+    // Settling with the sentinel would hand the guest a value it cannot name,
+    // which is what js_quickjsrb_call_global refuses to do for the same reason.
+    // The runtime's own throw is the honest answer, and it is already pending.
+    // Nothing left to describe the failure with, so the promise is rejected
+    // with the runtime's own throw rather than left for a guest that is still
+    // awaiting it, and rather than carried out of here to be attributed to
+    // whatever asks for an exception next.
+    JS_FreeValue(ctx, j_err);
+    js_settle_or_reject(ctx, resolving_funcs, JS_EXCEPTION);
+    return;
+  }
+  // Defined, not assigned, for the reason j_error_from_ruby_error gives: an
+  // accessor on Error.prototype absorbs the write, and the guest reads whatever
+  // that getter says instead of why its call was rejected. Built first and
+  // checked, so the sentinel is never what the error says its message is.
+  JSValue j_message = JS_NewString(ctx, StringValueCStr(r_message));
+  if (JS_IsException(j_message))
+  {
+    JS_FreeValue(ctx, j_message);
+    JS_FreeValue(ctx, j_err);
+    js_settle_or_reject(ctx, resolving_funcs, JS_EXCEPTION);
+    return;
+  }
+  if (JS_DefinePropertyValueStr(ctx, j_err, "message", j_message,
+                                JS_PROP_WRITABLE | JS_PROP_CONFIGURABLE) < 0)
+  {
+    // An Error with no own message is one Error.prototype answers for, which
+    // is what defining it was for, and the define's throw would be left to
+    // land on an unrelated evaluation.
+    JS_FreeValue(ctx, j_err);
+    js_settle_or_reject(ctx, resolving_funcs, JS_EXCEPTION);
+    return;
+  }
   JSValue ret = JS_Call(ctx, resolving_funcs[1], JS_UNDEFINED, 1, (JSValueConst *)&j_err);
   JS_FreeValue(ctx, j_err);
   JS_FreeValue(ctx, ret);
 }
 
+// Quickjs::CryptoKey, or Qnil while the Ruby layer that defines it has not been
+// loaded — requiring the extension alone is enough to reach the callers below.
+// Resolved without rb_const_get's raise, because these run inside QuickJS
+// native callbacks with no rb_protect between them and the interpreter: a
+// NameError there longjmps through QuickJS's own frames, past the JS values
+// they still hold.
+//
+// Looked up per call rather than cached in a static. A class held only by a
+// constant table is movable, so a cached VALUE survives GC.compact as an
+// address the collector has since handed to something else — which would name
+// the wrong class, or a non-class that makes rb_obj_is_kind_of raise the very
+// unprotected raise this function exists to avoid. Two constant lookups are
+// nothing beside the OpenSSL work every caller goes on to do.
+static VALUE r_crypto_key_class(void)
+{
+  // Gated too, though Init_quickjsrb defines it before any of this can run.
+  // Not for the promise, which every caller creates after resolving the key,
+  // but because a raise out of a JSCFunction unwinds past QuickJS's own call
+  // frame, which is what this function exists to answer instead of.
+  if (!rb_const_defined_at(rb_cObject, rb_intern("Quickjs")))
+    return Qnil;
+  // Defined answers true for an autoload here too, and rb_const_get would run
+  // its body from this callback, which is the raise being avoided.
+  if (!NIL_P(rb_autoload_p(rb_cObject, rb_intern("Quickjs"))))
+    return Qnil;
+
+  VALUE r_quickjs = rb_const_get(rb_cObject, rb_intern("Quickjs"));
+  // Same reason the inner one is type-checked: rb_const_defined_at reads a
+  // constant table off its receiver, so a non-module bound to the name is
+  // worse than the NameError being avoided.
+  if (!RB_TYPE_P(r_quickjs, T_MODULE))
+    return Qnil;
+  if (!rb_const_defined_at(r_quickjs, rb_intern("CryptoKey")))
+    return Qnil;
+  // Defined answers true for a registered autoload too, and rb_const_get would
+  // then run the autoload body here, which is a raise this function cannot
+  // afford for the reason above. Nobody autoloads this constant, but the claim
+  // has to hold rather than happen to.
+  if (!NIL_P(rb_autoload_p(r_quickjs, rb_intern("CryptoKey"))))
+    return Qnil;
+
+  VALUE r_class = rb_const_get(r_quickjs, rb_intern("CryptoKey"));
+  // Defined is not the same as a class. rb_obj_is_kind_of takes a class or a
+  // module and raises TypeError on anything else, so a String bound to the
+  // name would make the unprotected raise above; a Module would not raise but
+  // is not what a key is an instance of either. One predicate covers both.
+  return RB_TYPE_P(r_class, T_CLASS) ? r_class : Qnil;
+}
+
 // Find Ruby CryptoKey from a JS CryptoKey object via rb_object_id handle.
 static VALUE r_find_alive_crypto_key(JSContext *ctx, JSValueConst j_key)
 {
+  // Both of the reads below can run the guest's own code on a value it chose:
+  // a getter for the property, a valueOf for the conversion, either of which
+  // can reach a Ruby bridge. Nothing here can report what that raises, since
+  // this runs after its caller's rb_protect has returned, but the exception it
+  // parked in alive_objects has to come back out: find_ruby_error is the only
+  // thing that takes one out, so leaving it would pin one per call, at a rate
+  // the guest picks.
   JSValue j_handle = JS_GetPropertyStr(ctx, j_key, "rb_object_id");
+  if (JS_IsException(j_handle))
+  {
+    quickjsrb_drain_pending(ctx);
+    return Qnil;
+  }
+
+  // Only a number is a handle. Asking JS_ToInt64 for one is what runs valueOf,
+  // and the answer for anything else was never going to be a handle anyway.
+  int32_t tag = JS_VALUE_GET_NORM_TAG(j_handle);
+  if (tag != JS_TAG_INT && tag != JS_TAG_FLOAT64)
+  {
+    JS_FreeValue(ctx, j_handle);
+    return Qnil;
+  }
+
   int64_t handle = 0;
   JS_ToInt64(ctx, &handle, j_handle);
   JS_FreeValue(ctx, j_handle);
   if (handle <= 0)
     return Qnil;
   VMData *data = JS_GetContextOpaque(ctx);
-  return rb_hash_aref(data->alive_objects, LONG2NUM(handle));
+  VALUE r_key = rb_hash_aref(data->alive_objects, LL2NUM(handle));
+  // Before the class lookup, which is otherwise paid on the path a guest can
+  // repeat for free: sign('HMAC', {}, buf) reaches no OpenSSL work to dwarf it.
+  if (NIL_P(r_key))
+    return Qnil;
+  // The handle is read off whatever the guest passed as the key, and
+  // alive_objects also holds bridged exceptions and the Ruby object behind a
+  // File proxy. Without this an object carrying another entry's id reaches the
+  // operations below as if it were a key, and the caller is told about a
+  // method missing on a File rather than about an invalid CryptoKey.
+  VALUE r_key_class = r_crypto_key_class();
+  if (NIL_P(r_key_class) || !rb_obj_is_kind_of(r_key, r_key_class))
+    return Qnil;
+  return r_key;
+}
+
+// Every read below is a property of an object the guest handed in, so a getter
+// answers it and may throw. The block that follows each read already skips an
+// exception, but skipping is not enough: a throw from a bridge carries a host
+// exception that find_ruby_error is the only thing to take back out of
+// alive_objects, so a skipped one pins it for the life of the VM, once per
+// read, at a rate the guest picks.
+//
+// The read only. What each block then does with the value, JS_ToInt32 on a
+// length, JS_ToCString on a curve name, a buffer conversion on an iv, runs the
+// guest's valueOf or toString and can throw for the same reason, and those
+// returns are unchecked here as they were before. #130.
+static JSValue js_algo_read(JSContext *ctx, JSValueConst j_algo, const char *name)
+{
+  JSValue j_value = JS_GetPropertyStr(ctx, j_algo, name);
+  if (JS_IsException(j_value))
+    // Taken, not put back. Putting it back and carrying on would leave it
+    // pending for the next thing that asks, and carrying on is what this does:
+    // the block below skips the property and the operation runs without it. So
+    // the guest's own error is lost here, replaced by whatever the call fails
+    // with next. Both halves want the same fix, a way for this function to
+    // refuse, which its ten callers do not have yet. #130.
+    quickjsrb_drain_pending(ctx);
+  return j_value;
 }
 
 // Build a comprehensive Ruby Hash (symbol keys) from a JS algorithm object.
@@ -103,7 +315,7 @@ static VALUE js_algo_to_ruby_hash(JSContext *ctx, JSValueConst j_algo)
   if (JS_IsString(j_algo))
     return r_hash;
 
-  JSValue j_length = JS_GetPropertyStr(ctx, j_algo, "length");
+  JSValue j_length = js_algo_read(ctx, j_algo, "length");
   if (!JS_IsUndefined(j_length) && !JS_IsException(j_length))
   {
     int32_t length = 0;
@@ -112,7 +324,7 @@ static VALUE js_algo_to_ruby_hash(JSContext *ctx, JSValueConst j_algo)
   }
   JS_FreeValue(ctx, j_length);
 
-  JSValue j_named_curve = JS_GetPropertyStr(ctx, j_algo, "namedCurve");
+  JSValue j_named_curve = js_algo_read(ctx, j_algo, "namedCurve");
   if (!JS_IsUndefined(j_named_curve) && !JS_IsException(j_named_curve))
   {
     const char *nc = JS_ToCString(ctx, j_named_curve);
@@ -124,7 +336,7 @@ static VALUE js_algo_to_ruby_hash(JSContext *ctx, JSValueConst j_algo)
   }
   JS_FreeValue(ctx, j_named_curve);
 
-  JSValue j_hash = JS_GetPropertyStr(ctx, j_algo, "hash");
+  JSValue j_hash = js_algo_read(ctx, j_algo, "hash");
   if (!JS_IsUndefined(j_hash) && !JS_IsException(j_hash))
   {
     const char *hash_name = js_get_algorithm_name(ctx, j_hash);
@@ -136,7 +348,7 @@ static VALUE js_algo_to_ruby_hash(JSContext *ctx, JSValueConst j_algo)
   }
   JS_FreeValue(ctx, j_hash);
 
-  JSValue j_modulus_length = JS_GetPropertyStr(ctx, j_algo, "modulusLength");
+  JSValue j_modulus_length = js_algo_read(ctx, j_algo, "modulusLength");
   if (!JS_IsUndefined(j_modulus_length) && !JS_IsException(j_modulus_length))
   {
     int32_t mod_len = 0;
@@ -145,7 +357,7 @@ static VALUE js_algo_to_ruby_hash(JSContext *ctx, JSValueConst j_algo)
   }
   JS_FreeValue(ctx, j_modulus_length);
 
-  JSValue j_pub_exp = JS_GetPropertyStr(ctx, j_algo, "publicExponent");
+  JSValue j_pub_exp = js_algo_read(ctx, j_algo, "publicExponent");
   if (!JS_IsUndefined(j_pub_exp) && !JS_IsException(j_pub_exp))
   {
     VALUE r_pe = js_buffer_to_ruby_str(ctx, j_pub_exp);
@@ -154,7 +366,7 @@ static VALUE js_algo_to_ruby_hash(JSContext *ctx, JSValueConst j_algo)
   }
   JS_FreeValue(ctx, j_pub_exp);
 
-  JSValue j_iv = JS_GetPropertyStr(ctx, j_algo, "iv");
+  JSValue j_iv = js_algo_read(ctx, j_algo, "iv");
   if (!JS_IsUndefined(j_iv) && !JS_IsException(j_iv))
   {
     VALUE r_iv = js_buffer_to_ruby_str(ctx, j_iv);
@@ -163,7 +375,7 @@ static VALUE js_algo_to_ruby_hash(JSContext *ctx, JSValueConst j_algo)
   }
   JS_FreeValue(ctx, j_iv);
 
-  JSValue j_tag_length = JS_GetPropertyStr(ctx, j_algo, "tagLength");
+  JSValue j_tag_length = js_algo_read(ctx, j_algo, "tagLength");
   if (!JS_IsUndefined(j_tag_length) && !JS_IsException(j_tag_length))
   {
     int32_t tag_length = 0;
@@ -172,7 +384,7 @@ static VALUE js_algo_to_ruby_hash(JSContext *ctx, JSValueConst j_algo)
   }
   JS_FreeValue(ctx, j_tag_length);
 
-  JSValue j_additional_data = JS_GetPropertyStr(ctx, j_algo, "additionalData");
+  JSValue j_additional_data = js_algo_read(ctx, j_algo, "additionalData");
   if (!JS_IsUndefined(j_additional_data) && !JS_IsException(j_additional_data))
   {
     VALUE r_ad = js_buffer_to_ruby_str(ctx, j_additional_data);
@@ -181,7 +393,7 @@ static VALUE js_algo_to_ruby_hash(JSContext *ctx, JSValueConst j_algo)
   }
   JS_FreeValue(ctx, j_additional_data);
 
-  JSValue j_counter = JS_GetPropertyStr(ctx, j_algo, "counter");
+  JSValue j_counter = js_algo_read(ctx, j_algo, "counter");
   if (!JS_IsUndefined(j_counter) && !JS_IsException(j_counter))
   {
     VALUE r_counter = js_buffer_to_ruby_str(ctx, j_counter);
@@ -190,7 +402,7 @@ static VALUE js_algo_to_ruby_hash(JSContext *ctx, JSValueConst j_algo)
   }
   JS_FreeValue(ctx, j_counter);
 
-  JSValue j_salt = JS_GetPropertyStr(ctx, j_algo, "salt");
+  JSValue j_salt = js_algo_read(ctx, j_algo, "salt");
   if (!JS_IsUndefined(j_salt) && !JS_IsException(j_salt))
   {
     VALUE r_salt = js_buffer_to_ruby_str(ctx, j_salt);
@@ -199,7 +411,7 @@ static VALUE js_algo_to_ruby_hash(JSContext *ctx, JSValueConst j_algo)
   }
   JS_FreeValue(ctx, j_salt);
 
-  JSValue j_iterations = JS_GetPropertyStr(ctx, j_algo, "iterations");
+  JSValue j_iterations = js_algo_read(ctx, j_algo, "iterations");
   if (!JS_IsUndefined(j_iterations) && !JS_IsException(j_iterations))
   {
     int32_t iterations = 0;
@@ -208,7 +420,7 @@ static VALUE js_algo_to_ruby_hash(JSContext *ctx, JSValueConst j_algo)
   }
   JS_FreeValue(ctx, j_iterations);
 
-  JSValue j_info = JS_GetPropertyStr(ctx, j_algo, "info");
+  JSValue j_info = js_algo_read(ctx, j_algo, "info");
   if (!JS_IsUndefined(j_info) && !JS_IsException(j_info))
   {
     VALUE r_info = js_buffer_to_ruby_str(ctx, j_info);
@@ -217,7 +429,7 @@ static VALUE js_algo_to_ruby_hash(JSContext *ctx, JSValueConst j_algo)
   }
   JS_FreeValue(ctx, j_info);
 
-  JSValue j_salt_length = JS_GetPropertyStr(ctx, j_algo, "saltLength");
+  JSValue j_salt_length = js_algo_read(ctx, j_algo, "saltLength");
   if (!JS_IsUndefined(j_salt_length) && !JS_IsException(j_salt_length))
   {
     int32_t salt_length = 0;
@@ -226,7 +438,7 @@ static VALUE js_algo_to_ruby_hash(JSContext *ctx, JSValueConst j_algo)
   }
   JS_FreeValue(ctx, j_salt_length);
 
-  JSValue j_label = JS_GetPropertyStr(ctx, j_algo, "label");
+  JSValue j_label = js_algo_read(ctx, j_algo, "label");
   if (!JS_IsUndefined(j_label) && !JS_IsException(j_label))
   {
     VALUE r_label = js_buffer_to_ruby_str(ctx, j_label);
@@ -235,7 +447,7 @@ static VALUE js_algo_to_ruby_hash(JSContext *ctx, JSValueConst j_algo)
   }
   JS_FreeValue(ctx, j_label);
 
-  JSValue j_public = JS_GetPropertyStr(ctx, j_algo, "public");
+  JSValue j_public = js_algo_read(ctx, j_algo, "public");
   if (!JS_IsUndefined(j_public) && !JS_IsException(j_public) && JS_IsObject(j_public))
   {
     VALUE r_public = r_find_alive_crypto_key(ctx, j_public);
@@ -247,77 +459,292 @@ static VALUE js_algo_to_ruby_hash(JSContext *ctx, JSValueConst j_algo)
   return r_hash;
 }
 
-// Build a JS CryptoKey plain object from a Ruby Quickjs::CryptoKey.
-// Stores the Ruby object in alive_objects; sets rb_object_id as non-enumerable.
-static JSValue js_crypto_key_to_js(JSContext *ctx, VALUE r_key)
+
+// Builds the string and defines it, reporting whether it got that far, so a
+// caller can throw away a half-described object rather than define the
+// allocation-failure sentinel as an ordinary property value. Defined, not
+// assigned, for the reason js_crypto_key_to_js gives.
+static bool j_define_str(JSContext *ctx, JSValue j_obj, const char *prop, VALUE r_str)
+{
+  JSValue j_val = JS_NewString(ctx, StringValueCStr(r_str));
+  if (JS_IsException(j_val))
+  {
+    JS_FreeValue(ctx, j_val);
+    return false;
+  }
+  return JS_DefinePropertyValueStr(ctx, j_obj, prop, j_val, JS_PROP_C_W_E) >= 0;
+}
+
+// Build a JS CryptoKey plain object from a Ruby Quickjs::CryptoKey. Stores the
+// Ruby object in alive_objects; sets rb_object_id as non-enumerable.
+//
+// registered_here, when given, says whether this call is the one that put the
+// key in alive_objects, so a caller that has to throw the key away can take
+// exactly the row it caused and not one an earlier crossing still relies on.
+static JSValue js_crypto_key_to_js(JSContext *ctx, VALUE r_key, bool *registered_here_out)
 {
   VMData *data = JS_GetContextOpaque(ctx);
-  VALUE r_object_id = rb_funcall(r_key, rb_intern("object_id"), 0);
-  rb_hash_aset(data->alive_objects, r_object_id, r_key);
-  int64_t handle = NUM2LONG(r_object_id);
 
+  // Nothing is registered until the key is fully described, which is the
+  // ordering j_error_from_ruby_error follows and the only version of it that
+  // holds: the reads below raise, and so does describing them, since
+  // StringValueCStr rejects a non-String and a NUL, and NUM2INT rejects a
+  // non-Integer. A raise out of a JSCFunction after registering would leave a
+  // row anchoring this key for the life of the VM with nothing able to reach
+  // it. With the draw last, there is nothing to leave.
   VALUE r_type = rb_funcall(r_key, rb_intern("type"), 0);
   VALUE r_extractable = rb_funcall(r_key, rb_intern("extractable"), 0);
   VALUE r_algorithm = rb_funcall(r_key, rb_intern("algorithm"), 0);
   VALUE r_usages = rb_funcall(r_key, rb_intern("usages"), 0);
 
-  JSValue j_key = JS_NewObject(ctx);
-
-  JS_SetPropertyStr(ctx, j_key, "type", JS_NewString(ctx, StringValueCStr(r_type)));
-  JS_SetPropertyStr(ctx, j_key, "extractable", JS_NewBool(ctx, RTEST(r_extractable)));
-
-  JSValue j_algo = JS_NewObject(ctx);
-
   VALUE r_algo_name = rb_hash_aref(r_algorithm, rb_str_new_cstr("name"));
-  JS_SetPropertyStr(ctx, j_algo, "name", JS_NewString(ctx, StringValueCStr(r_algo_name)));
-
   VALUE r_algo_length = rb_hash_aref(r_algorithm, rb_str_new_cstr("length"));
-  if (!NIL_P(r_algo_length))
-    JS_SetPropertyStr(ctx, j_algo, "length", JS_NewInt32(ctx, NUM2INT(r_algo_length)));
-
   VALUE r_algo_named_curve = rb_hash_aref(r_algorithm, rb_str_new_cstr("namedCurve"));
-  if (!NIL_P(r_algo_named_curve))
-    JS_SetPropertyStr(ctx, j_algo, "namedCurve", JS_NewString(ctx, StringValueCStr(r_algo_named_curve)));
-
   VALUE r_algo_hash = rb_hash_aref(r_algorithm, rb_str_new_cstr("hash"));
-  if (!NIL_P(r_algo_hash))
-  {
-    JSValue j_hash_obj = JS_NewObject(ctx);
-    JS_SetPropertyStr(ctx, j_hash_obj, "name", JS_NewString(ctx, StringValueCStr(r_algo_hash)));
-    JS_SetPropertyStr(ctx, j_algo, "hash", j_hash_obj);
-  }
-
   VALUE r_algo_modulus_length = rb_hash_aref(r_algorithm, rb_str_new_cstr("modulusLength"));
-  if (!NIL_P(r_algo_modulus_length))
-    JS_SetPropertyStr(ctx, j_algo, "modulusLength", JS_NewInt32(ctx, NUM2INT(r_algo_modulus_length)));
-
   VALUE r_algo_pub_exp = rb_hash_aref(r_algorithm, rb_str_new_cstr("publicExponent"));
-  if (!NIL_P(r_algo_pub_exp))
-  {
-    JSValue j_pe_buf = JS_NewArrayBufferCopy(ctx,
-                                             (const uint8_t *)RSTRING_PTR(r_algo_pub_exp),
-                                             RSTRING_LEN(r_algo_pub_exp));
-    JSValue j_uint8 = JS_GetPropertyStr(ctx, JS_GetGlobalObject(ctx), "Uint8Array");
-    JSValue j_pe = JS_CallConstructor(ctx, j_uint8, 1, (JSValueConst *)&j_pe_buf);
-    JS_FreeValue(ctx, j_uint8);
-    JS_FreeValue(ctx, j_pe_buf);
-    JS_SetPropertyStr(ctx, j_algo, "publicExponent", j_pe);
-  }
-
-  JS_SetPropertyStr(ctx, j_key, "algorithm", j_algo);
-
   long usages_len = RARRAY_LEN(r_usages);
-  JSValue j_usages = JS_NewArray(ctx);
+
+  // Touched for their conversions, not their values: StringValueCStr raises on
+  // a non-String and on an embedded NUL, NUM2INT on a non-Integer. Doing that
+  // here means the describing below cannot raise, which is what lets the draw
+  // sit between the two. Both orderings cost something otherwise: draw first
+  // and a raise from describing orphans a table row that anchors this key, with
+  // its private material, for the life of the VM; draw last and a raise from
+  // the draw leaves j_key, and the promise capability the caller is holding,
+  // unreleased. With nothing between them able to raise, neither is reachable.
+  StringValueCStr(r_type);
+  StringValueCStr(r_algo_name);
+  if (!NIL_P(r_algo_length))
+    NUM2INT(r_algo_length);
+  if (!NIL_P(r_algo_named_curve))
+    StringValueCStr(r_algo_named_curve);
+  if (!NIL_P(r_algo_hash))
+    StringValueCStr(r_algo_hash);
+  if (!NIL_P(r_algo_modulus_length))
+    NUM2INT(r_algo_modulus_length);
+  if (!NIL_P(r_algo_pub_exp))
+    StringValue(r_algo_pub_exp);
+  // Into a list of our own, because StringValueCStr converts the local it is
+  // given and rb_ary_entry hands back a temporary: touching that would leave
+  // the caller's array holding the unconverted member, and the describing loop
+  // would convert it a second time, after the draw and with j_key allocated,
+  // which is the raise the ordering above exists to rule out.
+  VALUE r_usage_strings = rb_ary_new_capa(usages_len);
   for (long i = 0; i < usages_len; i++)
   {
     VALUE r_usage = rb_ary_entry(r_usages, i);
-    JS_SetPropertyUint32(ctx, j_usages, (uint32_t)i, JS_NewString(ctx, StringValueCStr(r_usage)));
+    StringValueCStr(r_usage);
+    rb_ary_push(r_usage_strings, r_usage);
   }
-  JS_SetPropertyStr(ctx, j_key, "usages", j_usages);
 
-  JS_DefinePropertyValueStr(ctx, j_key, "rb_object_id",
-                            JS_NewInt64(ctx, handle),
-                            JS_PROP_CONFIGURABLE | JS_PROP_WRITABLE);
+  // Taken here, in the same raise-safe stretch, so the rollback paths below can
+  // undo a registration without dispatching from inside a JSCFunction.
+  VALUE r_key_object_id = rb_obj_id(r_key);
+
+  // Drawn here, with everything that can raise behind it and nothing allocated
+  // in front of it.
+  bool registered_here = false;
+  VALUE r_object_id = alive_objects_register(data, r_key, &registered_here);
+  if (registered_here_out != NULL)
+    *registered_here_out = registered_here;
+  if (NIL_P(r_object_id))
+    return JS_ThrowInternalError(ctx, "quickjs: could not publish a handle for a CryptoKey");
+
+  // Checked, like every value that becomes a property of the key: passing the
+  // sentinel to JS_DefinePropertyValue* stores it as an ordinary value, which
+  // is the shape the rest of this branch refuses.
+  JSValue j_key = JS_NewObject(ctx);
+  if (JS_IsException(j_key))
+  {
+    if (registered_here)
+    {
+      alive_objects_unregister(data, r_object_id, r_key_object_id);
+      // The claim goes with the row: a caller told the row is theirs would ask
+      // alive_objects_forget for one that is already gone.
+      registered_here = false;
+      if (registered_here_out != NULL)
+        *registered_here_out = false;
+    }
+    return j_key;
+  }
+
+  bool described = j_define_str(ctx, j_key, "type", r_type);
+  described = JS_DefinePropertyValueStr(ctx, j_key, "extractable", JS_NewBool(ctx, RTEST(r_extractable)),
+                                       JS_PROP_WRITABLE | JS_PROP_ENUMERABLE | JS_PROP_CONFIGURABLE) >= 0 && described;
+
+  // Every one of these is defined rather than assigned: an accessor a guest
+  // puts on Object.prototype otherwise absorbs the write, and the key ends up
+  // describing itself with whatever that getter says, including reporting
+  // extractable: true for a key generated without it.
+  JSValue j_algo = JS_NewObject(ctx);
+  if (JS_IsException(j_algo))
+  {
+    if (registered_here)
+    {
+      alive_objects_unregister(data, r_object_id, r_key_object_id);
+      // The claim goes with the row: a caller told the row is theirs would ask
+      // alive_objects_forget for one that is already gone.
+      registered_here = false;
+      if (registered_here_out != NULL)
+        *registered_here_out = false;
+    }
+    JS_FreeValue(ctx, j_key);
+    return j_algo;
+  }
+
+  described = j_define_str(ctx, j_algo, "name", r_algo_name) && described;
+
+  if (!NIL_P(r_algo_length))
+    described = JS_DefinePropertyValueStr(ctx, j_algo, "length", JS_NewInt32(ctx, NUM2INT(r_algo_length)),
+                                         JS_PROP_WRITABLE | JS_PROP_ENUMERABLE | JS_PROP_CONFIGURABLE) >= 0 && described;
+
+  if (!NIL_P(r_algo_named_curve))
+    described = j_define_str(ctx, j_algo, "namedCurve", r_algo_named_curve) && described;
+
+  if (!NIL_P(r_algo_hash))
+  {
+    JSValue j_hash_obj = JS_NewObject(ctx);
+    if (JS_IsException(j_hash_obj))
+    {
+      if (registered_here)
+        alive_objects_unregister(data, r_object_id, r_key_object_id);
+      JS_FreeValue(ctx, j_algo);
+      JS_FreeValue(ctx, j_key);
+      return j_hash_obj;
+    }
+    described = j_define_str(ctx, j_hash_obj, "name", r_algo_hash) && described;
+    described = JS_DefinePropertyValueStr(ctx, j_algo, "hash", j_hash_obj,
+                                         JS_PROP_WRITABLE | JS_PROP_ENUMERABLE | JS_PROP_CONFIGURABLE) >= 0 && described;
+  }
+
+  if (!NIL_P(r_algo_modulus_length))
+    described = JS_DefinePropertyValueStr(ctx, j_algo, "modulusLength", JS_NewInt32(ctx, NUM2INT(r_algo_modulus_length)),
+                                         JS_PROP_WRITABLE | JS_PROP_ENUMERABLE | JS_PROP_CONFIGURABLE) >= 0 && described;
+
+  if (!NIL_P(r_algo_pub_exp))
+  {
+    // Built through JS_NewTypedArray rather than by calling globalThis's
+    // Uint8Array. That constructor is the guest's to delete or replace, and a
+    // replacement can throw anything it likes, including a Ruby exception from
+    // a bridge: nothing here can report it, because this runs after its
+    // caller's rb_protect has returned and every caller stores the result
+    // unchecked. Not reading the global removes the question rather than
+    // answering it. What remains is the runtime's own allocation failing, and
+    // both branches below take that rather than leave it: no caller of this
+    // function returns JS_EXCEPTION, so a throw left set would be attributed to
+    // whatever evaluation next asked for one. The cost is that a key can come
+    // back describing itself without publicExponent, with the out-of-memory
+    // reported nowhere. #129.
+    JSValue j_pe_buf = JS_NewArrayBufferCopy(ctx,
+                                             (const uint8_t *)RSTRING_PTR(r_algo_pub_exp),
+                                             RSTRING_LEN(r_algo_pub_exp));
+    if (JS_IsException(j_pe_buf))
+    {
+      // Taken here for the reason the branch below gives: the key is still
+      // handed over without a publicExponent, so leaving this set would
+      // attribute the allocation failure to whatever asked next.
+      JS_FreeValue(ctx, JS_GetException(ctx));
+    }
+    else
+    {
+      JSValue j_args[3] = {j_pe_buf, JS_NewInt32(ctx, 0), JS_NewInt64(ctx, RSTRING_LEN(r_algo_pub_exp))};
+      JSValue j_pe = JS_NewTypedArray(ctx, 3, (JSValueConst *)j_args, JS_TYPED_ARRAY_UINT8);
+      JS_FreeValue(ctx, j_pe_buf);
+      if (JS_IsException(j_pe))
+        // Taken and lost, because the key is still described well enough to
+        // hand over and a throw left here would surface at whatever calls
+        // JS_GetException next. It can be a throw an earlier describe set, so
+        // js_settle_or_reject no longer assumes the slot is full. The only way
+        // to get here is the runtime's own allocation failing, which the next
+        // one will fail at too.
+        JS_FreeValue(ctx, JS_GetException(ctx));
+      else
+        described = JS_DefinePropertyValueStr(ctx, j_algo, "publicExponent", j_pe,
+                                             JS_PROP_WRITABLE | JS_PROP_ENUMERABLE | JS_PROP_CONFIGURABLE) >= 0 && described;
+    }
+  }
+
+  described = JS_DefinePropertyValueStr(ctx, j_key, "algorithm", j_algo,
+                                       JS_PROP_WRITABLE | JS_PROP_ENUMERABLE | JS_PROP_CONFIGURABLE) >= 0 && described;
+
+  JSValue j_usages = JS_NewArray(ctx);
+  if (JS_IsException(j_usages))
+  {
+    if (registered_here)
+    {
+      alive_objects_unregister(data, r_object_id, r_key_object_id);
+      // The claim goes with the row: a caller told the row is theirs would ask
+      // alive_objects_forget for one that is already gone.
+      registered_here = false;
+      if (registered_here_out != NULL)
+        *registered_here_out = false;
+    }
+    JS_FreeValue(ctx, j_key);
+    return j_usages;
+  }
+  for (long i = 0; i < usages_len; i++)
+  {
+    VALUE r_usage = rb_ary_entry(r_usage_strings, i);
+    // Defined, like every other property of the key: an index property on
+    // Array.prototype takes the fast array path away, and the element write
+    // then walks the chain into the guest's setter like any named one would.
+    // StringValueCStr cannot raise here: it is a String already, converted
+    // above, before anything was drawn or allocated.
+    JSValue j_usage = JS_NewString(ctx, StringValueCStr(r_usage));
+    if (JS_IsException(j_usage))
+    {
+      JS_FreeValue(ctx, j_usage);
+      described = false;
+    }
+    else
+    {
+      described = JS_DefinePropertyValueUint32(ctx, j_usages, (uint32_t)i, j_usage, JS_PROP_C_W_E) >= 0 && described;
+    }
+  }
+  described = JS_DefinePropertyValueStr(ctx, j_key, "usages", j_usages,
+                                       JS_PROP_WRITABLE | JS_PROP_ENUMERABLE | JS_PROP_CONFIGURABLE) >= 0 && described;
+
+  if (!described)
+  {
+    // A key that cannot say what it is, is not one to hand over: the runtime's
+    // own throw is already pending from whichever allocation failed. The row
+    // goes with it, since the draw is behind us now: left there it would anchor
+    // this key, key_data included, for the life of the VM with nothing in JS
+    // able to reach it. Only what this call made, because the same key crossing
+    // twice reuses its handle and the earlier crossing still relies on that row.
+    if (registered_here)
+    {
+      alive_objects_unregister(data, r_object_id, r_key_object_id);
+      // The claim goes with the row: a caller told the row is theirs would ask
+      // alive_objects_forget for one that is already gone.
+      registered_here = false;
+      if (registered_here_out != NULL)
+        *registered_here_out = false;
+    }
+    JS_FreeValue(ctx, j_key);
+    return JS_EXCEPTION;
+  }
+
+  // A key that looks like a key and carries no handle is worse than no key:
+  // every later sign or exportKey on it fails as an invalid key while the row
+  // keeps anchoring the Ruby object.
+  if (JS_DefinePropertyValueStr(ctx, j_key, "rb_object_id",
+                                JS_NewInt64(ctx, NUM2LL(r_object_id)),
+                                JS_PROP_CONFIGURABLE | JS_PROP_WRITABLE) < 0)
+  {
+    // Only what this call put there: the same key object crossing twice reuses
+    // its handle, and taking that row would unanchor the key the earlier
+    // crossing handed the guest.
+    if (registered_here)
+    {
+      alive_objects_unregister(data, r_object_id, r_key_object_id);
+      if (registered_here_out != NULL)
+        *registered_here_out = false;
+    }
+    JS_FreeValue(ctx, j_key);
+    return JS_EXCEPTION;
+  }
 
   return j_key;
 }
@@ -407,21 +834,45 @@ static JSValue js_subtle_generate_key(JSContext *ctx, JSValueConst this_val, int
   {
     VALUE r_priv = rb_hash_aref(r_result, ID2SYM(rb_intern("private_key")));
     VALUE r_pub = rb_hash_aref(r_result, ID2SYM(rb_intern("public_key")));
+    bool priv_registered_here = false;
+    bool pub_registered_here = false;
+    JSValue j_priv = js_crypto_key_to_js(ctx, r_priv, &priv_registered_here);
+    JSValue j_pub = js_crypto_key_to_js(ctx, r_pub, &pub_registered_here);
     JSValue j_pair = JS_NewObject(ctx);
-    JSValue j_priv = js_crypto_key_to_js(ctx, r_priv);
-    JSValue j_pub = js_crypto_key_to_js(ctx, r_pub);
-    JS_SetPropertyStr(ctx, j_pair, "privateKey", j_priv);
-    JS_SetPropertyStr(ctx, j_pair, "publicKey", j_pub);
-    JSValue ret = JS_Call(ctx, resolving_funcs[0], JS_UNDEFINED, 1, (JSValueConst *)&j_pair);
-    JS_FreeValue(ctx, j_pair);
-    JS_FreeValue(ctx, ret);
+    bool built = !JS_IsException(j_priv) && !JS_IsException(j_pub) && !JS_IsException(j_pair);
+    if (built)
+    {
+      built = JS_DefinePropertyValueStr(ctx, j_pair, "privateKey", j_priv, JS_PROP_C_W_E) >= 0;
+      built = JS_DefinePropertyValueStr(ctx, j_pair, "publicKey", j_pub, JS_PROP_C_W_E) >= 0 && built;
+    }
+    else
+    {
+      // Half a pair is not a pair, and the sentinel is not a value to hand on.
+      JS_FreeValue(ctx, j_priv);
+      JS_FreeValue(ctx, j_pub);
+    }
+
+    if (built)
+    {
+      js_settle_or_reject(ctx, resolving_funcs, j_pair);
+    }
+    else
+    {
+      // Whichever key did get built is being dropped here, so its row goes with
+      // it. Left behind, it would anchor a Ruby CryptoKey, private material
+      // included, for the life of the VM with nothing in JS able to reach it.
+      VMData *data = JS_GetContextOpaque(ctx);
+      if (priv_registered_here)
+        alive_objects_forget(data, r_priv);
+      if (pub_registered_here)
+        alive_objects_forget(data, r_pub);
+      JS_FreeValue(ctx, j_pair);
+      js_settle_or_reject(ctx, resolving_funcs, JS_EXCEPTION);
+    }
   }
   else
   {
-    JSValue j_result = js_crypto_key_to_js(ctx, r_result);
-    JSValue ret = JS_Call(ctx, resolving_funcs[0], JS_UNDEFINED, 1, (JSValueConst *)&j_result);
-    JS_FreeValue(ctx, j_result);
-    JS_FreeValue(ctx, ret);
+    js_settle_or_reject(ctx, resolving_funcs, js_crypto_key_to_js(ctx, r_result, NULL));
   }
 
   JS_FreeValue(ctx, resolving_funcs[0]);
@@ -473,10 +924,7 @@ static JSValue js_subtle_import_key(JSContext *ctx, JSValueConst this_val, int a
   }
   else
   {
-    JSValue j_result = js_crypto_key_to_js(ctx, r_result);
-    JSValue ret = JS_Call(ctx, resolving_funcs[0], JS_UNDEFINED, 1, (JSValueConst *)&j_result);
-    JS_FreeValue(ctx, j_result);
-    JS_FreeValue(ctx, ret);
+    js_settle_or_reject(ctx, resolving_funcs, js_crypto_key_to_js(ctx, r_result, NULL));
   }
 
   JS_FreeValue(ctx, resolving_funcs[0]);
@@ -825,10 +1273,7 @@ static JSValue js_subtle_derive_key(JSContext *ctx, JSValueConst this_val, int a
   }
   else
   {
-    JSValue j_result = js_crypto_key_to_js(ctx, r_result);
-    JSValue ret = JS_Call(ctx, resolving_funcs[0], JS_UNDEFINED, 1, (JSValueConst *)&j_result);
-    JS_FreeValue(ctx, j_result);
-    JS_FreeValue(ctx, ret);
+    js_settle_or_reject(ctx, resolving_funcs, js_crypto_key_to_js(ctx, r_result, NULL));
   }
 
   JS_FreeValue(ctx, resolving_funcs[0]);
@@ -959,10 +1404,7 @@ static JSValue js_subtle_unwrap_key(JSContext *ctx, JSValueConst this_val, int a
   }
   else
   {
-    JSValue j_result = js_crypto_key_to_js(ctx, r_result);
-    JSValue ret = JS_Call(ctx, resolving_funcs[0], JS_UNDEFINED, 1, (JSValueConst *)&j_result);
-    JS_FreeValue(ctx, j_result);
-    JS_FreeValue(ctx, ret);
+    js_settle_or_reject(ctx, resolving_funcs, js_crypto_key_to_js(ctx, r_result, NULL));
   }
 
   JS_FreeValue(ctx, resolving_funcs[0]);

--- a/ext/quickjsrb/quickjsrb_file.c
+++ b/ext/quickjsrb/quickjsrb_file.c
@@ -148,6 +148,7 @@ static JSValue j_rethrow_the_guests_own(JSContext *ctx)
 
 static JSValue js_ruby_file_slice(JSContext *ctx, JSValueConst _this, int argc, JSValueConst *argv)
 {
+  VMData *data = JS_GetContextOpaque(ctx);
   VALUE r_file = r_find_alive_rb_file(ctx, argv[0]);
   if (NIL_P(r_file))
     return JS_UNDEFINED;
@@ -188,10 +189,6 @@ static JSValue js_ruby_file_slice(JSContext *ctx, JSValueConst _this, int argc, 
       end = file_size;
   }
 
-  const char *content_type = "";
-  if (argc > 3 && JS_IsString(argv[3]))
-    content_type = JS_ToCString(ctx, argv[3]);
-
   long len = end > start ? end - start : 0;
 
   rb_funcall(r_file, rb_intern("rewind"), 0);
@@ -200,30 +197,91 @@ static JSValue js_ruby_file_slice(JSContext *ctx, JSValueConst _this, int argc, 
   VALUE r_bytes = rb_funcall(r_file, rb_intern("read"), 1, LONG2NUM(len));
   rb_funcall(r_bytes, rb_intern("force_encoding"), 1, rb_str_new_cstr("BINARY"));
 
+  // Built after every call that can raise, and while the C string is still
+  // owned, so nothing here is holding a JS value when a Ruby raise unwinds and
+  // nothing is left to free on the paths that bail out below.
+  JSValue j_type_str;
+  if (argc > 3 && JS_IsString(argv[3]))
+  {
+    const char *content_type = JS_ToCString(ctx, argv[3]);
+    if (content_type == NULL)
+      // It threw on the way, and returning a Blob with that left pending would
+      // attribute it to whatever asks next.
+      return j_rethrow_the_guests_own(ctx);
+    j_type_str = JS_NewString(ctx, content_type);
+    JS_FreeCString(ctx, content_type);
+  }
+  else
+  {
+    j_type_str = JS_NewString(ctx, "");
+  }
+  if (JS_IsException(j_type_str))
+    return j_type_str;
+
+  // Built through JS_NewTypedArray and the constructor captured at init, not
+  // by calling globalThis.Uint8Array and globalThis.Blob: those are names the
+  // guest can delete or replace with a shim, and a slice of a host File is not
+  // something it gets to answer for. Every step is checked, so a sentinel is
+  // never stored into j_parts and handed on as an ordinary element.
   JSValue j_buf = JS_NewArrayBufferCopy(ctx, (const uint8_t *)RSTRING_PTR(r_bytes), RSTRING_LEN(r_bytes));
-  JSValue j_global = JS_GetGlobalObject(ctx);
-  JSValue j_uint8_ctor = JS_GetPropertyStr(ctx, j_global, "Uint8Array");
-  JSValue j_uint8 = JS_CallConstructor(ctx, j_uint8_ctor, 1, &j_buf);
+  if (JS_IsException(j_buf))
+  {
+    JS_FreeValue(ctx, j_type_str);
+    return j_buf;
+  }
+
+  JSValue j_ta_args[3] = {j_buf, JS_NewInt32(ctx, 0), JS_NewInt64(ctx, RSTRING_LEN(r_bytes))};
+  JSValue j_uint8 = JS_NewTypedArray(ctx, 3, (JSValueConst *)j_ta_args, JS_TYPED_ARRAY_UINT8);
+  JS_FreeValue(ctx, j_buf);
+  if (JS_IsException(j_uint8))
+  {
+    JS_FreeValue(ctx, j_type_str);
+    return j_uint8;
+  }
+
+  if (JS_IsUndefined(data->j_blob_ctor))
+  {
+    JS_FreeValue(ctx, j_uint8);
+    JS_FreeValue(ctx, j_type_str);
+    return JS_ThrowInternalError(ctx, "Blob is not available to build a slice");
+  }
 
   JSValue j_parts = JS_NewArray(ctx);
-  JS_SetPropertyUint32(ctx, j_parts, 0, j_uint8);
+  if (JS_IsException(j_parts))
+  {
+    JS_FreeValue(ctx, j_uint8);
+    JS_FreeValue(ctx, j_type_str);
+    return j_parts;
+  }
+  if (JS_DefinePropertyValueUint32(ctx, j_parts, 0, j_uint8, JS_PROP_C_W_E) < 0)
+  {
+    // The define freed the bytes on its way out, so carrying on would build the
+    // Blob from an empty array and hand the guest a zero-length slice of a file
+    // that is not empty, with a throw left pending behind it.
+    JS_FreeValue(ctx, j_parts);
+    JS_FreeValue(ctx, j_type_str);
+    return JS_EXCEPTION;
+  }
 
   JSValue j_opts = JS_NewObject(ctx);
-  JS_SetPropertyStr(ctx, j_opts, "type", JS_NewString(ctx, content_type));
+  if (JS_IsException(j_opts))
+  {
+    JS_FreeValue(ctx, j_parts);
+    JS_FreeValue(ctx, j_type_str);
+    return j_opts;
+  }
+  if (JS_DefinePropertyValueStr(ctx, j_opts, "type", j_type_str, JS_PROP_C_W_E) < 0)
+  {
+    JS_FreeValue(ctx, j_parts);
+    JS_FreeValue(ctx, j_opts);
+    return JS_EXCEPTION;
+  }
 
-  JSValue j_blob_ctor = JS_GetPropertyStr(ctx, j_global, "Blob");
   JSValueConst blob_args[2] = {j_parts, j_opts};
-  JSValue j_blob = JS_CallConstructor(ctx, j_blob_ctor, 2, blob_args);
+  JSValue j_blob = JS_CallConstructor(ctx, data->j_blob_ctor, 2, blob_args);
 
-  if (argc > 3 && JS_IsString(argv[3]))
-    JS_FreeCString(ctx, content_type);
-
-  JS_FreeValue(ctx, j_buf);
-  JS_FreeValue(ctx, j_uint8_ctor);
   JS_FreeValue(ctx, j_parts);
   JS_FreeValue(ctx, j_opts);
-  JS_FreeValue(ctx, j_blob_ctor);
-  JS_FreeValue(ctx, j_global);
 
   return j_blob;
 }
@@ -231,12 +289,12 @@ static JSValue js_ruby_file_slice(JSContext *ctx, JSValueConst _this, int argc, 
 void quickjsrb_init_file_proxy(VMData *data)
 {
   const char *factory_src =
-      "(function(getName, getSize, getType, getLastModified, getText, getArrayBuffer, getSlice) {\n"
+      "(function(FileProto, getName, getSize, getType, getLastModified, getText, getArrayBuffer, getSlice) {\n"
       "  return function(handle) {\n"
-      "    var target = Object.create(File.prototype);\n"
+      "    var target = Object.create(FileProto);\n"
       "    Object.defineProperty(target, 'rb_object_id', { value: handle, enumerable: false });\n"
       "    return new Proxy(target, {\n"
-      "      getPrototypeOf: function() { return File.prototype; },\n"
+      "      getPrototypeOf: function() { return FileProto; },\n"
       "      get: function(target, prop, receiver) {\n"
       "        if (prop === 'name') return getName(handle);\n"
       "        if (prop === 'size') return getSize(handle);\n"
@@ -254,19 +312,54 @@ void quickjsrb_init_file_proxy(VMData *data)
       "})";
   JSValue j_factory_fn = JS_Eval(data->context, factory_src, strlen(factory_src), "<file-proxy>", JS_EVAL_TYPE_GLOBAL);
 
-  JSValue j_helpers[7];
-  j_helpers[0] = quickjsrb_new_ruby_bridge(data->context, js_ruby_file_name, "__rb_file_name", 1);
-  j_helpers[1] = quickjsrb_new_ruby_bridge(data->context, js_ruby_file_size, "__rb_file_size", 1);
-  j_helpers[2] = quickjsrb_new_ruby_bridge(data->context, js_ruby_file_type, "__rb_file_type", 1);
-  j_helpers[3] = quickjsrb_new_ruby_bridge(data->context, js_ruby_file_last_modified, "__rb_file_last_modified", 1);
-  j_helpers[4] = quickjsrb_new_ruby_bridge(data->context, js_ruby_file_text, "__rb_file_text", 1);
-  j_helpers[5] = quickjsrb_new_ruby_bridge(data->context, js_ruby_file_array_buffer, "__rb_file_array_buffer", 1);
-  j_helpers[6] = quickjsrb_new_ruby_bridge(data->context, js_ruby_file_slice, "__rb_file_slice", 4);
+  // The prototype is taken here too, not read from globalThis.File when a proxy
+  // is built: the closure below runs per crossing, which is after guest code,
+  // and a replaced File otherwise decides what a host File is an instance of.
+  // The handle keeps working either way, so what this closes is the shape of
+  // the value rather than the bridge.
+  JSValue j_global_for_proto = JS_GetGlobalObject(data->context);
+  JSValue j_file_class = JS_GetPropertyStr(data->context, j_global_for_proto, "File");
+  JS_FreeValue(data->context, j_global_for_proto);
+  JSValue j_file_proto = JS_GetPropertyStr(data->context, j_file_class, "prototype");
+  JS_FreeValue(data->context, j_file_class);
 
-  data->j_file_proxy_creator = JS_Call(data->context, j_factory_fn, JS_UNDEFINED, 7, j_helpers);
+  JSValue j_helpers[8];
+  j_helpers[0] = j_file_proto;
+  j_helpers[1] = quickjsrb_new_ruby_bridge(data->context, js_ruby_file_name, "__rb_file_name", 1);
+  j_helpers[2] = quickjsrb_new_ruby_bridge(data->context, js_ruby_file_size, "__rb_file_size", 1);
+  j_helpers[3] = quickjsrb_new_ruby_bridge(data->context, js_ruby_file_type, "__rb_file_type", 1);
+  j_helpers[4] = quickjsrb_new_ruby_bridge(data->context, js_ruby_file_last_modified, "__rb_file_last_modified", 1);
+  j_helpers[5] = quickjsrb_new_ruby_bridge(data->context, js_ruby_file_text, "__rb_file_text", 1);
+  j_helpers[6] = quickjsrb_new_ruby_bridge(data->context, js_ruby_file_array_buffer, "__rb_file_array_buffer", 1);
+  j_helpers[7] = quickjsrb_new_ruby_bridge(data->context, js_ruby_file_slice, "__rb_file_slice", 4);
+
+  // Freed before it is replaced, for the reason the Blob capture below gives:
+  // initialize is private but reachable through send, and a second pass would
+  // otherwise leak this closure and the seven bridges it holds.
+  if (!JS_IsUndefined(data->j_file_proxy_creator))
+    JS_FreeValue(data->context, data->j_file_proxy_creator);
+  data->j_file_proxy_creator = JS_Call(data->context, j_factory_fn, JS_UNDEFINED, 8, j_helpers);
+
+  // Taken here, before a line of guest code has run, because slice builds its
+  // result with it and globalThis.Blob is the guest's to replace by then.
+  //
+  // Once per VM, like the Proxy probe: initialize is private but reachable
+  // through send, and a second pass would overwrite this reference without
+  // freeing the first, which outlives JS_FreeRuntime along with everything it
+  // holds.
+  if (!JS_IsUndefined(data->j_blob_ctor))
+    JS_FreeValue(data->context, data->j_blob_ctor);
+  JSValue j_global = JS_GetGlobalObject(data->context);
+  data->j_blob_ctor = JS_GetPropertyStr(data->context, j_global, "Blob");
+  JS_FreeValue(data->context, j_global);
+  if (JS_IsException(data->j_blob_ctor))
+  {
+    JS_FreeValue(data->context, JS_GetException(data->context));
+    data->j_blob_ctor = JS_UNDEFINED;
+  }
 
   JS_FreeValue(data->context, j_factory_fn);
-  for (int i = 0; i < 7; i++)
+  for (int i = 0; i < 8; i++)
     JS_FreeValue(data->context, j_helpers[i]);
 }
 

--- a/ext/quickjsrb/quickjsrb_file.c
+++ b/ext/quickjsrb/quickjsrb_file.c
@@ -3,10 +3,25 @@
 
 static VALUE r_find_alive_rb_file(JSContext *ctx, JSValue j_handle)
 {
-  int64_t handle;
-  JS_ToInt64(ctx, &handle, j_handle);
+  // Initialised and checked like its siblings. Unreachable today, since the
+  // handle is the factory closure's own number and the bridges are never on
+  // the global, but it feeds a table lookup and would read a garbage key.
+  int64_t handle = 0;
+  if (JS_ToInt64(ctx, &handle, j_handle) < 0)
+  {
+    quickjsrb_drain_pending(ctx);
+    return Qnil;
+  }
   VMData *data = JS_GetContextOpaque(ctx);
-  return rb_hash_aref(data->alive_objects, LONG2NUM(handle));
+  VALUE r_file = rb_hash_aref(data->alive_objects, LL2NUM(handle));
+  // Only what this subsystem parked, the way both sibling readers check now.
+  // The table is shared with bridged exceptions and CryptoKeys, and the bridges
+  // below call File methods on whatever they are handed. Unreachable today,
+  // since the handle is the factory closure's own number, but the check is what
+  // makes that an invariant rather than an argument about reachability.
+  if (!rb_obj_is_kind_of(r_file, rb_cFile))
+    return Qnil;
+  return r_file;
 }
 
 static JSValue js_ruby_file_name(JSContext *ctx, JSValueConst _this, int argc, JSValueConst *argv)
@@ -99,6 +114,32 @@ static JSValue js_ruby_file_array_buffer(JSContext *ctx, JSValueConst _this, int
   return promise;
 }
 
+// Hands the guest back the throw it made, rather than an error of our own,
+// which would tell it less than it already knew.
+//
+// Deliberately without unparking: the throw is going back into JS, and it is
+// the handle that lets it come out the other side as the host exception it
+// started as. Taking the entry here would leave the JS error carrying a handle
+// that resolves to nothing, and a caller that expected ArgumentError would get
+// a generic Quickjs::RuntimeError instead. A throw the guest then catches and
+// keeps stays parked, which is what any caught bridged error does: #114.
+static JSValue j_rethrow_the_guests_own(JSContext *ctx)
+{
+  // JS_Throw clears the uncatchable flag, so a deadline that fired inside the
+  // guest's valueOf would come back catchable and a script that caught it and
+  // returned would finish past its budget. Thrown the way js_poll_interrupts
+  // throws it instead, which is what it was before this touched it.
+  if (eval_budget_lapsed_now(ctx))
+  {
+    JS_FreeValue(ctx, JS_GetException(ctx));
+    JS_ThrowInternalError(ctx, "interrupted");
+    JS_SetUncatchableException(ctx, TRUE);
+    return JS_EXCEPTION;
+  }
+
+  return JS_Throw(ctx, JS_GetException(ctx));
+}
+
 static JSValue js_ruby_file_slice(JSContext *ctx, JSValueConst _this, int argc, JSValueConst *argv)
 {
   VALUE r_file = r_find_alive_rb_file(ctx, argv[0]);
@@ -111,8 +152,12 @@ static JSValue js_ruby_file_slice(JSContext *ctx, JSValueConst _this, int argc, 
   long start = 0;
   if (argc > 1 && !JS_IsUndefined(argv[1]))
   {
-    int64_t s;
-    JS_ToInt64(ctx, &s, argv[1]);
+    // The conversion runs the guest's valueOf, which can reach a bridge: an
+    // unchecked failure both parks the host exception and leaves s
+    // uninitialized to be used as an offset.
+    int64_t s = 0;
+    if (JS_ToInt64(ctx, &s, argv[1]) < 0)
+      return j_rethrow_the_guests_own(ctx);
     start = (long)s;
     if (start < 0)
       start = file_size + start;
@@ -125,8 +170,9 @@ static JSValue js_ruby_file_slice(JSContext *ctx, JSValueConst _this, int argc, 
   long end = file_size;
   if (argc > 2 && !JS_IsUndefined(argv[2]))
   {
-    int64_t e;
-    JS_ToInt64(ctx, &e, argv[2]);
+    int64_t e = 0;
+    if (JS_ToInt64(ctx, &e, argv[2]) < 0)
+      return j_rethrow_the_guests_own(ctx);
     end = (long)e;
     if (end < 0)
       end = file_size + end;
@@ -221,9 +267,10 @@ void quickjsrb_init_file_proxy(VMData *data)
 JSValue quickjsrb_file_to_js(JSContext *ctx, VALUE r_file)
 {
   VMData *data = JS_GetContextOpaque(ctx);
-  VALUE r_object_id = rb_funcall(r_file, rb_intern("object_id"), 0);
-  rb_hash_aset(data->alive_objects, r_object_id, r_file);
-  JSValue j_handle = JS_NewInt64(ctx, NUM2LONG(r_object_id));
+  VALUE r_object_id = alive_objects_register(data, r_file, NULL);
+  if (NIL_P(r_object_id))
+    return JS_ThrowInternalError(ctx, "quickjs: could not publish a handle for a host File");
+  JSValue j_handle = JS_NewInt64(ctx, NUM2LL(r_object_id));
   JSValue j_proxy = JS_Call(ctx, data->j_file_proxy_creator, JS_UNDEFINED, 1, &j_handle);
   JS_FreeValue(ctx, j_handle);
   return j_proxy;

--- a/ext/quickjsrb/quickjsrb_file.c
+++ b/ext/quickjsrb/quickjsrb_file.c
@@ -131,7 +131,13 @@ static JSValue j_rethrow_the_guests_own(JSContext *ctx)
   // throws it instead, which is what it was before this touched it.
   if (eval_budget_lapsed_now(ctx))
   {
-    JS_FreeValue(ctx, JS_GetException(ctx));
+    // Drained, not freed. This branch is the one that does not hand the throw
+    // back, so the reasoning quickjsrb_drain_pending gives for unparking
+    // applies here and not to the return below: nothing will carry the guest's
+    // throw out now, and a bridge it reached on the way has already parked the
+    // host exception, so freeing the JS error is the one path that leaves that
+    // entry with nothing able to take it.
+    quickjsrb_drain_pending(ctx);
     JS_ThrowInternalError(ctx, "interrupted");
     JS_SetUncatchableException(ctx, TRUE);
     return JS_EXCEPTION;

--- a/lib/quickjs/crypto_key.rb
+++ b/lib/quickjs/crypto_key.rb
@@ -11,5 +11,18 @@ module Quickjs
       @usages = usages
       @key_data = key_data
     end
+
+    # The bytes stay out of the string form. to_js_value has no case for this
+    # class, so anything that hands a key back to JS, a pass-through
+    # define_function or a logged value, converts it by calling inspect: a key
+    # generated with extractable: false would otherwise reach the guest in full
+    # through a function that exportKey refuses one call away.
+    def inspect
+      format(
+        '#<%s type=%p extractable=%p algorithm=%p usages=%p key_data=[FILTERED]>',
+        self.class, @type, @extractable, @algorithm, @usages
+      )
+    end
+    alias to_s inspect
   end
 end

--- a/sig/quickjs.rbs
+++ b/sig/quickjs.rbs
@@ -61,6 +61,7 @@ module Quickjs
     def gc!: () -> nil
 
     def memory_poisoned?: () -> bool
+    def poisoned?: () -> bool
 
     def dispose!: () -> nil
 

--- a/test/quickjs_crypto_subtle_key_test.rb
+++ b/test/quickjs_crypto_subtle_key_test.rb
@@ -187,6 +187,10 @@ describe "crypto.subtle key management" do
     # Describing a key runs StringValueCStr, which raises on a non-String, out
     # of a JSCFunction. Nothing is registered until the description is finished,
     # so a raise there cannot leave a row anchoring the key.
+    # The length is the guest's to write, and the loop that reads it polls no
+    # QuickJS interrupt, so timeout_msec cannot end it. Measured before this
+    # was bounded: 10,000,000 ran 1.9s past a 100ms budget and left the VM out
+    # of memory, which the guest chose by passing a number.
     # The handle read is own data, so an accessor on Object.prototype cannot
     # answer it: a bare object carrying no handle is not a key, whatever the
     # prototype says.
@@ -204,6 +208,40 @@ describe "crypto.subtle key management" do
       JS
 
       _(outcome).must_equal 'refused'
+    ensure
+      vm&.dispose!
+    end
+
+    # A negative length is an empty sequence under WebIDL's ToLength, not too
+    # many entries. JS_ToInt32 wraps, so 2**31 arrives negative and means the
+    # same thing.
+    it "reads a negative keyUsages length as an empty list" do
+      vm = Quickjs::VM.new(features: [::Quickjs::POLYFILL_CRYPTO])
+
+      [-1, 2**31].each do |length|
+        usages = vm.eval_code(<<~JS)
+          JSON.stringify((await crypto.subtle.importKey('raw', new Uint8Array(16), { name: 'HMAC', hash: { name: 'SHA-256' } }, false, { length: #{length} })).usages)
+        JS
+        _(usages).must_equal '[]'
+      end
+    ensure
+      vm&.dispose!
+    end
+
+    it "refuses a keyUsages list longer than a key can have" do
+      vm = Quickjs::VM.new(features: [::Quickjs::POLYFILL_CRYPTO], timeout_msec: 100)
+
+      started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      error = _ {
+        vm.eval_code(<<~JS)
+          await crypto.subtle.importKey('raw', new Uint8Array(16), { name: 'HMAC', hash: { name: 'SHA-256' } }, false, { length: 10_000_000 })
+        JS
+      }.must_raise Quickjs::TypeError
+      elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
+
+      _(error.message).must_match(/keyUsages/)
+      _(elapsed).must_be :<, 1.0
+      _(vm.poisoned?).must_equal false
     ensure
       vm&.dispose!
     end

--- a/test/quickjs_crypto_subtle_key_test.rb
+++ b/test/quickjs_crypto_subtle_key_test.rb
@@ -533,4 +533,26 @@ describe "crypto.subtle key management" do
     ensure
       vm&.dispose!
     end
+    # to_js_value has no case for Quickjs::CryptoKey, so a key handed back to
+    # JS converts by way of inspect. With the bytes in that string a guest
+    # reads a key generated extractable: false straight out of any pass-through
+    # host function, which exportKey refuses one call away.
+    it "does not put key material in the string a guest gets back" do
+      vm = Quickjs::VM.new(features: [::Quickjs::POLYFILL_CRYPTO])
+      host_key = nil
+      vm.define_function(:echo) { |k| host_key = k; k }
+      vm.eval_code("globalThis.k = await crypto.subtle.generateKey({name: 'AES-GCM', length: 256}, false, ['encrypt', 'decrypt'])")
+
+      seen = vm.eval_code("echo(globalThis.k)").to_s
+      bytes = host_key.key_data.to_s
+
+      _(bytes.bytesize).must_equal 32
+      _(seen).wont_include bytes
+      _(seen).must_include '[FILTERED]'
+      # The parts that are not the secret still describe the key.
+      _(seen).must_include 'AES-GCM'
+      _(seen).must_include 'extractable=false'
+    ensure
+      vm&.dispose!
+    end
 end

--- a/test/quickjs_crypto_subtle_key_test.rb
+++ b/test/quickjs_crypto_subtle_key_test.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 require_relative "test_helper"
-require "fileutils"
-require "tmpdir"
 require "open3"
+require "tmpdir"
+require "fileutils"
 
 describe "crypto.subtle key management" do
   before do
@@ -124,24 +124,23 @@ describe "crypto.subtle key management" do
       _ { ::Quickjs.eval_code(code, @options) }.must_raise Quickjs::RuntimeError
     end
   end
-    it "cannot be recovered by scanning the handle space" do
+
+  # A CryptoKey publishes its rb_object_id to the guest, and a thrown error
+  # carrying that id used to reach the table the exception bridge reads, which
+  # deletes what it finds. The key survived as an object and failed every
+  # operation with "invalid CryptoKey".
+  describe "when the guest throws the key's own rb_object_id" do
+    it "leaves the key usable" do
       vm = Quickjs::VM.new(features: [::Quickjs::POLYFILL_CRYPTO])
-      vm.eval_code("globalThis.k = await crypto.subtle.generateKey({name: 'HMAC', hash: 'SHA-256'}, false, ['sign', 'verify'])")
-      _(vm.eval_code("(await crypto.subtle.sign('HMAC', globalThis.k, new Uint8Array([1, 2, 3]))).byteLength")).must_equal 32
-      vm.eval_code('delete globalThis.k; 1')
+      vm.eval_code("globalThis.k = await crypto.subtle.generateKey({name: 'HMAC', hash: 'SHA-256'}, true, ['sign', 'verify'])")
+      sign = "(await crypto.subtle.sign('HMAC', globalThis.k, new Uint8Array([1, 2, 3]))).byteLength"
+      _(vm.eval_code(sign)).must_equal 32
 
-      found = vm.eval_code(<<~JS)
-        let found = 'none';
-        for (let i = 1; i < 5000; i++) {
-          try {
-            const s = await crypto.subtle.sign('HMAC', {rb_object_id: i}, new Uint8Array([1, 2, 3]));
-            if (s) { found = 'recovered at ' + i; break }
-          } catch (e) {}
-        }
-        found
-      JS
+      error = _ { vm.eval_code("throw Object.assign(new Error('guest'), {rb_object_id: globalThis.k.rb_object_id})") }
+        .must_raise Quickjs::RuntimeError
+      _(error.message).must_equal 'guest'
 
-      _(found).must_equal 'none'
+      _(vm.eval_code(sign)).must_equal 32
     ensure
       vm&.dispose!
     end
@@ -372,6 +371,7 @@ describe "crypto.subtle key management" do
     ensure
       vm&.dispose!
     end
+
     # The handle is read off whatever the guest passes as the key argument, so
     # unlike the File proxy's closure-captured one it is the guest's to choose.
     # An id belonging to another entry used to reach the operation as a key.
@@ -389,86 +389,41 @@ describe "crypto.subtle key management" do
     ensure
       vm&.dispose!
     end
-    # Guards against re-introducing a cache rather than pinning the lookup as
-    # it stands: a class held only by a constant table is movable, so a C
-    # static would keep an address the collector has since handed on. Passes
-    # either way today, since nothing is cached.
-    it "keeps working across a compaction" do
+
+    # The exponent used to be handed to JS by calling globalThis's Uint8Array,
+    # which the guest can delete or replace with anything, including a shim
+    # that throws. It is built directly now, so what the guest does to that
+    # name cannot reach the description.
+    it "describes the key in full even when Uint8Array is gone" do
       vm = Quickjs::VM.new(features: [::Quickjs::POLYFILL_CRYPTO])
-      vm.eval_code("globalThis.k = await crypto.subtle.generateKey({name: 'HMAC', hash: 'SHA-256'}, true, ['sign', 'verify'])")
-      sign = "(await crypto.subtle.sign('HMAC', globalThis.k, new Uint8Array([1, 2, 3]))).byteLength"
-      _(vm.eval_code(sign)).must_equal 32
+      vm.eval_code('globalThis.PE = new Uint8Array([1, 0, 1]); delete globalThis.Uint8Array; 1')
 
-      5.times { GC.compact }
+      described = vm.eval_code(<<~JS)
+        const k = await crypto.subtle.generateKey({name: 'RSA-OAEP', modulusLength: 2048, publicExponent: PE, hash: 'SHA-256'}, true, ['encrypt', 'decrypt']);
+        [Object.keys(k.publicKey.algorithm).join(','), Array.from(k.publicKey.algorithm.publicExponent).join('.')].join(' | ')
+      JS
 
-      _(vm.eval_code(sign)).must_equal 32
+      _(described).must_equal 'name,hash,modulusLength,publicExponent | 1.0.1'
+      _(vm.eval_code('1 + 1')).must_equal 2
     ensure
       vm&.dispose!
     end
-    # The lookup runs inside a QuickJS native callback with no rb_protect
-    # between it and the interpreter, so it must answer rather than raise when
-    # the Ruby layer that defines the class has not been loaded. Requiring the
-    # extension on its own is enough to get there, and a NameError from here
-    # longjmps through QuickJS's frames past the JS values they still hold.
-    # rb_const_defined_at answers true for a registered autoload, and the
-    # rb_const_get after it would run the autoload body from inside the
-    # callback, which is the raise this lookup exists to not make.
-    it "answers invalid CryptoKey rather than running an autoload" do
-      dir = Dir.mktmpdir('quickjs-autoload')
-      body = File.join(dir, 'raising_autoload.rb')
-      File.write(body, "raise 'autoload body'")
 
-      script = <<~RUBY
-        require "quickjs"
-        Quickjs.send(:remove_const, :CryptoKey)
-        Quickjs.autoload(:CryptoKey, #{body.inspect})
+    # A replacement that reaches a Ruby bridge used to have its exception
+    # swallowed and left parked in alive_objects.
+    it "does not run a replaced Uint8Array at all" do
+      vm = Quickjs::VM.new(features: [::Quickjs::POLYFILL_CRYPTO])
+      calls = 0
+      vm.define_function(:boom) { calls += 1; raise ArgumentError, 'host' }
+      vm.eval_code('globalThis.PE = new Uint8Array([1, 0, 1]); globalThis.Uint8Array = function () { boom() }; 1')
 
-        vm = Quickjs::VM.new(features: [Quickjs::POLYFILL_CRYPTO])
-        vm.define_function(:boom) { raise ArgumentError, 'host' }
-        vm.eval_code("globalThis.id = null; try { boom() } catch (e) { globalThis.id = e.rb_object_id }")
-        abort "no id was planted" unless vm.eval_code("typeof globalThis.id") == 'number'
-        begin
-          vm.eval_code('await crypto.subtle.sign("HMAC", {rb_object_id: globalThis.id}, new Uint8Array([1]))')
-          puts "no raise"
-        rescue Exception => e
-          puts "\#{e.class}: \#{e.message}"
-        end
-      RUBY
+      vm.eval_code("const k = await crypto.subtle.generateKey({name: 'RSA-OAEP', modulusLength: 2048, publicExponent: PE, hash: 'SHA-256'}, true, ['encrypt', 'decrypt']); 'resolved'")
 
-      lib = File.expand_path('../lib', __dir__)
-      out, status = Open3.capture2e(RbConfig.ruby, '-I', lib, '-e', script)
-
-      _(out).must_match(/Quickjs::TypeError: .*invalid CryptoKey/)
-      _(status).must_be :success?
+      _(calls).must_equal 0
     ensure
-      FileUtils.remove_entry(dir) if dir
+      vm&.dispose!
     end
-    it "answers invalid CryptoKey when Quickjs::CryptoKey is not defined" do
-      script = <<~RUBY
-        require "quickjs/quickjsrb"
-        abort "CryptoKey should not be loaded" if Quickjs.const_defined?(:CryptoKey)
-        vm = Quickjs::VM.new(features: [Quickjs::POLYFILL_CRYPTO])
-        # A real entry rather than a made-up id: 1 is in no table, so the nil
-        # hash hit alone would satisfy the callers and the class lookup would
-        # never be reached.
-        vm.define_function(:boom) { raise ArgumentError, 'host' }
-        vm.eval_code("globalThis.id = null; try { boom() } catch (e) { globalThis.id = e.rb_object_id }")
-        abort "no id was planted" unless vm.eval_code("typeof globalThis.id") == 'number'
-        begin
-          vm.eval_code('await crypto.subtle.sign("HMAC", {rb_object_id: globalThis.id}, new Uint8Array([1]))')
-          puts "no raise"
-        rescue Exception => e
-          puts "\#{e.class}: \#{e.message}"
-        end
-      RUBY
 
-      lib = File.expand_path('../lib', __dir__)
-      out, status = Open3.capture2e(RbConfig.ruby, '-I', lib, '-e', script)
-      # Asserted before the exit status so the abort guard's own message, or a
-      # LoadError, is what a failure reports rather than "expected success?".
-      _(out).must_match(/Quickjs::TypeError: .*invalid CryptoKey/)
-      _(status).must_be :success?
-    end
     # Every property of the algorithm and of the key is a read the guest can
     # answer with a getter, and a getter that reaches a bridge parks the host's
     # exception on the way out. A reader that skips the throw without draining
@@ -509,6 +464,7 @@ describe "crypto.subtle key management" do
     ensure
       vm&.dispose! unless vm&.disposed?
     end
+
     # The drain drops the throw, so nothing will carry the host exception out
     # and its anchor would only be a leak. A guest that kept its own reference
     # can still rethrow the object; what it has then is the message, not the
@@ -533,6 +489,29 @@ describe "crypto.subtle key management" do
     ensure
       vm&.dispose!
     end
+
+    it "cannot be recovered by scanning the handle space" do
+      vm = Quickjs::VM.new(features: [::Quickjs::POLYFILL_CRYPTO])
+      vm.eval_code("globalThis.k = await crypto.subtle.generateKey({name: 'HMAC', hash: 'SHA-256'}, false, ['sign', 'verify'])")
+      _(vm.eval_code("(await crypto.subtle.sign('HMAC', globalThis.k, new Uint8Array([1, 2, 3]))).byteLength")).must_equal 32
+      vm.eval_code('delete globalThis.k; 1')
+
+      found = vm.eval_code(<<~JS)
+        let found = 'none';
+        for (let i = 1; i < 5000; i++) {
+          try {
+            const s = await crypto.subtle.sign('HMAC', {rb_object_id: i}, new Uint8Array([1, 2, 3]));
+            if (s) { found = 'recovered at ' + i; break }
+          } catch (e) {}
+        }
+        found
+      JS
+
+      _(found).must_equal 'none'
+    ensure
+      vm&.dispose!
+    end
+
     # to_js_value has no case for Quickjs::CryptoKey, so a key handed back to
     # JS converts by way of inspect. With the bytes in that string a guest
     # reads a key generated extractable: false straight out of any pass-through
@@ -555,4 +534,88 @@ describe "crypto.subtle key management" do
     ensure
       vm&.dispose!
     end
+
+    # Guards against re-introducing a cache rather than pinning the lookup as
+    # it stands: a class held only by a constant table is movable, so a C
+    # static would keep an address the collector has since handed on. Passes
+    # either way today, since nothing is cached.
+    it "keeps working across a compaction" do
+      vm = Quickjs::VM.new(features: [::Quickjs::POLYFILL_CRYPTO])
+      vm.eval_code("globalThis.k = await crypto.subtle.generateKey({name: 'HMAC', hash: 'SHA-256'}, true, ['sign', 'verify'])")
+      sign = "(await crypto.subtle.sign('HMAC', globalThis.k, new Uint8Array([1, 2, 3]))).byteLength"
+      _(vm.eval_code(sign)).must_equal 32
+
+      5.times { GC.compact }
+
+      _(vm.eval_code(sign)).must_equal 32
+    ensure
+      vm&.dispose!
+    end
+
+    # The lookup runs inside a QuickJS native callback with no rb_protect
+    # between it and the interpreter, so it must answer rather than raise when
+    # the Ruby layer that defines the class has not been loaded. Requiring the
+    # extension on its own is enough to get there, and a NameError from here
+    # longjmps through QuickJS's frames past the JS values they still hold.
+    # rb_const_defined_at answers true for a registered autoload, and the
+    # rb_const_get after it would run the autoload body from inside the
+    # callback, which is the raise this lookup exists to not make.
+    it "answers invalid CryptoKey rather than running an autoload" do
+      dir = Dir.mktmpdir('quickjs-autoload')
+      body = File.join(dir, 'raising_autoload.rb')
+      File.write(body, "raise 'autoload body'")
+
+      script = <<~RUBY
+        require "quickjs"
+        Quickjs.send(:remove_const, :CryptoKey)
+        Quickjs.autoload(:CryptoKey, #{body.inspect})
+
+        vm = Quickjs::VM.new(features: [Quickjs::POLYFILL_CRYPTO])
+        vm.define_function(:boom) { raise ArgumentError, 'host' }
+        vm.eval_code("globalThis.id = null; try { boom() } catch (e) { globalThis.id = e.rb_object_id }")
+        abort "no id was planted" unless vm.eval_code("typeof globalThis.id") == 'number'
+        begin
+          vm.eval_code('await crypto.subtle.sign("HMAC", {rb_object_id: globalThis.id}, new Uint8Array([1]))')
+          puts "no raise"
+        rescue Exception => e
+          puts "\#{e.class}: \#{e.message}"
+        end
+      RUBY
+
+      lib = File.expand_path('../lib', __dir__)
+      out, status = Open3.capture2e(RbConfig.ruby, '-I', lib, '-e', script)
+
+      _(out).must_match(/Quickjs::TypeError: .*invalid CryptoKey/)
+      _(status).must_be :success?
+    ensure
+      FileUtils.remove_entry(dir) if dir
+    end
+
+    it "answers invalid CryptoKey when Quickjs::CryptoKey is not defined" do
+      script = <<~RUBY
+        require "quickjs/quickjsrb"
+        abort "CryptoKey should not be loaded" if Quickjs.const_defined?(:CryptoKey)
+        vm = Quickjs::VM.new(features: [Quickjs::POLYFILL_CRYPTO])
+        # A real entry rather than a made-up id: 1 is in no table, so the nil
+        # hash hit alone would satisfy the callers and the class lookup would
+        # never be reached.
+        vm.define_function(:boom) { raise ArgumentError, 'host' }
+        vm.eval_code("globalThis.id = null; try { boom() } catch (e) { globalThis.id = e.rb_object_id }")
+        abort "no id was planted" unless vm.eval_code("typeof globalThis.id") == 'number'
+        begin
+          vm.eval_code('await crypto.subtle.sign("HMAC", {rb_object_id: globalThis.id}, new Uint8Array([1]))')
+          puts "no raise"
+        rescue Exception => e
+          puts "\#{e.class}: \#{e.message}"
+        end
+      RUBY
+
+      lib = File.expand_path('../lib', __dir__)
+      out, status = Open3.capture2e(RbConfig.ruby, '-I', lib, '-e', script)
+      # Asserted before the exit status so the abort guard's own message, or a
+      # LoadError, is what a failure reports rather than "expected success?".
+      _(out).must_match(/Quickjs::TypeError: .*invalid CryptoKey/)
+      _(status).must_be :success?
+    end
+  end
 end

--- a/test/quickjs_crypto_subtle_key_test.rb
+++ b/test/quickjs_crypto_subtle_key_test.rb
@@ -121,4 +121,232 @@ describe "crypto.subtle key management" do
       _ { ::Quickjs.eval_code(code, @options) }.must_raise Quickjs::RuntimeError
     end
   end
+    it "cannot be recovered by scanning the handle space" do
+      vm = Quickjs::VM.new(features: [::Quickjs::POLYFILL_CRYPTO])
+      vm.eval_code("globalThis.k = await crypto.subtle.generateKey({name: 'HMAC', hash: 'SHA-256'}, false, ['sign', 'verify'])")
+      _(vm.eval_code("(await crypto.subtle.sign('HMAC', globalThis.k, new Uint8Array([1, 2, 3]))).byteLength")).must_equal 32
+      vm.eval_code('delete globalThis.k; 1')
+
+      found = vm.eval_code(<<~JS)
+        let found = 'none';
+        for (let i = 1; i < 5000; i++) {
+          try {
+            const s = await crypto.subtle.sign('HMAC', {rb_object_id: i}, new Uint8Array([1, 2, 3]));
+            if (s) { found = 'recovered at ' + i; break }
+          } catch (e) {}
+        }
+        found
+      JS
+
+      _(found).must_equal 'none'
+    ensure
+      vm&.dispose!
+    end
+    # Both writers below define rather than assign, so a getter the guest puts
+    # on a prototype cannot answer in their place.
+    it "does not let a guest's Error.prototype answer for a rejection" do
+      vm = Quickjs::VM.new(features: [Quickjs::POLYFILL_CRYPTO])
+      vm.eval_code(<<~JS)
+        Object.defineProperty(Error.prototype, 'message', { set(v) {}, get() { return 'ghost' }, configurable: true });
+      JS
+
+      message = vm.eval_code(<<~JS)
+        let m = 'none';
+        try { await crypto.subtle.importKey('raw', new Uint8Array(16), { name: 'NOPE' }, true, ['sign']) }
+        catch (e) { m = e.message }
+        m
+      JS
+
+      _(message).must_include 'NOPE'
+    ensure
+      vm&.dispose!
+    end
+
+    it "does not let a guest's Object.prototype describe a key's algorithm" do
+      vm = Quickjs::VM.new(features: [::Quickjs::POLYFILL_CRYPTO])
+      vm.eval_code(<<~JS)
+        Object.defineProperty(Object.prototype, 'name',   { set() {}, get() { return 'POISON' }, configurable: true });
+        Object.defineProperty(Object.prototype, 'length', { set() {}, get() { return 4096 }, configurable: true });
+      JS
+
+      described = vm.eval_code(<<~JS)
+        const k = await crypto.subtle.generateKey({ name: 'AES-GCM', length: 128 }, false, ['encrypt']);
+        [k.algorithm.name, k.algorithm.length, Object.getOwnPropertyNames(k.algorithm).sort().join(',')].join('|')
+      JS
+
+      _(described).must_equal 'AES-GCM|128|length,name'
+    ensure
+      vm&.dispose!
+    end
+
+    # A key that could not be built is a rejection, never a resolution carrying
+    # the exception sentinel: typeof reads "unknown" for that and the guest can
+    # neither name it nor tell it apart from a key.
+    # Describing a key runs StringValueCStr, which raises on a non-String, out
+    # of a JSCFunction. Nothing is registered until the description is finished,
+    # so a raise there cannot leave a row anchoring the key.
+    # A usages member that is not a String converts through to_str, which runs
+    # Ruby and can raise. It is converted before anything is drawn or
+    # allocated, so the raise cannot orphan a row.
+    it "anchors nothing when a usages member raises on conversion" do
+      vm = Quickjs::VM.new(features: [::Quickjs::POLYFILL_CRYPTO])
+      late = Class.new { def to_str = raise(ArgumentError, 'late') }
+      malformed = Class.new(::Quickjs::CryptoKey)
+
+      ::Quickjs::SubtleCrypto.singleton_class.alias_method(:generate_key_before_stub, :generate_key)
+      ::Quickjs::SubtleCrypto.define_singleton_method(:generate_key) do |_algo, _extractable, _usages|
+        malformed.allocate.tap do |k|
+          k.instance_variable_set(:@key_data, 'x' * 16)
+          k.instance_variable_set(:@type, 'secret')
+          k.instance_variable_set(:@extractable, false)
+          k.instance_variable_set(:@algorithm, { 'name' => 'AES-GCM' })
+          k.instance_variable_set(:@usages, [late.new])
+        end
+      end
+
+      20.times do
+        vm.eval_code("try { await crypto.subtle.generateKey({ name: 'AES-GCM', length: 128 }, false, ['encrypt']) } catch (e) {} 1") rescue nil
+      end
+
+      GC.start(full_mark: true, immediate_sweep: true)
+      before = ObjectSpace.each_object(malformed).count
+      vm.dispose!
+      GC.start(full_mark: true, immediate_sweep: true)
+
+      _(before - ObjectSpace.each_object(malformed).count).must_equal 0
+    ensure
+      ::Quickjs::SubtleCrypto.singleton_class.alias_method(:generate_key, :generate_key_before_stub)
+      ::Quickjs::SubtleCrypto.singleton_class.remove_method(:generate_key_before_stub)
+      vm&.dispose! unless vm&.disposed?
+    end
+
+    it "anchors nothing when describing the key raises" do
+      vm = Quickjs::VM.new(features: [::Quickjs::POLYFILL_CRYPTO])
+      malformed = Class.new(::Quickjs::CryptoKey) do
+        def type = 42
+      end
+
+      ::Quickjs::SubtleCrypto.singleton_class.alias_method(:generate_key_before_stub, :generate_key)
+      ::Quickjs::SubtleCrypto.define_singleton_method(:generate_key) do |_algo, _extractable, _usages|
+        malformed.new('secret', type: 'secret', extractable: false, algorithm: { 'name' => 'AES-GCM' }, usages: ['encrypt'])
+      rescue ArgumentError
+        malformed.allocate.tap do |k|
+          k.instance_variable_set(:@key_data, 'x' * 16)
+          k.instance_variable_set(:@extractable, false)
+          k.instance_variable_set(:@algorithm, { 'name' => 'AES-GCM' })
+          k.instance_variable_set(:@usages, ['encrypt'])
+        end
+      end
+
+      20.times do
+        vm.eval_code("try { await crypto.subtle.generateKey({ name: 'AES-GCM', length: 128 }, false, ['encrypt']) } catch (e) {} 1") rescue nil
+      end
+
+      GC.start(full_mark: true, immediate_sweep: true)
+      before = ObjectSpace.each_object(malformed).count
+      vm.dispose!
+      GC.start(full_mark: true, immediate_sweep: true)
+
+      _(before - ObjectSpace.each_object(malformed).count).must_equal 0
+    ensure
+      ::Quickjs::SubtleCrypto.singleton_class.alias_method(:generate_key, :generate_key_before_stub)
+      ::Quickjs::SubtleCrypto.singleton_class.remove_method(:generate_key_before_stub)
+      vm&.dispose! unless vm&.disposed?
+    end
+
+    it "rejects rather than resolving with a key it could not build" do
+      vm = Quickjs::VM.new(features: [::Quickjs::POLYFILL_CRYPTO])
+      vm.define_function(:boom) { raise IOError, 'host' }
+
+      SecureRandom.singleton_class.alias_method(:random_number_before_stub, :random_number)
+      SecureRandom.define_singleton_method(:random_number) { |_limit| 4 }
+      # Takes the one handle that source can draw, so the key cannot have one.
+      vm.eval_code('try { boom() } catch (e) {} 1')
+
+      single = vm.eval_code(<<~JS)
+        let o = 'none';
+        try { const k = await crypto.subtle.generateKey({ name: 'AES-GCM', length: 128 }, true, ['encrypt']); o = 'resolved ' + typeof k }
+        catch (e) { o = 'rejected' }
+        o
+      JS
+
+      _(single).must_equal 'rejected'
+    ensure
+      SecureRandom.singleton_class.alias_method(:random_number, :random_number_before_stub)
+      SecureRandom.singleton_class.remove_method(:random_number_before_stub)
+      vm&.dispose!
+    end
+
+    it "rejects rather than resolving with half a key pair" do
+      vm = Quickjs::VM.new(features: [::Quickjs::POLYFILL_CRYPTO])
+      vm.define_function(:boom) { raise IOError, 'host' }
+
+      SecureRandom.singleton_class.alias_method(:random_number_before_stub, :random_number)
+      SecureRandom.define_singleton_method(:random_number) { |_limit| 4 }
+      vm.eval_code('try { boom() } catch (e) {} 1')
+
+      pair = vm.eval_code(<<~JS)
+        let o = 'none';
+        try { const p = await crypto.subtle.generateKey({ name: 'ECDSA', namedCurve: 'P-256' }, true, ['sign', 'verify']); o = 'resolved ' + typeof p.privateKey }
+        catch (e) { o = 'rejected' }
+        o
+      JS
+
+      _(pair).must_equal 'rejected'
+    ensure
+      SecureRandom.singleton_class.alias_method(:random_number, :random_number_before_stub)
+      SecureRandom.singleton_class.remove_method(:random_number_before_stub)
+      vm&.dispose!
+    end
+
+    it "does not let a guest's Array.prototype answer for a key's usages" do
+      vm = Quickjs::VM.new(features: [::Quickjs::POLYFILL_CRYPTO])
+      # An index property, which costs the fast array path and sends the
+      # element write through the chain like a named one.
+      vm.eval_code("Object.defineProperty(Array.prototype, 0, { set() {}, get() { return 'decrypt' }, configurable: true }); 1")
+
+      described = vm.eval_code(<<~JS)
+        const k = await crypto.subtle.generateKey({ name: 'AES-GCM', length: 128 }, false, ['encrypt']);
+        [k.usages.length, k.usages[0], JSON.stringify(k.usages)].join('|')
+      JS
+
+      _(described).must_equal '1|encrypt|["encrypt"]'
+    ensure
+      vm&.dispose!
+    end
+
+    it "does not let a guest's Object.prototype stand in for a private key" do
+      vm = Quickjs::VM.new(features: [::Quickjs::POLYFILL_CRYPTO])
+      vm.eval_code(<<~JS)
+        Object.defineProperty(Object.prototype, 'privateKey', { set() {}, get() { return 'POISON' }, configurable: true });
+      JS
+
+      described = vm.eval_code(<<~JS)
+        const pair = await crypto.subtle.generateKey({ name: 'ECDSA', namedCurve: 'P-256' }, true, ['sign', 'verify']);
+        [typeof pair.privateKey, Object.getOwnPropertyNames(pair).sort().join(',')].join('|')
+      JS
+
+      _(described).must_equal 'object|privateKey,publicKey'
+    ensure
+      vm&.dispose!
+    end
+
+    it "does not let a guest's Object.prototype describe a key we handed out" do
+      vm = Quickjs::VM.new(features: [Quickjs::POLYFILL_CRYPTO])
+      vm.eval_code(<<~JS)
+        for (const name of ['type', 'extractable', 'algorithm', 'usages']) {
+          Object.defineProperty(Object.prototype, name, { get() { return 'POISON' }, configurable: true });
+        }
+      JS
+
+      described = vm.eval_code(<<~JS)
+        const key = await crypto.subtle.generateKey({ name: 'AES-GCM', length: 256 }, false, ['encrypt']);
+        [key.type, key.extractable, JSON.stringify(key.usages), key.algorithm.name].join('|')
+      JS
+
+      _(described).must_equal 'secret|false|["encrypt"]|AES-GCM'
+    ensure
+      vm&.dispose!
+    end
+
 end

--- a/test/quickjs_crypto_subtle_key_test.rb
+++ b/test/quickjs_crypto_subtle_key_test.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 require_relative "test_helper"
+require "fileutils"
+require "tmpdir"
+require "open3"
 
 describe "crypto.subtle key management" do
   before do
@@ -185,6 +188,27 @@ describe "crypto.subtle key management" do
     # Describing a key runs StringValueCStr, which raises on a non-String, out
     # of a JSCFunction. Nothing is registered until the description is finished,
     # so a raise there cannot leave a row anchoring the key.
+    # The handle read is own data, so an accessor on Object.prototype cannot
+    # answer it: a bare object carrying no handle is not a key, whatever the
+    # prototype says.
+    it "does not let an inherited handle sign with a key it never carried" do
+      vm = Quickjs::VM.new(features: [::Quickjs::POLYFILL_CRYPTO])
+
+      outcome = vm.eval_code(<<~JS)
+        const k = await crypto.subtle.generateKey({ name: 'HMAC', hash: 'SHA-256' }, false, ['sign', 'verify']);
+        globalThis.H = k.rb_object_id;
+        Object.defineProperty(Object.prototype, 'rb_object_id', { get() { return globalThis.H }, configurable: true });
+        let o = 'none';
+        try { await crypto.subtle.sign('HMAC', {}, new Uint8Array([1, 2, 3])); o = 'signed' }
+        catch (e) { o = 'refused' }
+        o
+      JS
+
+      _(outcome).must_equal 'refused'
+    ensure
+      vm&.dispose!
+    end
+
     # A usages member that is not a String converts through to_str, which runs
     # Ruby and can raise. It is converted before anything is drawn or
     # allocated, so the raise cannot orphan a row.
@@ -348,5 +372,165 @@ describe "crypto.subtle key management" do
     ensure
       vm&.dispose!
     end
+    # The handle is read off whatever the guest passes as the key argument, so
+    # unlike the File proxy's closure-captured one it is the guest's to choose.
+    # An id belonging to another entry used to reach the operation as a key.
+    it "refuses an id that belongs to something else in the table" do
+      vm = Quickjs::VM.new(features: [::Quickjs::POLYFILL_CRYPTO])
+      vm.define_function(:boom) { raise ArgumentError, 'host' }
+      vm.eval_code("globalThis.id = null; try { boom() } catch (e) { globalThis.id = e.rb_object_id }")
+      # Without this the id could go undefined and the pre-existing handle <= 0
+      # check would produce the same message, leaving the test guarding nothing.
+      _(vm.eval_code("typeof globalThis.id")).must_equal 'number'
 
+      error = _ { vm.eval_code("await crypto.subtle.sign('HMAC', {rb_object_id: globalThis.id}, new Uint8Array([1, 2, 3]))") }
+        .must_raise Quickjs::TypeError
+      _(error.message).must_match(/invalid CryptoKey/)
+    ensure
+      vm&.dispose!
+    end
+    # Guards against re-introducing a cache rather than pinning the lookup as
+    # it stands: a class held only by a constant table is movable, so a C
+    # static would keep an address the collector has since handed on. Passes
+    # either way today, since nothing is cached.
+    it "keeps working across a compaction" do
+      vm = Quickjs::VM.new(features: [::Quickjs::POLYFILL_CRYPTO])
+      vm.eval_code("globalThis.k = await crypto.subtle.generateKey({name: 'HMAC', hash: 'SHA-256'}, true, ['sign', 'verify'])")
+      sign = "(await crypto.subtle.sign('HMAC', globalThis.k, new Uint8Array([1, 2, 3]))).byteLength"
+      _(vm.eval_code(sign)).must_equal 32
+
+      5.times { GC.compact }
+
+      _(vm.eval_code(sign)).must_equal 32
+    ensure
+      vm&.dispose!
+    end
+    # The lookup runs inside a QuickJS native callback with no rb_protect
+    # between it and the interpreter, so it must answer rather than raise when
+    # the Ruby layer that defines the class has not been loaded. Requiring the
+    # extension on its own is enough to get there, and a NameError from here
+    # longjmps through QuickJS's frames past the JS values they still hold.
+    # rb_const_defined_at answers true for a registered autoload, and the
+    # rb_const_get after it would run the autoload body from inside the
+    # callback, which is the raise this lookup exists to not make.
+    it "answers invalid CryptoKey rather than running an autoload" do
+      dir = Dir.mktmpdir('quickjs-autoload')
+      body = File.join(dir, 'raising_autoload.rb')
+      File.write(body, "raise 'autoload body'")
+
+      script = <<~RUBY
+        require "quickjs"
+        Quickjs.send(:remove_const, :CryptoKey)
+        Quickjs.autoload(:CryptoKey, #{body.inspect})
+
+        vm = Quickjs::VM.new(features: [Quickjs::POLYFILL_CRYPTO])
+        vm.define_function(:boom) { raise ArgumentError, 'host' }
+        vm.eval_code("globalThis.id = null; try { boom() } catch (e) { globalThis.id = e.rb_object_id }")
+        abort "no id was planted" unless vm.eval_code("typeof globalThis.id") == 'number'
+        begin
+          vm.eval_code('await crypto.subtle.sign("HMAC", {rb_object_id: globalThis.id}, new Uint8Array([1]))')
+          puts "no raise"
+        rescue Exception => e
+          puts "\#{e.class}: \#{e.message}"
+        end
+      RUBY
+
+      lib = File.expand_path('../lib', __dir__)
+      out, status = Open3.capture2e(RbConfig.ruby, '-I', lib, '-e', script)
+
+      _(out).must_match(/Quickjs::TypeError: .*invalid CryptoKey/)
+      _(status).must_be :success?
+    ensure
+      FileUtils.remove_entry(dir) if dir
+    end
+    it "answers invalid CryptoKey when Quickjs::CryptoKey is not defined" do
+      script = <<~RUBY
+        require "quickjs/quickjsrb"
+        abort "CryptoKey should not be loaded" if Quickjs.const_defined?(:CryptoKey)
+        vm = Quickjs::VM.new(features: [Quickjs::POLYFILL_CRYPTO])
+        # A real entry rather than a made-up id: 1 is in no table, so the nil
+        # hash hit alone would satisfy the callers and the class lookup would
+        # never be reached.
+        vm.define_function(:boom) { raise ArgumentError, 'host' }
+        vm.eval_code("globalThis.id = null; try { boom() } catch (e) { globalThis.id = e.rb_object_id }")
+        abort "no id was planted" unless vm.eval_code("typeof globalThis.id") == 'number'
+        begin
+          vm.eval_code('await crypto.subtle.sign("HMAC", {rb_object_id: globalThis.id}, new Uint8Array([1]))')
+          puts "no raise"
+        rescue Exception => e
+          puts "\#{e.class}: \#{e.message}"
+        end
+      RUBY
+
+      lib = File.expand_path('../lib', __dir__)
+      out, status = Open3.capture2e(RbConfig.ruby, '-I', lib, '-e', script)
+      # Asserted before the exit status so the abort guard's own message, or a
+      # LoadError, is what a failure reports rather than "expected success?".
+      _(out).must_match(/Quickjs::TypeError: .*invalid CryptoKey/)
+      _(status).must_be :success?
+    end
+    # Every property of the algorithm and of the key is a read the guest can
+    # answer with a getter, and a getter that reaches a bridge parks the host's
+    # exception on the way out. A reader that skips the throw without draining
+    # it leaves one behind per read.
+    it "does not park a host exception raised by a getter it reads" do
+      vm = Quickjs::VM.new(features: [::Quickjs::POLYFILL_CRYPTO])
+      # cause: nil keeps the count independent of #126, where a raise chains to
+      # whatever the bridge left in $! and holds that chain reachable from
+      # errinfo however little the VM parked. It is belt and braces for this
+      # shape, whose calls are awaited and see $! nil in the block; it is
+      # load-bearing for a repeated synchronous `try { boom() } catch {}`.
+      vm.define_function(:boom) { raise IOError.new('host'), cause: nil }
+      vm.eval_code("globalThis.k = await crypto.subtle.generateKey({name: 'HMAC', hash: 'SHA-256'}, true, ['sign', 'verify'])")
+
+      shapes = [
+        "await crypto.subtle.sign({get name() { boom() }}, globalThis.k, new Uint8Array([1]))",
+        "await crypto.subtle.sign('HMAC', {get rb_object_id() { boom() }}, new Uint8Array([1]))",
+        "await crypto.subtle.importKey('raw', new Uint8Array(16), {name: 'HMAC', get hash() { boom() }}, true, ['sign'])",
+        "await crypto.subtle.generateKey({name: 'AES-GCM', get length() { boom() }}, true, ['encrypt'])",
+        "await crypto.subtle.encrypt({name: 'AES-GCM', get iv() { boom() }}, globalThis.k, new Uint8Array([1]))",
+        # keyUsages is read the same way the algorithm is.
+        "await crypto.subtle.generateKey({name: 'HMAC', hash: 'SHA-256'}, true, {get length() { boom() }})",
+        "await crypto.subtle.generateKey({name: 'HMAC', hash: 'SHA-256'}, true, {length: 1, get 0() { boom() }})",
+        # A throw whose own rb_object_id getter reaches the bridge, so draining
+        # it is itself a read that can park one.
+        "const mk = () => { const o = {}; Object.defineProperty(o, 'rb_object_id', {get() { boom() }}); return o };" \
+          "const bad = {}; Object.defineProperty(bad, 'rb_object_id', {get() { throw mk() }});" \
+          "await crypto.subtle.sign('HMAC', bad, new Uint8Array([1]))",
+      ]
+      shapes.each { |js| 20.times { vm.eval_code("try { #{js} } catch (e) {}") } }
+
+      GC.start(full_mark: true, immediate_sweep: true)
+      before = ObjectSpace.each_object(IOError).count
+      vm.dispose!
+      GC.start(full_mark: true, immediate_sweep: true)
+
+      _(before - ObjectSpace.each_object(IOError).count).must_equal 0
+    ensure
+      vm&.dispose! unless vm&.disposed?
+    end
+    # The drain drops the throw, so nothing will carry the host exception out
+    # and its anchor would only be a leak. A guest that kept its own reference
+    # can still rethrow the object; what it has then is the message, not the
+    # class. j_rethrow_the_guests_own makes the opposite trade because it hands
+    # the throw back rather than dropping it.
+    it "keeps the message but not the class of an error the guest saved" do
+      vm = Quickjs::VM.new(features: [::Quickjs::POLYFILL_CRYPTO])
+      vm.define_function(:boom) { raise ArgumentError, 'host secret' }
+      vm.eval_code("globalThis.k = await crypto.subtle.generateKey({name: 'HMAC', hash: 'SHA-256'}, true, ['sign', 'verify'])")
+      vm.eval_code(<<~JS)
+        globalThis.saved = null;
+        try {
+          await crypto.subtle.sign({name: 'HMAC', get length() { try { boom() } catch (e) { saved = e; throw e } }}, globalThis.k, new Uint8Array([1]));
+        } catch (e) {}
+        1
+      JS
+
+      error = _ { vm.eval_code('throw globalThis.saved') }.must_raise Quickjs::RuntimeError
+
+      _(error.message).must_equal 'host secret'
+      _(error).wont_be_kind_of ArgumentError
+    ensure
+      vm&.dispose!
+    end
 end

--- a/test/quickjs_polyfill_test.rb
+++ b/test/quickjs_polyfill_test.rb
@@ -534,6 +534,80 @@ describe "RubyFileProxy" do
       vm&.dispose!
     end
   end
+  # The proxy publishes its rb_object_id to the guest, and a thrown error
+  # carrying that id used to reach the same table the exception bridge reads,
+  # which deletes what it finds. The File stayed an instance of File and
+  # answered undefined for everything.
+  describe "when the guest throws the proxy's own rb_object_id" do
+    before do
+      @vm = Quickjs::VM.new(features: [Quickjs::POLYFILL_FILE])
+      @vm.define_function(:get_file) { @file }
+      @vm.eval_code('globalThis.h = get_file();')
+    end
+
+    after { @vm.dispose! }
+
+    it "leaves the file readable" do
+      # Broadly, so that what fails when the guard goes is the readability
+      # below rather than the class of the throw, which the test after this
+      # one is for.
+      _ { @vm.eval_code('throw Object.assign(new Error("guest"), {rb_object_id: globalThis.h.rb_object_id})') }
+        .must_raise Exception
+
+      _(@vm.eval_code('globalThis.h.name')).must_equal File.basename(@file.path)
+      _(@vm.eval_code('globalThis.h.size')).must_equal 'hello world'.bytesize
+    end
+
+    it "reports the forged throw as the guest's own error" do
+      error = _ { @vm.eval_code('throw Object.assign(new Error("guest"), {rb_object_id: globalThis.h.rb_object_id})') }
+        .must_raise Quickjs::RuntimeError
+
+      _(error.message).must_equal 'guest'
+    end
+  end
+  # slice converts its bounds with JS_ToInt64, which runs the guest's valueOf.
+  # An unchecked failure parked whatever a bridge raised there and then used an
+  # uninitialised offset.
+  describe "slice with a bound the guest computes" do
+    it "gives the guest back its own error" do
+      vm = Quickjs::VM.new(features: [Quickjs::POLYFILL_FILE])
+      vm.define_function(:get_file) { @file }
+      vm.eval_code('globalThis.h = get_file();')
+
+      message = vm.eval_code("let m = 'none'; try { globalThis.h.slice({valueOf() { throw new Error('no') }}, 5) } catch (e) { m = e.message } m")
+
+      _(message).must_equal 'no'
+    ensure
+      vm&.dispose!
+    end
+
+    # The throw goes back into JS carrying its handle, which is what lets it
+    # come out the other side as the host exception it started as. Unparking it
+    # here would hand the caller a generic Quickjs::RuntimeError instead.
+    it "still reports the host exception the bound raised" do
+      vm = Quickjs::VM.new(features: [Quickjs::POLYFILL_FILE])
+      vm.define_function(:boom) { raise ArgumentError, 'host' }
+      vm.define_function(:get_file) { @file }
+      vm.eval_code('globalThis.h = get_file();')
+
+      error = _ { vm.eval_code("globalThis.h.slice({valueOf() { boom() }}, 5)") }.must_raise ArgumentError
+
+      _(error.message).must_equal 'host'
+    ensure
+      vm&.dispose!
+    end
+
+    it "still slices when the bounds are ordinary" do
+      vm = Quickjs::VM.new(features: [Quickjs::POLYFILL_FILE])
+      vm.define_function(:get_file) { @file }
+      vm.eval_code('globalThis.h = get_file();')
+
+      _(vm.eval_code('await globalThis.h.slice(0, 5).text()')).must_equal 'hello'
+      _(vm.eval_code('await globalThis.h.slice(-5).text()')).must_equal 'world'
+    ensure
+      vm&.dispose!
+    end
+  end
 end
 
 describe "JS File to Ruby" do

--- a/test/quickjs_polyfill_test.rb
+++ b/test/quickjs_polyfill_test.rb
@@ -355,6 +355,35 @@ describe "RubyFileProxy" do
   end
 
   describe "with POLYFILL_FILE feature" do
+    # The proxy factory takes File.prototype at init rather than reading
+    # globalThis.File per crossing, which happens after guest code.
+    it "stays an instance of the real File when the guest replaces the name" do
+      vm = Quickjs::VM.new(features: [Quickjs::POLYFILL_FILE])
+      vm.define_function(:get_file) { @file }
+      vm.eval_code("globalThis.RealFile = File; globalThis.File = class Fake {}; 1")
+
+      shape = vm.eval_code(<<~JS)
+        const x = get_file();
+        [x instanceof RealFile, x instanceof File, Object.getPrototypeOf(x) === RealFile.prototype].join('|')
+      JS
+
+      _(shape).must_equal 'true|false|true'
+      # And the bridge still answers, which was never the broken part.
+      _(vm.eval_code('get_file().name')).must_equal File.basename(@file.path)
+    end
+
+    # slice builds its result with JS_NewTypedArray and the Blob constructor
+    # captured at init, so replacing the global names does not reach it. The
+    # Blob polyfill itself still reads Uint8Array from the global, which is why
+    # only Blob is poisoned here: that one is entirely ours to answer for.
+    it "builds a slice through a Blob constructor the guest cannot replace" do
+      vm = Quickjs::VM.new(features: [Quickjs::POLYFILL_FILE])
+      vm.define_function(:get_file) { @file }
+      vm.eval_code("globalThis.Blob = function () { throw new Error('nope') }; 1")
+
+      _(vm.eval_code("get_file().slice(0, 5).size")).must_equal 5
+    end
+
     it "is an instance of File" do
       vm = Quickjs::VM.new(features: [Quickjs::POLYFILL_FILE])
       vm.define_function(:get_file) { @file }
@@ -485,86 +514,7 @@ describe "RubyFileProxy" do
       _(result).must_include '#<File:'
     end
   end
-  # One entry per object rather than per crossing. The handle used to be the
-  # object_id, so re-bridging overwrote its own row; a fresh draw each time
-  # would add one instead, and nothing is ever removed from the table.
-  describe "crossing into JS more than once" do
-    it "keeps one handle for one object" do
-      vm = Quickjs::VM.new(features: [Quickjs::POLYFILL_FILE])
-      vm.define_function(:get_file) { @file }
 
-      first = vm.eval_code('get_file().rb_object_id')
-      _(vm.eval_code("for (let i = 0; i < 500; i++) get_file(); get_file().rb_object_id")).must_equal first
-      _(first).must_be :>, 0
-    ensure
-      vm&.dispose!
-    end
-
-    it "still converts back to the same Ruby object" do
-      vm = Quickjs::VM.new(features: [Quickjs::POLYFILL_FILE])
-      vm.define_function(:get_file) { @file }
-      vm.define_function(:same) { |x| x.equal?(@file) }
-
-      _(vm.eval_code('get_file(); same(get_file())')).must_equal true
-    ensure
-      vm&.dispose!
-    end
-  end
-  # The handle used to be the Ruby object_id, a small sequential integer that
-  # nothing ever removes from the table, so a later script could walk the space
-  # and be handed a File it had never held.
-  describe "when a later script scans the handle space" do
-    it "does not hand back a file it was never given" do
-      vm = Quickjs::VM.new(features: [Quickjs::POLYFILL_FILE])
-      vm.define_function(:get_file) { @file }
-      vm.define_function(:take) { |x| x.is_a?(::File) ? "FILE:#{x.read}" : x.class.to_s }
-      vm.eval_code('get_file(); 1')
-
-      found = vm.eval_code(<<~JS)
-        let found = 'none';
-        for (let i = 1; i < 4000; i++) {
-          const got = take({rb_object_id: i});
-          if (typeof got === 'string' && got.startsWith('FILE:')) { found = 'recovered at ' + i; break }
-        }
-        found
-      JS
-
-      _(found).must_equal 'none'
-    ensure
-      vm&.dispose!
-    end
-  end
-  # The proxy publishes its rb_object_id to the guest, and a thrown error
-  # carrying that id used to reach the same table the exception bridge reads,
-  # which deletes what it finds. The File stayed an instance of File and
-  # answered undefined for everything.
-  describe "when the guest throws the proxy's own rb_object_id" do
-    before do
-      @vm = Quickjs::VM.new(features: [Quickjs::POLYFILL_FILE])
-      @vm.define_function(:get_file) { @file }
-      @vm.eval_code('globalThis.h = get_file();')
-    end
-
-    after { @vm.dispose! }
-
-    it "leaves the file readable" do
-      # Broadly, so that what fails when the guard goes is the readability
-      # below rather than the class of the throw, which the test after this
-      # one is for.
-      _ { @vm.eval_code('throw Object.assign(new Error("guest"), {rb_object_id: globalThis.h.rb_object_id})') }
-        .must_raise Exception
-
-      _(@vm.eval_code('globalThis.h.name')).must_equal File.basename(@file.path)
-      _(@vm.eval_code('globalThis.h.size')).must_equal 'hello world'.bytesize
-    end
-
-    it "reports the forged throw as the guest's own error" do
-      error = _ { @vm.eval_code('throw Object.assign(new Error("guest"), {rb_object_id: globalThis.h.rb_object_id})') }
-        .must_raise Quickjs::RuntimeError
-
-      _(error.message).must_equal 'guest'
-    end
-  end
   # slice converts its bounds with JS_ToInt64, which runs the guest's valueOf.
   # An unchecked failure parked whatever a bridge raised there and then used an
   # uninitialised offset.
@@ -606,6 +556,89 @@ describe "RubyFileProxy" do
       _(vm.eval_code('await globalThis.h.slice(-5).text()')).must_equal 'world'
     ensure
       vm&.dispose!
+    end
+  end
+
+  # One entry per object rather than per crossing. The handle used to be the
+  # object_id, so re-bridging overwrote its own row; a fresh draw each time
+  # would add one instead, and nothing is ever removed from the table.
+  describe "crossing into JS more than once" do
+    it "keeps one handle for one object" do
+      vm = Quickjs::VM.new(features: [Quickjs::POLYFILL_FILE])
+      vm.define_function(:get_file) { @file }
+
+      first = vm.eval_code('get_file().rb_object_id')
+      _(vm.eval_code("for (let i = 0; i < 500; i++) get_file(); get_file().rb_object_id")).must_equal first
+      _(first).must_be :>, 0
+    ensure
+      vm&.dispose!
+    end
+
+    it "still converts back to the same Ruby object" do
+      vm = Quickjs::VM.new(features: [Quickjs::POLYFILL_FILE])
+      vm.define_function(:get_file) { @file }
+      vm.define_function(:same) { |x| x.equal?(@file) }
+
+      _(vm.eval_code('get_file(); same(get_file())')).must_equal true
+    ensure
+      vm&.dispose!
+    end
+  end
+
+  # The handle used to be the Ruby object_id, a small sequential integer that
+  # nothing ever removes from the table, so a later script could walk the space
+  # and be handed a File it had never held.
+  describe "when a later script scans the handle space" do
+    it "does not hand back a file it was never given" do
+      vm = Quickjs::VM.new(features: [Quickjs::POLYFILL_FILE])
+      vm.define_function(:get_file) { @file }
+      vm.define_function(:take) { |x| x.is_a?(::File) ? "FILE:#{x.read}" : x.class.to_s }
+      vm.eval_code('get_file(); 1')
+
+      found = vm.eval_code(<<~JS)
+        let found = 'none';
+        for (let i = 1; i < 4000; i++) {
+          const got = take({rb_object_id: i});
+          if (typeof got === 'string' && got.startsWith('FILE:')) { found = 'recovered at ' + i; break }
+        }
+        found
+      JS
+
+      _(found).must_equal 'none'
+    ensure
+      vm&.dispose!
+    end
+  end
+
+  # The proxy publishes its rb_object_id to the guest, and a thrown error
+  # carrying that id used to reach the same table the exception bridge reads,
+  # which deletes what it finds. The File stayed an instance of File and
+  # answered undefined for everything.
+  describe "when the guest throws the proxy's own rb_object_id" do
+    before do
+      @vm = Quickjs::VM.new(features: [Quickjs::POLYFILL_FILE])
+      @vm.define_function(:get_file) { @file }
+      @vm.eval_code('globalThis.h = get_file();')
+    end
+
+    after { @vm.dispose! }
+
+    it "leaves the file readable" do
+      # Broadly, so that what fails when the guard goes is the readability
+      # below rather than the class of the throw, which the test after this
+      # one is for.
+      _ { @vm.eval_code('throw Object.assign(new Error("guest"), {rb_object_id: globalThis.h.rb_object_id})') }
+        .must_raise Exception
+
+      _(@vm.eval_code('globalThis.h.name')).must_equal File.basename(@file.path)
+      _(@vm.eval_code('globalThis.h.size')).must_equal 'hello world'.bytesize
+    end
+
+    it "reports the forged throw as the guest's own error" do
+      error = _ { @vm.eval_code('throw Object.assign(new Error("guest"), {rb_object_id: globalThis.h.rb_object_id})') }
+        .must_raise Quickjs::RuntimeError
+
+      _(error.message).must_equal 'guest'
     end
   end
 end

--- a/test/quickjs_polyfill_test.rb
+++ b/test/quickjs_polyfill_test.rb
@@ -485,6 +485,55 @@ describe "RubyFileProxy" do
       _(result).must_include '#<File:'
     end
   end
+  # One entry per object rather than per crossing. The handle used to be the
+  # object_id, so re-bridging overwrote its own row; a fresh draw each time
+  # would add one instead, and nothing is ever removed from the table.
+  describe "crossing into JS more than once" do
+    it "keeps one handle for one object" do
+      vm = Quickjs::VM.new(features: [Quickjs::POLYFILL_FILE])
+      vm.define_function(:get_file) { @file }
+
+      first = vm.eval_code('get_file().rb_object_id')
+      _(vm.eval_code("for (let i = 0; i < 500; i++) get_file(); get_file().rb_object_id")).must_equal first
+      _(first).must_be :>, 0
+    ensure
+      vm&.dispose!
+    end
+
+    it "still converts back to the same Ruby object" do
+      vm = Quickjs::VM.new(features: [Quickjs::POLYFILL_FILE])
+      vm.define_function(:get_file) { @file }
+      vm.define_function(:same) { |x| x.equal?(@file) }
+
+      _(vm.eval_code('get_file(); same(get_file())')).must_equal true
+    ensure
+      vm&.dispose!
+    end
+  end
+  # The handle used to be the Ruby object_id, a small sequential integer that
+  # nothing ever removes from the table, so a later script could walk the space
+  # and be handed a File it had never held.
+  describe "when a later script scans the handle space" do
+    it "does not hand back a file it was never given" do
+      vm = Quickjs::VM.new(features: [Quickjs::POLYFILL_FILE])
+      vm.define_function(:get_file) { @file }
+      vm.define_function(:take) { |x| x.is_a?(::File) ? "FILE:#{x.read}" : x.class.to_s }
+      vm.eval_code('get_file(); 1')
+
+      found = vm.eval_code(<<~JS)
+        let found = 'none';
+        for (let i = 1; i < 4000; i++) {
+          const got = take({rb_object_id: i});
+          if (typeof got === 'string' && got.startsWith('FILE:')) { found = 'recovered at ' + i; break }
+        }
+        found
+      JS
+
+      _(found).must_equal 'none'
+    ensure
+      vm&.dispose!
+    end
+  end
 end
 
 describe "JS File to Ruby" do

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -252,6 +252,271 @@ describe Quickjs do
     end
   end
 
+  describe "BridgedErrorHandles" do
+    before do
+      @handle_tempfile = Tempfile.new(['handle', '.txt'])
+      @handle_tempfile.write('hello')
+      @handle_tempfile.flush
+      @handle_file = File.open(@handle_tempfile.path, 'r')
+    end
+
+    after do
+      @handle_file.close
+      @handle_tempfile.close
+      @handle_tempfile.unlink
+    end
+
+    # find_ruby_error reads the handle as an own data property, so it runs no
+    # guest code. A getter would let a thrown object reach a Ruby bridge from
+    # inside the very lookup that exists to take a bridged exception back out.
+    it "does not resolve a handle defined as a getter" do
+      vm = Quickjs::VM.new
+      vm.define_function(:boom) { raise ArgumentError, 'host' }
+      vm.eval_code("globalThis.id = null; try { boom() } catch (e) { globalThis.id = e.rb_object_id }")
+      _(vm.eval_code('typeof globalThis.id')).must_equal 'number'
+
+      # A real Error, because a thrown plain object is turned away for not being
+      # one before the handle is ever read, and would pass this on any build.
+      error = _ {
+        vm.eval_code("throw Object.defineProperty(new Error('g'), 'rb_object_id', {get() { return globalThis.id }})")
+      }.must_raise Quickjs::RuntimeError
+
+      # The guest's own throw, not the host's ArgumentError replayed through it.
+      _(error).wont_be_kind_of ArgumentError
+    ensure
+      vm&.dispose!
+    end
+    # Drawing a handle calls out to SecureRandom, which a host's own suite can
+    # stub flat. Nothing polls a QuickJS interrupt inside a C loop, so an
+    # unbounded retry there is not something timeout_msec can end: before this
+    # was bounded, the second object bridged into the VM span forever and only
+    # an outer Timeout.timeout broke it.
+    #
+    # The refusal is latched rather than raised, and reported from the next
+    # entry point, because raising from inside a JSCFunction leaves the
+    # runtime's frame chain pointing at C stack that is gone and the next Error
+    # the guest builds walks it. The VM stays usable enough to be told off.
+    it "condemns the VM rather than spinning when the source stops being random" do
+      vm = Quickjs::VM.new(timeout_msec: 300)
+      vm.define_function(:boom) { |n| raise IOError, "e#{n}" }
+
+      SecureRandom.singleton_class.alias_method(:random_number_before_stub, :random_number)
+      SecureRandom.define_singleton_method(:random_number) { |_limit| 4 }
+
+      vm.eval_code('try { boom(1) } catch (e) {} 1')
+      # The bridge refuses inside JS rather than unwinding through it.
+      _(vm.eval_code('try { boom(2) } catch (e) { "refused" }')).must_equal 'refused'
+
+      error = _ { vm.eval_code('1') }.must_raise Quickjs::RuntimeError
+      _(error.message).must_match(/distinct usable integers/)
+    ensure
+      SecureRandom.singleton_class.alias_method(:random_number, :random_number_before_stub)
+      SecureRandom.singleton_class.remove_method(:random_number_before_stub)
+      vm&.dispose!
+    end
+
+    # The bound only catches a source that keeps returning the same value. One
+    # that returns something that is not an Integer raises inside the loop,
+    # before the bound is consulted, and that raise is the one that segfaults.
+    # An Integer is not enough: NUM2LL raises RangeError on one too wide for
+    # the handle space, and a negative one is stored under a key every reader
+    # treats as "no entry", which anchors the object and loses the identity of
+    # the exception it was bridging.
+    it "condemns the VM when the source returns a number it cannot use" do
+      [2**100, -5].each do |drawn|
+        vm = Quickjs::VM.new
+        vm.define_function(:boom) { raise IOError, 'host' }
+
+        SecureRandom.singleton_class.alias_method(:random_number_before_stub, :random_number)
+        SecureRandom.define_singleton_method(:random_number) { |_limit| drawn }
+
+        _(vm.eval_code('try { boom() } catch (e) { "refused" }')).must_equal 'refused'
+        _(vm.poisoned?).must_equal true
+
+        error = _ { vm.eval_code('1') }.must_raise Quickjs::RuntimeError
+        _(error.message).must_match(/distinct usable integers/)
+      ensure
+        SecureRandom.singleton_class.alias_method(:random_number, :random_number_before_stub)
+        SecureRandom.singleton_class.remove_method(:random_number_before_stub)
+        vm&.dispose!
+      end
+    end
+
+    it "condemns the VM when the source returns something that is not a number" do
+      vm = Quickjs::VM.new
+      vm.define_function(:boom) { raise IOError, 'host' }
+
+      SecureRandom.singleton_class.alias_method(:random_number_before_stub, :random_number)
+      SecureRandom.define_singleton_method(:random_number) { |_limit| nil }
+
+      _(vm.eval_code('try { boom() } catch (e) { "refused" }')).must_equal 'refused'
+
+      error = _ { vm.eval_code('1') }.must_raise Quickjs::RuntimeError
+      _(error.message).must_match(/distinct usable integers/)
+    ensure
+      SecureRandom.singleton_class.alias_method(:random_number, :random_number_before_stub)
+      SecureRandom.singleton_class.remove_method(:random_number_before_stub)
+      vm&.dispose!
+    end
+
+    # A strict test double raises on an unexpected invocation as readily as a
+    # loose one returns a constant, and the draw is a Ruby dispatch this branch
+    # introduced: a raise out of it would be a new way into #134, where the
+    # frame chain is left stale and the next Error the guest builds walks it.
+    #
+    # It is held rather than swallowed, because rb_protect cannot tell a stubbed
+    # source apart from an Interrupt or a host's own Timeout::Error, and handed
+    # back from the next entry point as itself.
+    it "hands back what was raised at the registrar, from somewhere safe" do
+      vm = Quickjs::VM.new
+      vm.define_function(:boom) { raise IOError, 'host' }
+      vm.eval_code('globalThis.deep = (n) => n === 0 ? boom() : deep(n - 1); 1')
+
+      SecureRandom.singleton_class.alias_method(:random_number_before_stub, :random_number)
+      SecureRandom.define_singleton_method(:random_number) { |_limit| raise Timeout::Error, 'host timeout' }
+
+      # The evaluation in flight finishes rather than unwinding through QuickJS.
+      _(vm.eval_code('try { deep(5) } catch (e) { "caught" }')).must_equal 'caught'
+      # And it is not left as the host's $! either.
+      _($!).must_be_nil
+
+      # Not poisoned by it: the VM is usable, and a host following the README's
+      # recycle path would otherwise discard a healthy one.
+      _(vm.poisoned?).must_equal false
+
+      error = _ { vm.eval_code('1') }.must_raise Timeout::Error
+      _(error.message).must_equal 'host timeout'
+
+      # A passing raise is not a broken handle source, so the VM recovers.
+      SecureRandom.singleton_class.alias_method(:random_number, :random_number_before_stub)
+      SecureRandom.singleton_class.remove_method(:random_number_before_stub)
+      _(vm.eval_code('1 + 1')).must_equal 2
+      _(vm.poisoned?).must_equal false
+
+      # A fresh VM still builds Errors, which is the part that used to segfault.
+      other = Quickjs::VM.new
+      _(other.eval_code("try { throw new Error('x') } catch (e) { e.message }")).must_equal 'x'
+      other.dispose!
+    ensure
+      if SecureRandom.singleton_class.method_defined?(:random_number_before_stub)
+        SecureRandom.singleton_class.alias_method(:random_number, :random_number_before_stub)
+        SecureRandom.singleton_class.remove_method(:random_number_before_stub)
+      end
+      vm&.dispose!
+    end
+
+    # memory_poisoned? answers for out-of-memory only, so a host following the
+    # README's recycle pattern would otherwise hold a VM that looks healthy and
+    # refuses everything.
+    it "says it is poisoned without claiming the memory was" do
+      vm = Quickjs::VM.new
+      vm.define_function(:boom) { raise IOError, 'host' }
+      _(vm.poisoned?).must_equal false
+
+      SecureRandom.singleton_class.alias_method(:random_number_before_stub, :random_number)
+      SecureRandom.define_singleton_method(:random_number) { |_limit| nil }
+      vm.eval_code('try { boom() } catch (e) {} 1') rescue nil
+
+      _(vm.poisoned?).must_equal true
+      _(vm.memory_poisoned?).must_equal false
+    ensure
+      SecureRandom.singleton_class.alias_method(:random_number, :random_number_before_stub)
+      SecureRandom.singleton_class.remove_method(:random_number_before_stub)
+      vm&.dispose!
+    end
+
+    # The raise this replaced could take the process with it: the longjmp skips
+    # QuickJS's own frame-chain restore, and build_backtrace then walks stack
+    # that is gone.
+    it "survives a guest building errors after the handle source broke" do
+      vm = Quickjs::VM.new
+      vm.define_function(:boom) { |n| raise IOError, "e#{n}" }
+      vm.eval_code('globalThis.deep = (n) => n === 0 ? boom(1) : deep(n - 1); 1')
+
+      SecureRandom.singleton_class.alias_method(:random_number_before_stub, :random_number)
+      SecureRandom.define_singleton_method(:random_number) { |_limit| 4 }
+      4.times { vm.eval_code('try { deep(30) } catch (e) {} 1') rescue nil }
+      SecureRandom.singleton_class.alias_method(:random_number, :random_number_before_stub)
+      SecureRandom.singleton_class.remove_method(:random_number_before_stub)
+
+      # Poisoned now, so a fresh VM is what carries on. The point of the test is
+      # that the process reached this line at all.
+      other = Quickjs::VM.new
+      10.times { _(other.eval_code("function g(n){ if (n === 0) throw new Error('x'); return g(n - 1) } try { g(20) } catch (e) { e.message }")).must_equal 'x' }
+      other.dispose!
+    ensure
+      vm&.dispose!
+    end
+
+    # Asking the exception for its message runs Ruby the host wrote, and that
+    # can raise. Registering before it does parks the entry with nothing left
+    # pointing at it.
+    it "parks nothing when reading the message raises" do
+      vm = Quickjs::VM.new
+      nasty = Class.new(StandardError) { def message = "a\0b" }
+      vm.define_function(:boom) { raise nasty }
+
+      20.times { vm.eval_code('try { boom() } catch (e) {}') rescue nil }
+
+      GC.start(full_mark: true, immediate_sweep: true)
+      before = ObjectSpace.each_object(nasty).count
+      vm.dispose!
+      GC.start(full_mark: true, immediate_sweep: true)
+
+      _(before - ObjectSpace.each_object(nasty).count).must_equal 0
+    ensure
+      vm&.dispose! unless vm&.disposed?
+    end
+
+    it "still gives back a bridged exception thrown as it was handed over" do
+      vm = Quickjs::VM.new
+      vm.define_function(:boom) { raise ArgumentError, 'host' }
+
+      error = _ { vm.eval_code("try { boom() } catch (e) { throw e }") }.must_raise ArgumentError
+
+      _(error.message).must_equal 'host'
+    ensure
+      vm&.dispose!
+    end
+    # The handle is written with defineProperty, not assignment, so an accessor
+    # a guest installs on Error.prototype cannot absorb the write and leave the
+    # error without an own one.
+    it "reports the host exception through a poisoned Error.prototype" do
+      vm = Quickjs::VM.new
+      vm.define_function(:boom) { raise ArgumentError, 'host' }
+      vm.eval_code("Object.defineProperty(Error.prototype, 'rb_object_id', {set(v) {}, get() {}}); 1")
+
+      error = _ { vm.eval_code('boom()') }.must_raise ArgumentError
+
+      _(error.message).must_equal 'host'
+    ensure
+      vm&.dispose!
+    end
+    it "shows the guest the same shape a native Error has" do
+      vm = Quickjs::VM.new
+      vm.define_function(:boom) { raise ArgumentError, 'host secret' }
+
+      bridged = vm.eval_code("(() => { try { boom() } catch (e) { return JSON.stringify(e) } })()")
+      native = vm.eval_code("(() => { try { throw new Error('plain') } catch (e) { return JSON.stringify(e) } })()")
+
+      _(bridged).must_equal native
+      # The message is still there to read, only not to enumerate.
+      _(vm.eval_code("(() => { try { boom() } catch (e) { return e.message } })()")).must_equal 'host secret'
+    ensure
+      vm&.dispose!
+    end
+    it "keeps the handle off what the guest enumerates" do
+      vm = Quickjs::VM.new
+      vm.define_function(:boom) { raise ArgumentError, 'host' }
+
+      keys = vm.eval_code("let k = []; try { boom() } catch (e) { k = Object.keys(e) } k.join(',')")
+
+      _(keys).wont_include 'rb_object_id'
+    ensure
+      vm&.dispose!
+    end
+  end
+
   describe "Exceptions" do
     it "throws Quickjs::SyntaxError if SyntaxError happens" do
       err = _ { ::Quickjs.eval_code("}{") }.must_raise Quickjs::SyntaxError

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -286,6 +286,18 @@ describe Quickjs do
     ensure
       vm&.dispose!
     end
+    it "does not ask the guest's Number to convert a Bignum" do
+      vm = Quickjs::VM.new
+      vm.define_function(:big) { 2**70 }
+      vm.define_function(:wrapped) { { 'n' => 2**70, 'other' => 'kept' } }
+      vm.eval_code("globalThis.Number = function () { throw new Error('nope') }; 1")
+
+      _(vm.eval_code("big()")).must_equal (2**70).to_f
+      _(vm.eval_code("JSON.stringify(wrapped())")).must_equal %({"n":#{(2**70).to_f},"other":"kept"})
+    ensure
+      vm&.dispose!
+    end
+
     # Drawing a handle calls out to SecureRandom, which a host's own suite can
     # stub flat. Nothing polls a QuickJS interrupt inside a C loop, so an
     # unbounded retry there is not something timeout_msec can end: before this

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -405,6 +405,24 @@ describe Quickjs do
       vm&.dispose!
     end
 
+    # An accessor on Object.prototype answers a handle read that walks the
+    # prototype chain, and then every object crossing back to Ruby becomes
+    # whichever host object the guest already holds a handle for.
+    it "does not let an inherited handle decide what a value converts to" do
+      vm = Quickjs::VM.new(features: [Quickjs::POLYFILL_FILE])
+      vm.define_function(:get_file) { @handle_file }
+      vm.eval_code('globalThis.H = get_file().rb_object_id; 1')
+
+      converted = vm.eval_code(<<~JS)
+        Object.defineProperty(Object.prototype, 'rb_object_id', { get() { return globalThis.H }, configurable: true });
+        ({ a: 1, b: { c: 2 } })
+      JS
+
+      _(converted).must_equal({ 'a' => 1, 'b' => { 'c' => 2 } })
+    ensure
+      vm&.dispose!
+    end
+
     # memory_poisoned? answers for out-of-memory only, so a host following the
     # README's recycle pattern would otherwise hold a VM that looks healthy and
     # refuses everything.
@@ -422,6 +440,21 @@ describe Quickjs do
     ensure
       SecureRandom.singleton_class.alias_method(:random_number, :random_number_before_stub)
       SecureRandom.singleton_class.remove_method(:random_number_before_stub)
+      vm&.dispose!
+    end
+
+    # The bridge reads rb_errinfo and used not to clear it, so $! survived
+    # eval_code returning normally: later raises chained to it through cause,
+    # and a script that did nothing else exited 1 with a backtrace it never
+    # raised.
+    it "leaves the host's $! alone once the guest has caught the throw" do
+      vm = Quickjs::VM.new
+      vm.define_function(:boom) { raise IOError, 'host' }
+
+      vm.eval_code('try { boom() } catch (e) {} 1')
+
+      _($!).must_be_nil
+    ensure
       vm&.dispose!
     end
 
@@ -468,16 +501,76 @@ describe Quickjs do
       vm&.dispose! unless vm&.disposed?
     end
 
-    it "still gives back a bridged exception thrown as it was handed over" do
+
+    # A Proxy answers a descriptor read with its own trap, so guest code can
+    # run while an error is being recovered. What it throws is taken, including
+    # a host exception it parked on the way, and a trap that throws another
+    # Proxy is refused rather than followed, so the guest does not choose how
+    # far this goes.
+    it "takes what a thrown Proxy's descriptor trap raises, at any nesting" do
       vm = Quickjs::VM.new
-      vm.define_function(:boom) { raise ArgumentError, 'host' }
+      vm.define_function(:boom) { raise IOError.new('host'), cause: nil }
+      vm.eval_code(<<~JS)
+        globalThis.chain = (n) => n === 0
+          ? new Proxy({}, { getOwnPropertyDescriptor() { boom() } })
+          : new Proxy({}, { getOwnPropertyDescriptor() { throw chain(n - 1) } });
+      JS
 
-      error = _ { vm.eval_code("try { boom() } catch (e) { throw e }") }.must_raise ArgumentError
+      [0, 1, 32, 40].each do |depth|
+        20.times { vm.eval_code("globalThis.c = chain(#{depth}); throw { toString() { throw globalThis.c } }") rescue nil }
+      end
 
-      _(error.message).must_equal 'host'
+      GC.start(full_mark: true, immediate_sweep: true)
+      before = ObjectSpace.each_object(IOError).count
+      vm.dispose!
+      GC.start(full_mark: true, immediate_sweep: true)
+
+      _(before - ObjectSpace.each_object(IOError).count).must_equal 0
     ensure
-      vm&.dispose!
+      vm&.dispose! unless vm&.disposed?
     end
+
+    # What counts as a Proxy is settled at init from one this extension builds.
+    # Read off the guest's global instead and a script decides the answer, for
+    # this VM and, when the answer is remembered process-wide, for later ones.
+    it "is not told what a Proxy is by the guest" do
+      poisoned = Quickjs::VM.new
+      poisoned.define_function(:boom) { raise ArgumentError, 'host secret' }
+      poisoned.eval_code('globalThis.Proxy = function () { return new Error("decoy") }; 1')
+      _ { poisoned.eval_code('boom()') }.must_raise ArgumentError
+
+      later = Quickjs::VM.new
+      later.define_function(:boom) { raise ArgumentError, 'host secret' }
+      _ { later.eval_code('boom()') }.must_raise ArgumentError
+    ensure
+      poisoned&.dispose!
+      later&.dispose!
+    end
+
+    it "still knows a Proxy after the guest deletes the constructor" do
+      vm = Quickjs::VM.new
+      vm.define_function(:boom) { raise IOError.new('x'), cause: nil }
+      vm.eval_code('globalThis.P = Proxy; delete globalThis.Proxy;' \
+                   'globalThis.inner = new P({}, { getOwnPropertyDescriptor() { boom() } });' \
+                   'globalThis.c = new P({}, { getOwnPropertyDescriptor() { throw globalThis.inner } }); 1')
+
+      # The outer trap runs; what it throws is a Proxy, so the inner one is
+      # refused rather than followed, and the bridge is never reached.
+      calls_before = 0
+      vm.define_function(:count) { calls_before += 1 }
+      20.times { vm.eval_code('count(); throw { toString() { throw globalThis.c } }') rescue nil }
+      _(calls_before).must_equal 20
+
+      GC.start(full_mark: true, immediate_sweep: true)
+      before = ObjectSpace.each_object(IOError).count
+      vm.dispose!
+      GC.start(full_mark: true, immediate_sweep: true)
+
+      _(before - ObjectSpace.each_object(IOError).count).must_equal 0
+    ensure
+      vm&.dispose! unless vm&.disposed?
+    end
+
     # The handle is written with defineProperty, not assignment, so an accessor
     # a guest installs on Error.prototype cannot absorb the write and leave the
     # error without an own one.
@@ -492,6 +585,21 @@ describe Quickjs do
     ensure
       vm&.dispose!
     end
+
+    # Both properties are defined rather than assigned, so an accessor the guest
+    # installs on Error.prototype cannot absorb either write.
+    it "reports the message through a poisoned Error.prototype" do
+      vm = Quickjs::VM.new
+      vm.define_function(:boom) { raise ArgumentError, 'host secret' }
+      vm.eval_code("Object.defineProperty(Error.prototype, 'message', {set(v) {}, get() { return 'ghost' }, configurable: true}); 1")
+
+      seen = vm.eval_code("let m = 'none'; try { boom() } catch (e) { m = e.message } m")
+
+      _(seen).must_equal 'host secret'
+    ensure
+      vm&.dispose!
+    end
+
     it "shows the guest the same shape a native Error has" do
       vm = Quickjs::VM.new
       vm.define_function(:boom) { raise ArgumentError, 'host secret' }
@@ -505,6 +613,7 @@ describe Quickjs do
     ensure
       vm&.dispose!
     end
+
     it "keeps the handle off what the guest enumerates" do
       vm = Quickjs::VM.new
       vm.define_function(:boom) { raise ArgumentError, 'host' }
@@ -512,6 +621,35 @@ describe Quickjs do
       keys = vm.eval_code("let k = []; try { boom() } catch (e) { k = Object.keys(e) } k.join(',')")
 
       _(keys).wont_include 'rb_object_id'
+    ensure
+      vm&.dispose!
+    end
+
+    # A throw an earlier unchecked read left pending is not one this read
+    # caused, and must not be handed back as the bridged error for whatever is
+    # being converted now.
+    it "does not claim a throw that was already pending" do
+      vm = Quickjs::VM.new
+      vm.define_function(:boom) { raise ArgumentError, 'host-secret' }
+
+      converted = vm.eval_code(<<~JS)
+        const p = new Proxy([], { get(t, k) { if (k === 'length') boom(); return Reflect.get(t, k) } });
+        ({ a: p, e: new Error('plain') })
+      JS
+
+      _(converted['e']).must_equal({})
+      _(converted['e']).wont_be_kind_of Exception
+    ensure
+      vm&.dispose!
+    end
+
+    it "still gives back a bridged exception thrown as it was handed over" do
+      vm = Quickjs::VM.new
+      vm.define_function(:boom) { raise ArgumentError, 'host' }
+
+      error = _ { vm.eval_code("try { boom() } catch (e) { throw e }") }.must_raise ArgumentError
+
+      _(error.message).must_equal 'host'
     ensure
       vm&.dispose!
     end

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -2598,10 +2598,13 @@ end
           attempt = proc { @vm.define_function(['myLib', 'hello']) { 1 } rescue marker }
 
           3.times(&attempt)
-          GC.start
+          # Both sweeps are full and immediate: a plain GC.start leaves enough
+          # of these behind often enough that the count is noise, and the test
+          # then fails on a build that pins nothing.
+          GC.start(full_mark: true, immediate_sweep: true)
           before = ObjectSpace.each_object(marker).count
           200.times(&attempt)
-          GC.start
+          GC.start(full_mark: true, immediate_sweep: true)
 
           _(ObjectSpace.each_object(marker).count - before).must_equal 0
         end

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -298,6 +298,41 @@ describe Quickjs do
       vm&.dispose!
     end
 
+    # A Hash or an Array we build for the guest is filled with defines for the
+    # same reason a bridged error's properties are: an accessor the guest put
+    # on a prototype otherwise takes the value and leaves no own property.
+    it "does not hand a returned Hash's values to a guest's setter" do
+      vm = Quickjs::VM.new
+      vm.define_function(:get_hash) { { 'token' => 'secret' } }
+      vm.eval_code(<<~JS)
+        globalThis.stolen = null;
+        Object.defineProperty(Object.prototype, 'token',
+          { set(v) { globalThis.stolen = v }, get() { return 'GHOST' }, configurable: true });
+      JS
+
+      seen = vm.eval_code("const h = get_hash(); [h.token, Object.getOwnPropertyNames(h).join(','), globalThis.stolen].join('|')")
+
+      _(seen).must_equal 'secret|token|'
+    ensure
+      vm&.dispose!
+    end
+
+    it "does not hand a returned Array's elements to a guest's setter" do
+      vm = Quickjs::VM.new
+      vm.define_function(:get_ary) { [10, 20, 30] }
+      vm.eval_code(<<~JS)
+        globalThis.taken = { n: 0 };
+        Object.defineProperty(Array.prototype, 0,
+          { set(v) { globalThis.taken.n++ }, get() { return 'GHOST' }, configurable: true });
+      JS
+
+      seen = vm.eval_code("const a = get_ary(); [a.length, a[0], globalThis.taken.n].join('|')")
+
+      _(seen).must_equal '3|10|0'
+    ensure
+      vm&.dispose!
+    end
+
     # Drawing a handle calls out to SecureRandom, which a host's own suite can
     # stub flat. Nothing polls a QuickJS interrupt inside a C loop, so an
     # unbounded retry there is not something timeout_msec can end: before this


### PR DESCRIPTION
Closes #113.

`alive_objects` anchors three unrelated things behind one table: a bridged exception waiting to be thrown back, and the Ruby objects behind a `File` or a `CryptoKey` proxy, which stay reachable while the guest holds the proxy. The readers of that table did not agree about what they were allowed to take, and the handle they read was guessable. Seven commits, one subject each.

## Take only what your own subsystem parked

`find_ruby_error` took whatever a handle mapped to and deleted it, so a script that copied a live proxy's handle onto anything throwable severed that proxy:

```ruby
vm.eval_code('globalThis.h = get_file();')
vm.eval_code('throw Object.assign(new Error("guest"), {rb_object_id: globalThis.h.rb_object_id})')
vm.eval_code('globalThis.h.name')   #=> was :undefined, permanently, while still `instanceof File`
```

A `CryptoKey` failed the same way, loudly. The crypto reader had the mirror problem, calling key methods on whatever it was handed and reporting a missing method on a `File` rather than an invalid key.

Reading a handle also stopped running the guest's code, in all three readers. It was an ordinary property read, so a getter answered it and could reach a bridge from inside the lookup that exists to take a bridged exception back out; it is an own data property read now, which is how all three writers define it. That closes a type confusion the other two readers had: with `Object.defineProperty(Object.prototype, 'rb_object_id', {get(){ return aHandleTheGuestHolds }})`, every object crossing back to Ruby became that host `File` or `CryptoKey`, top-level result and nested members alike, and a bare `{}` signed with a key generated `extractable: false`. Both reproduce identically on `main`. A `Proxy` answers even that through its `getOwnPropertyDescriptor` trap, so what the trap throws is taken rather than dropped, and a trap that throws another `Proxy` is refused rather than followed.

The readers that run guest code drain what it throws. A getter on an algorithm property, on a key handle, on a file's slice bounds can reach a bridge, and the bridge parks the host exception on its way out; a reader that skipped the throw and freed the value left it parked for the life of the VM, once per call, at a rate the guest picks. The slice bound is the exception: it hands the throw back to the guest, so the handle has to stay live for the error to arrive as the host exception it started as, and a lapsed budget is re-thrown the way `js_poll_interrupts` throws it rather than downgraded to something catchable.

## Publish a handle a guest cannot walk to

The handle was the Ruby `object_id`: a small sequential integer, in a table nothing ever leaves. So a later script could count.

```ruby
vm.eval_code('get_file(); 1')        # every JS reference dropped
vm.eval_code("for (let i = 1; i < 4000; i++) { const got = take({rb_object_id: i}); ... }")
#=> recovered the Ruby File at 576, and read it
```

The same walk re-acquires a `CryptoKey` after `delete globalThis.k`, including one generated `extractable: false`. Handles come from 2^48 through `SecureRandom` now, with a private reverse map so an object bridged twice keeps one entry, and both rows are deleted together. The retry on a collision is bounded at sixteen draws and then fails loudly, because nothing polls a QuickJS interrupt inside a C loop: a host whose suite stubs `SecureRandom.random_number` flat would otherwise spin forever on the second object it bridges, with `timeout_msec` unable to end it. The refusal is latched and reported from the next entry point rather than raised where it is noticed, the way an out-of-memory already is: a raise from inside a `JSCFunction` unwinds past QuickJS's own frame-chain restore, and the next `Error` the guest builds walks the stale chain in `build_backtrace` and takes the process with it. That crash is **#134** and reproduces identically on `main`. This branch's job is only to not add a new way into it, and the draw is one: it is a Ruby dispatch that did not exist before, and a strict test double raises on an unexpected invocation as readily as a loose one returns a constant. The whole registration runs under `rb_protect`, so a raise from the source, or a `NoMemoryError` from the two hash writes, does not unwind through QuickJS. What it caught is kept rather than discarded and re-raised from the next entry point as itself, because `rb_protect` cannot tell a stubbed source apart from an `Interrupt` or the host's own `Timeout::Error`, and swallowing one of those would lose it with no trace. A passing raise says nothing about the handle source, so it does not latch and the VM recovers. `poisoned?` stays false for it, so a host following the recycle path below does not throw away a healthy VM. With no longjmp there is nothing to strand, which is what an earlier draft of this had to argue around. `js_crypto_key_to_js` also does its four Ruby reads before it registers now, so a raise from one of them cannot leave a row anchoring a key that nothing can reach. A key that could not be built settles its promise as a rejection rather than resolving with the exception sentinel, which `typeof` reads as `"unknown"` and a guest can neither name nor tell apart from a key; the same goes for half a key pair. Every `JS_DefinePropertyValue*` on a key now feeds that decision, so a key missing its `algorithm` is refused rather than handed over for `Object.prototype` to describe. Nothing is registered until the key is fully described, which is what makes the ordering claim true rather than nearly true: describing a key runs `StringValueCStr` and `NUM2INT`, both of which raise, and a raise after registering would leave a row anchoring the Ruby key with nothing able to reach it. A key pair that cannot be completed takes back whichever of its two keys did register, private material included.

Every property we put on an object we hand the guest is *defined* rather than assigned, because `JS_SetPropertyStr` walks the prototype chain. On a bridged error, an accessor on `Error.prototype` absorbed both writes, no own property was created, and every host exception became unreportable and permanently parked on one line of guest setup. The same write reached a rejected `crypto.subtle` call, where a getter answered for why the call failed, and a `CryptoKey`'s own description, where a getter on `Object.prototype` claimed `type`, `extractable`, `algorithm` and `usages`, so a key generated `extractable: false` described itself however the guest liked. It reached one level further down too: `key.algorithm` kept no own property at all, reporting whatever `Object.prototype` said its `name` and `length` were, and a generated key pair's `privateKey` could be absorbed whole, leaving `pair.privateKey` to be any value the guest chose. Elements are not exempt either: an index property on `Array.prototype` costs the fast array path, after which an element write walks the chain like a named one, so `key.usages` came back with `length === 0` and `usages[0]` reading whatever the guest's getter said.

The handle is drawn at the top of that function, next to the message read, rather than after the error is built: drawing it calls `SecureRandom` and writes two hashes, and a raise from any of them would longjmp out of a `JSCFunction` past the values already allocated. The class id the Proxy check compares against is learned once per VM instead of once per `initialize`, which is private but reachable through `send` after guest code has run.

## Keep a key's bytes out of the string a guest gets back

`to_js_value` has no case for `Quickjs::CryptoKey`, so a key crossing back to JS converted through `inspect`, and `inspect` printed every ivar. Any pass-through `define_function` handed the guest the raw AES or HMAC secret of a key generated `extractable: false`, which `exportKey` refuses one call away.

## Build what we hand back without asking the guest for a constructor

The public exponent was handed to JS by calling `globalThis.Uint8Array`, which a guest can delete or replace with a shim that throws. Built with `JS_NewTypedArray` now, so what the guest does to that name cannot reach the description.

A Ruby Bignum crossing over called `globalThis.Number`, so replacing that name made every Bignum a host returned fail, including one nested in a returned Hash. It converts with `rb_str_to_dbl` now, which is the conversion `Number(str)` performs.

The file proxy takes `File.prototype` at init for the same reason, and `Object.create`, `Object.defineProperty`, `Proxy`, `Reflect.get` and `Symbol.toStringTag` with it: the factory closure runs per crossing, so every one of those names was the guest's to answer for by then. `globalThis.Proxy = null` broke every crossing, and a replaced `Object.defineProperty` published the handle as an ordinary enumerable property.

The proxy's handler now has a null prototype, which matters more than it sounds: QuickJS resolves a missing trap with an ordinary property get that walks the handler's chain, so with `Object.prototype` in it a guest writing `Object.prototype.getOwnPropertyDescriptor` supplied the trap for the very read this branch made load-bearing. Measured, that turned a host `::File` into a `Quickjs::File` on its way back, and the descriptor invariant check compares flags without comparing the value, so a handle of the guest's choosing could come back instead.

A host `File`'s `slice` had the same shape: it read both `Uint8Array` and `Blob` off `globalThis` at call time and checked neither, so a replaced `Uint8Array` put `JS_EXCEPTION` into the parts array as an ordinary element and handed that to the `Blob` constructor with the guest's throw still pending. The bytes go through `JS_NewTypedArray`, the `Blob` constructor is captured at init alongside the file proxy creator, and every step is checked. The `Blob` polyfill still reads `Uint8Array` from the global inside its own JS, which is the same on `main` and is not something this layer answers for.

## Define a returned Hash and Array too, rather than assigning into them

The same write builds every `Hash` and `Array` a `define_function` returns, and fails the same way:

```js
Object.defineProperty(Object.prototype, 'token', { set(v) { stolen = v }, get() { return 'GHOST' } });
get_hash()   // Ruby: { 'token' => 'secret' }
//=> h.token is 'GHOST', h has no own properties, and the host's 'secret' reached the guest's setter
```

Neither this nor the Array case is new: both behave identically on `main`, and they are fixed here only because this is where the invariant they break got written down. A `Hash` key of `"__proto__"` becomes an own property as a result, rather than reparenting the object it was meant to be a key of.

## Bound the usages list a guest gets to size

The `length` driving the usages loop is a property of an object the guest passed in, and the loop does a property read and a Ruby allocation per step without polling a QuickJS interrupt, so `timeout_msec` cannot end it:

```js
crypto.subtle.importKey('raw', new Uint8Array(16), {name: 'HMAC', hash: {name: 'SHA-256'}}, false, {length: 10_000_000})
//=> 1.92s on a VM with timeout_msec: 100, and the VM ends up out of memory and poisoned
```

Eight usages exist in the spec, so a list near the bound is not a usages list. Refused rather than truncated, and refused as a rejection: these entry points are specified to always return a promise, so a guest writing `importKey(...).catch(h)` has to reach `h` even for a refusal decided before the operation starts. A negative length is not that: WebIDL's `ToLength` makes it an empty sequence, which is what `main` answers and what this answers. Not new here and identical on `main`; it is fixed in this branch because the function was rewritten here.

## Sweep fully before counting what a leak test left behind

One test in the base measured with a plain `GC.start` and failed 18 times in 25 runs in isolation, on a build that pins nothing. Both sweeps are full and immediate now, which is what every other leak measurement here already used: 0 in 25. The assertion is unchanged.

## Two visible changes to note

`rb_object_id`, where a guest reads it, is now a `Float` rather than an `Integer`: handles run past `INT32_MAX`, so QuickJS carries them as doubles. Values stay exact well below 2^53 and nothing internal depends on the type.

Both of a bridged error's own properties are now non-enumerable, where assignment had made them enumerable. That is the point for the handle, which is not part of the error. It applies to `message` as a consequence: a bridged error now has the same shape a native `Error` does, `{}` under `JSON.stringify`, where before it was the one `Error` in the runtime whose message showed up there. On the Ruby side, converting the *same* JS error object a second time, after its entry has been unparked, now yields `{}` rather than `{"rb_object_id" => …, "message" => …}`; the first conversion is unaffected, since it resolves to the host exception itself.

## Tests

722 runs, 1260 assertions, 0 failures, 1 skip. Each commit builds and passes on its own (688 / 707 / 708 / 717 / 719 / 719 / 722).

## What this does not do

The handle is unguessable but not unforgeable: a guest that legitimately holds one object's handle can still present it on another, and the reader will resolve it. That buys nothing now, since it is the same object either way, and closing it properly is the unforgeable-handle work in **#114**, along with the table's real problem, that nothing leaves it until the VM dies.

Three things a conversion cannot currently do are deferred to **#130**: an algorithm property whose read fails and the operation continuing without it, a `console.log` argument that cannot convert, an object whose member read throws. Each is answered today by inventing a stand-in value, and all three want one refusal path. An out-of-memory while describing a key resolves the promise with the exponent missing, which is **#129**.

## Merge order

`oom-allocator-latch` adds a fourth `alive_objects` reader using `INT2NUM` on an `int32_t`. Whichever of the two lands second needs it widened to `LL2NUM` / `int64_t`, or it will silently stop matching a 2^48 handle.













