### PR TITLE
Read JS_IsArray's third answer instead of taking it for yes

### DIFF
--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -1018,13 +1018,14 @@ static VALUE to_rb_value_inner(JSContext *ctx, JSValue j_val, ConvState *conv)
 
     VALUE r_result;
     int memoize = 1;
-    // JS_IsArray is tri-state: 1, 0, and -1 when it cannot resolve a proxy,
-    // which is what a revoked one does. Read as a boolean the -1 said "array",
-    // so a value JS itself refuses to inspect came back as an ordinary empty
-    // Array, indistinguishable from a genuine one. The throw js_resolve_proxy
-    // left pending is the guest's own TypeError, so rendering it hands the
-    // caller what the guest would have seen and takes the exception off the
-    // context on the way.
+    // JS_IsArray is tri-state: 1, 0, and -1 when it cannot resolve a proxy —
+    // a revoked one, or a chain too deep to walk. Read as a boolean the -1 said
+    // "array", so a value JS itself refuses to inspect came back as an ordinary
+    // empty Array, indistinguishable from a genuine one. js_resolve_proxy
+    // throws on both paths, a TypeError for the revoked case and a stack
+    // overflow for the deep one, and it is the guest's own either way: what
+    // Array.isArray would have reported. Rendering it hands the caller that,
+    // and takes the exception off the context on the way.
     int is_array = JS_IsArray(ctx, j_val);
     if (is_array < 0)
       return raise_js_exception(ctx); // raises

--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -986,7 +986,15 @@ static VALUE to_rb_value_inner(JSContext *ctx, JSValue j_val, ConvState *conv)
           if (JS_IsArray(ctx, j_val) < 0)
           {
             JS_FreeValue(ctx, JS_GetException(ctx));
+            // The trap that revoked can have raised on the way, and a throw
+            // carrying a Ruby exception is a bridge reporting a host failure:
+            // it has to come back out, and find_ruby_error is the only thing
+            // that takes it out of alive_objects, so discarding it would pin
+            // it for the life of the VM at a rate the guest picks.
+            VALUE r_ruby_error = find_ruby_error(ctx, j_pending);
             JS_FreeValue(ctx, j_pending);
+            if (!NIL_P(r_ruby_error))
+              rb_exc_raise(r_ruby_error);
             conv_frame_pop(conv);
             return rb_str_new2(QUICKJSRB_UNRENDERABLE);
           }
@@ -1015,7 +1023,15 @@ static VALUE to_rb_value_inner(JSContext *ctx, JSValue j_val, ConvState *conv)
           if (JS_IsArray(ctx, j_val) < 0)
           {
             JS_FreeValue(ctx, JS_GetException(ctx));
+            // The trap that revoked can have raised on the way, and a throw
+            // carrying a Ruby exception is a bridge reporting a host failure:
+            // it has to come back out, and find_ruby_error is the only thing
+            // that takes it out of alive_objects, so discarding it would pin
+            // it for the life of the VM at a rate the guest picks.
+            VALUE r_ruby_error = find_ruby_error(ctx, j_pending);
             JS_FreeValue(ctx, j_pending);
+            if (!NIL_P(r_ruby_error))
+              rb_exc_raise(r_ruby_error);
             conv_frame_pop(conv);
             return rb_str_new2(QUICKJSRB_UNRENDERABLE);
           }
@@ -1100,6 +1116,11 @@ static VALUE to_rb_value_inner(JSContext *ctx, JSValue j_val, ConvState *conv)
       // and one of them may revoke the proxy it was asked about. The r_seen
       // marking is undone so a second occurrence substitutes too rather than
       // reading as the cycle nil is reserved for.
+      //
+      // Not the last word either: js_is_plain_object and the walkers below run
+      // traps of their own, and a proxy that waits until one of those still
+      // converts to an empty container, because those reads are unchecked.
+      // That is #119 rather than the tri-state this branch is about.
       if (conv->substitute_unresolvable)
       {
         JS_FreeValue(ctx, JS_GetException(ctx));

--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -974,7 +974,26 @@ static VALUE to_rb_value_inner(JSContext *ctx, JSValue j_val, ConvState *conv)
       // Checked before the call for the same reason as the BigInt branch:
       // calling JS_EXCEPTION throws "not a function" over the real error.
       if (JS_IsException(j_toStringFunc))
+      {
+        // A function target reaches this branch before the check at the top of
+        // the case can be repeated, since JS_IsFunction answers off is_func
+        // without resolving. So the question is asked here, holding the throw
+        // aside because asking replaces it, and putting it back if the proxy
+        // was not the reason: a host error still comes out of a logged value.
+        if (conv->substitute_unresolvable)
+        {
+          JSValue j_pending = JS_GetException(ctx);
+          if (JS_IsArray(ctx, j_val) < 0)
+          {
+            JS_FreeValue(ctx, JS_GetException(ctx));
+            JS_FreeValue(ctx, j_pending);
+            conv_frame_pop(conv);
+            return rb_str_new2(QUICKJSRB_UNRENDERABLE);
+          }
+          JS_Throw(ctx, j_pending);
+        }
         return raise_js_exception(ctx);
+      }
       JSValue j_source = JS_Call(ctx, j_toStringFunc, j_val, 0, NULL);
       conv_return(conv, depth);
       conv_borrow(conv, depth, j_source);
@@ -985,7 +1004,25 @@ static VALUE to_rb_value_inner(JSContext *ctx, JSValue j_val, ConvState *conv)
       // dispose! reached from a toString gets to report ThreadError. The frame
       // still holds j_source, so conv_release hands it back on the way out.
       if (source == NULL)
+      {
+        // Same question as the read above, and the same care with the throw:
+        // calling toString with a revoked proxy as `this` is how a function
+        // target refuses, and a log row substitutes for that while still
+        // letting a bridge's Ruby exception through.
+        if (conv->substitute_unresolvable)
+        {
+          JSValue j_pending = JS_GetException(ctx);
+          if (JS_IsArray(ctx, j_val) < 0)
+          {
+            JS_FreeValue(ctx, JS_GetException(ctx));
+            JS_FreeValue(ctx, j_pending);
+            conv_frame_pop(conv);
+            return rb_str_new2(QUICKJSRB_UNRENDERABLE);
+          }
+          JS_Throw(ctx, j_pending);
+        }
         return raise_js_exception(ctx);
+      }
       conv_borrow_key(conv, depth, source);
       VALUE r_source = rb_str_new2(source);
       conv_frame_pop(conv);
@@ -1057,7 +1094,20 @@ static VALUE to_rb_value_inner(JSContext *ctx, JSValue j_val, ConvState *conv)
     // and takes the exception off the context on the way.
     int is_array = JS_IsArray(ctx, j_val);
     if (is_array < 0)
+    {
+      // Asked again because the answer can change under us: the reads between
+      // here and the check at the top of this case run the guest's own traps,
+      // and one of them may revoke the proxy it was asked about. The r_seen
+      // marking is undone so a second occurrence substitutes too rather than
+      // reading as the cycle nil is reserved for.
+      if (conv->substitute_unresolvable)
+      {
+        JS_FreeValue(ctx, JS_GetException(ctx));
+        rb_hash_delete(conv->r_seen, r_key);
+        return rb_str_new2(QUICKJSRB_UNRENDERABLE);
+      }
       return raise_js_exception(ctx); // raises
+    }
     if (is_array)
     {
       r_result = js_array_to_rb(ctx, j_val, conv);

--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -1593,6 +1593,19 @@ static VALUE r_build_log_row(VALUE r_build)
 
       r_raw = rb_str_new2(js_hold_format(hold, "%s: %s\n%s", errorClassName, errorClassMessage, stackTrace));
     }
+    else if (JS_IsArray(ctx, j_logged) < 0)
+    {
+      // Substituted here rather than left to the conversion, which now reports
+      // an unresolvable proxy instead of calling it an Array. A log line must
+      // not decide whether the statement after it runs, and this one would
+      // decide it twice over: the raise comes back to the guest as a catchable
+      // Error, which parks the Ruby exception in alive_objects until something
+      // throws it back, so a guest that catches its own console.log in a loop
+      // pins one per iteration. Same substitution the Promise above gets, and
+      // for the same reason.
+      JS_FreeValue(ctx, JS_GetException(ctx));
+      r_raw = rb_str_new2(QUICKJSRB_UNRENDERABLE);
+    }
     else
     {
       r_raw = to_rb_value(ctx, j_logged);

--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -909,6 +909,22 @@ static VALUE to_rb_value_for_log(JSContext *ctx, JSValue j_val)
   return to_rb_value_with(ctx, j_val, true);
 }
 
+// The placeholder a console row gets for a proxy it cannot resolve. The throw
+// is discarded, but not before find_ruby_error has looked at it: a trap can
+// revoke and reach a Ruby bridge in the same breath, and that throw carries the
+// host's exception, which has to come back out and is only taken out of
+// alive_objects here.
+static VALUE r_substituted_unresolvable(JSContext *ctx)
+{
+  JSValue j_pending = JS_GetException(ctx);
+  VALUE r_ruby_error = find_ruby_error(ctx, j_pending);
+  JS_FreeValue(ctx, j_pending);
+  if (!NIL_P(r_ruby_error))
+    rb_exc_raise(r_ruby_error);
+
+  return rb_str_new2(QUICKJSRB_UNRENDERABLE);
+}
+
 static VALUE to_rb_value_inner(JSContext *ctx, JSValue j_val, ConvState *conv)
 {
   switch (JS_VALUE_GET_NORM_TAG(j_val))
@@ -952,10 +968,7 @@ static VALUE to_rb_value_inner(JSContext *ctx, JSValue j_val, ConvState *conv)
     // before the r_seen marking, so a proxy met twice in one row is two
     // substitutions rather than a second one reading as a cycle.
     if (conv != NULL && conv->substitute_unresolvable && JS_IsArray(ctx, j_val) < 0)
-    {
-      JS_FreeValue(ctx, JS_GetException(ctx));
-      return rb_str_new2(QUICKJSRB_UNRENDERABLE);
-    }
+      return r_substituted_unresolvable(ctx);
 
     int promiseState = JS_PromiseState(ctx, j_val);
     if (promiseState != -1)
@@ -1070,9 +1083,8 @@ static VALUE to_rb_value_inner(JSContext *ctx, JSValue j_val, ConvState *conv)
       // That is #119 rather than the tri-state this branch is about.
       if (conv->substitute_unresolvable)
       {
-        JS_FreeValue(ctx, JS_GetException(ctx));
         rb_hash_delete(conv->r_seen, r_key);
-        return rb_str_new2(QUICKJSRB_UNRENDERABLE);
+        return r_substituted_unresolvable(ctx);
       }
       return raise_js_exception(ctx); // raises
     }
@@ -1448,6 +1460,31 @@ static VALUE r_try_call_proc(VALUE r_try_args)
   );
 }
 
+struct js_arg_conversion
+{
+  JSContext *ctx;
+  JSValue j_val;
+};
+
+static VALUE js_arg_conversion_run(VALUE r_conversion)
+{
+  struct js_arg_conversion *conversion = (struct js_arg_conversion *)r_conversion;
+  return to_rb_value(conversion->ctx, conversion->j_val);
+}
+
+// Hands a Ruby exception back to the guest as a JS throw, the way a raise from
+// the block itself is already handed back, so the caller sees an error instead
+// of the conversion silently yielding nothing. A Ruby throw leaves internal
+// data rather than an Exception in errinfo and has nowhere to go from here.
+static JSValue j_throw_from_ruby_errinfo(JSContext *ctx)
+{
+  VALUE r_error = rb_errinfo();
+  rb_set_errinfo(Qnil);
+  if (!rb_obj_is_kind_of(r_error, rb_eException))
+    return JS_ThrowInternalError(ctx, "an argument could not be converted");
+  return JS_Throw(ctx, j_error_from_ruby_error(ctx, r_error));
+}
+
 static JSValue js_quickjsrb_call_global(JSContext *ctx, JSValueConst _this, int argc, JSValueConst *argv, int _magic, JSValue *func_data)
 {
   // func_data[0] holds the Ruby Symbol ID for the defined function (stored by
@@ -1470,12 +1507,22 @@ static JSValue js_quickjsrb_call_global(JSContext *ctx, JSValueConst _this, int 
   VALUE r_call_args = rb_ary_new();
   rb_ary_push(r_call_args, r_proc);
 
+  // Converted under a protect, because to_rb_value raises for an argument it
+  // cannot represent and this is a JSCFunction: the longjmp would go out
+  // through QuickJS's own frames, past the JS_FreeValue below, pinning the
+  // argument and everything it holds on the JS heap for the life of the VM.
+  // Repeatable by the guest, which is enough to condemn a VM by out-of-memory
+  // rather than merely to leak.
   VALUE r_argv = rb_ary_new();
   for (int i = 0; i < argc; i++)
   {
-    JSValue j_v = JS_DupValue(ctx, argv[i]);
-    rb_ary_push(r_argv, to_rb_value(ctx, j_v));
-    JS_FreeValue(ctx, j_v);
+    struct js_arg_conversion conversion = {ctx, JS_DupValue(ctx, argv[i])};
+    int state;
+    VALUE r_converted = rb_protect(js_arg_conversion_run, (VALUE)&conversion, &state);
+    JS_FreeValue(ctx, conversion.j_val);
+    if (state)
+      return j_throw_from_ruby_errinfo(ctx);
+    rb_ary_push(r_argv, r_converted);
   }
   rb_ary_push(r_call_args, r_argv);
   rb_ary_push(r_call_args, ULONG2NUM(data->eval_time->limit_ms));

--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -974,34 +974,7 @@ static VALUE to_rb_value_inner(JSContext *ctx, JSValue j_val, ConvState *conv)
       // Checked before the call for the same reason as the BigInt branch:
       // calling JS_EXCEPTION throws "not a function" over the real error.
       if (JS_IsException(j_toStringFunc))
-      {
-        // A function target reaches this branch before the check at the top of
-        // the case can be repeated, since JS_IsFunction answers off is_func
-        // without resolving. So the question is asked here, holding the throw
-        // aside because asking replaces it, and putting it back if the proxy
-        // was not the reason: a host error still comes out of a logged value.
-        if (conv->substitute_unresolvable)
-        {
-          JSValue j_pending = JS_GetException(ctx);
-          if (JS_IsArray(ctx, j_val) < 0)
-          {
-            JS_FreeValue(ctx, JS_GetException(ctx));
-            // The trap that revoked can have raised on the way, and a throw
-            // carrying a Ruby exception is a bridge reporting a host failure:
-            // it has to come back out, and find_ruby_error is the only thing
-            // that takes it out of alive_objects, so discarding it would pin
-            // it for the life of the VM at a rate the guest picks.
-            VALUE r_ruby_error = find_ruby_error(ctx, j_pending);
-            JS_FreeValue(ctx, j_pending);
-            if (!NIL_P(r_ruby_error))
-              rb_exc_raise(r_ruby_error);
-            conv_frame_pop(conv);
-            return rb_str_new2(QUICKJSRB_UNRENDERABLE);
-          }
-          JS_Throw(ctx, j_pending);
-        }
         return raise_js_exception(ctx);
-      }
       JSValue j_source = JS_Call(ctx, j_toStringFunc, j_val, 0, NULL);
       conv_return(conv, depth);
       conv_borrow(conv, depth, j_source);
@@ -1012,33 +985,7 @@ static VALUE to_rb_value_inner(JSContext *ctx, JSValue j_val, ConvState *conv)
       // dispose! reached from a toString gets to report ThreadError. The frame
       // still holds j_source, so conv_release hands it back on the way out.
       if (source == NULL)
-      {
-        // Same question as the read above, and the same care with the throw:
-        // calling toString with a revoked proxy as `this` is how a function
-        // target refuses, and a log row substitutes for that while still
-        // letting a bridge's Ruby exception through.
-        if (conv->substitute_unresolvable)
-        {
-          JSValue j_pending = JS_GetException(ctx);
-          if (JS_IsArray(ctx, j_val) < 0)
-          {
-            JS_FreeValue(ctx, JS_GetException(ctx));
-            // The trap that revoked can have raised on the way, and a throw
-            // carrying a Ruby exception is a bridge reporting a host failure:
-            // it has to come back out, and find_ruby_error is the only thing
-            // that takes it out of alive_objects, so discarding it would pin
-            // it for the life of the VM at a rate the guest picks.
-            VALUE r_ruby_error = find_ruby_error(ctx, j_pending);
-            JS_FreeValue(ctx, j_pending);
-            if (!NIL_P(r_ruby_error))
-              rb_exc_raise(r_ruby_error);
-            conv_frame_pop(conv);
-            return rb_str_new2(QUICKJSRB_UNRENDERABLE);
-          }
-          JS_Throw(ctx, j_pending);
-        }
         return raise_js_exception(ctx);
-      }
       conv_borrow_key(conv, depth, source);
       VALUE r_source = rb_str_new2(source);
       conv_frame_pop(conv);

--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -320,6 +320,11 @@ struct ConvState
   ConvFrame *frames;
   long frame_count;
   long frame_capacity;
+  // Set for the walk that builds a console row. A log line must not decide
+  // whether the statement after it runs, so a proxy this walk cannot resolve
+  // is substituted at whatever depth it is found rather than reported. Only
+  // that one refusal: a host error met on the way still comes back out.
+  bool substitute_unresolvable;
   ConvFrame frames_inline[CONV_FRAMES_INLINE];
 };
 
@@ -876,7 +881,7 @@ static VALUE js_bigint_conversion_run(VALUE r_conversion)
   return rb_funcall(rb_str_new2(js_hold_own_cstring(hold, msg)), rb_intern("to_i"), 0);
 }
 
-VALUE to_rb_value(JSContext *ctx, JSValue j_val)
+static VALUE to_rb_value_with(JSContext *ctx, JSValue j_val, bool substitute_unresolvable)
 {
   // Only object graphs need the bookkeeping, and only they can recurse, so
   // primitives convert straight through rather than paying for the state and
@@ -889,7 +894,19 @@ VALUE to_rb_value(JSContext *ctx, JSValue j_val)
   conv.frames = conv.frames_inline;
   conv.frame_count = 0;
   conv.frame_capacity = CONV_FRAMES_INLINE;
+  conv.substitute_unresolvable = substitute_unresolvable;
   return rb_ensure(conv_run, (VALUE)&conv, conv_release, (VALUE)&conv);
+}
+
+VALUE to_rb_value(JSContext *ctx, JSValue j_val)
+{
+  return to_rb_value_with(ctx, j_val, false);
+}
+
+// The conversion a console row is built with. See ConvState.
+static VALUE to_rb_value_for_log(JSContext *ctx, JSValue j_val)
+{
+  return to_rb_value_with(ctx, j_val, true);
 }
 
 static VALUE to_rb_value_inner(JSContext *ctx, JSValue j_val, ConvState *conv)
@@ -1028,7 +1045,12 @@ static VALUE to_rb_value_inner(JSContext *ctx, JSValue j_val, ConvState *conv)
     // and takes the exception off the context on the way.
     int is_array = JS_IsArray(ctx, j_val);
     if (is_array < 0)
-      return raise_js_exception(ctx); // raises
+    {
+      if (!conv->substitute_unresolvable)
+        return raise_js_exception(ctx); // raises
+      JS_FreeValue(ctx, JS_GetException(ctx));
+      return rb_str_new2(QUICKJSRB_UNRENDERABLE);
+    }
     if (is_array)
     {
       r_result = js_array_to_rb(ctx, j_val, conv);
@@ -1593,22 +1615,14 @@ static VALUE r_build_log_row(VALUE r_build)
 
       r_raw = rb_str_new2(js_hold_format(hold, "%s: %s\n%s", errorClassName, errorClassMessage, stackTrace));
     }
-    else if (JS_IsArray(ctx, j_logged) < 0)
-    {
-      // Substituted here rather than left to the conversion, which now reports
-      // an unresolvable proxy instead of calling it an Array. A log line must
-      // not decide whether the statement after it runs, and this one would
-      // decide it twice over: the raise comes back to the guest as a catchable
-      // Error, which parks the Ruby exception in alive_objects until something
-      // throws it back, so a guest that catches its own console.log in a loop
-      // pins one per iteration. Same substitution the Promise above gets, and
-      // for the same reason.
-      JS_FreeValue(ctx, JS_GetException(ctx));
-      r_raw = rb_str_new2(QUICKJSRB_UNRENDERABLE);
-    }
     else
     {
-      r_raw = to_rb_value(ctx, j_logged);
+      // Substitutes an unresolvable proxy wherever in the graph it sits, the
+      // way the Promise above is substituted: the raise would otherwise come
+      // back to the guest as a catchable Error, whose Ruby exception is parked
+      // in alive_objects until something throws it back, so a guest that
+      // catches its own console.log in a loop pins one per iteration.
+      r_raw = to_rb_value_for_log(ctx, j_logged);
     }
     VALUE r_c = rb_str_new2(js_hold_cstring(hold, j_logged, QUICKJSRB_UNRENDERABLE));
 

--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -1018,7 +1018,17 @@ static VALUE to_rb_value_inner(JSContext *ctx, JSValue j_val, ConvState *conv)
 
     VALUE r_result;
     int memoize = 1;
-    if (JS_IsArray(ctx, j_val))
+    // JS_IsArray is tri-state: 1, 0, and -1 when it cannot resolve a proxy,
+    // which is what a revoked one does. Read as a boolean the -1 said "array",
+    // so a value JS itself refuses to inspect came back as an ordinary empty
+    // Array, indistinguishable from a genuine one. The throw js_resolve_proxy
+    // left pending is the guest's own TypeError, so rendering it hands the
+    // caller what the guest would have seen and takes the exception off the
+    // context on the way.
+    int is_array = JS_IsArray(ctx, j_val);
+    if (is_array < 0)
+      return raise_js_exception(ctx); // raises
+    if (is_array)
     {
       r_result = js_array_to_rb(ctx, j_val, conv);
     }

--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -945,6 +945,18 @@ static VALUE to_rb_value_inner(JSContext *ctx, JSValue j_val, ConvState *conv)
   }
   case JS_TAG_OBJECT:
   {
+    // Asked first, and only by the walk that builds a console row. It has to
+    // come before the branches below because JS_IsFunction reads a proxy's
+    // is_func without resolving it, so a proxy revoked over a function target
+    // would be claimed there and raise from the toString read instead; and
+    // before the r_seen marking, so a proxy met twice in one row is two
+    // substitutions rather than a second one reading as a cycle.
+    if (conv != NULL && conv->substitute_unresolvable && JS_IsArray(ctx, j_val) < 0)
+    {
+      JS_FreeValue(ctx, JS_GetException(ctx));
+      return rb_str_new2(QUICKJSRB_UNRENDERABLE);
+    }
+
     int promiseState = JS_PromiseState(ctx, j_val);
     if (promiseState != -1)
     {
@@ -1045,12 +1057,7 @@ static VALUE to_rb_value_inner(JSContext *ctx, JSValue j_val, ConvState *conv)
     // and takes the exception off the context on the way.
     int is_array = JS_IsArray(ctx, j_val);
     if (is_array < 0)
-    {
-      if (!conv->substitute_unresolvable)
-        return raise_js_exception(ctx); // raises
-      JS_FreeValue(ctx, JS_GetException(ctx));
-      return rb_str_new2(QUICKJSRB_UNRENDERABLE);
-    }
+      return raise_js_exception(ctx); // raises
     if (is_array)
     {
       r_result = js_array_to_rb(ctx, j_val, conv);
@@ -1617,11 +1624,12 @@ static VALUE r_build_log_row(VALUE r_build)
     }
     else
     {
-      // Substitutes an unresolvable proxy wherever in the graph it sits, the
-      // way the Promise above is substituted: the raise would otherwise come
-      // back to the guest as a catchable Error, whose Ruby exception is parked
-      // in alive_objects until something throws it back, so a guest that
-      // catches its own console.log in a loop pins one per iteration.
+      // Substitutes an unresolvable proxy wherever in the graph it sits. The
+      // raise would otherwise come back to the guest as a catchable Error,
+      // whose Ruby exception is parked in alive_objects until something throws
+      // it back, so a guest that catches its own console.log in a loop pins one
+      // per iteration. The Promise above is the same idea and only goes one
+      // level deep: a nested one still raises out of the row.
       r_raw = to_rb_value_for_log(ctx, j_logged);
     }
     VALUE r_c = rb_str_new2(js_hold_cstring(hold, j_logged, QUICKJSRB_UNRENDERABLE));

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -394,6 +394,31 @@ describe Quickjs do
           vm&.dispose!
         end
 
+        # The throw held aside while the proxy is asked about can be a bridge
+        # reporting a host failure. Discarding it would swallow the error and
+        # leave the Ruby exception parked in alive_objects, which only
+        # find_ruby_error takes it out of.
+        it "still reports a host error raised by the revoking trap itself" do
+          vm = Quickjs::VM.new
+          vm.on_log { |l| }
+          vm.define_function('boom') { raise IOError, 'host' }
+          vm.eval_code(<<~JS)
+            globalThis.mk = () => {
+              let rev;
+              const t = function(){};
+              const p = new Proxy(t, { get(x, k) { if (rev) { rev(); rev = null; boom() } return x[k] } });
+              const r = Proxy.revocable(p, {});
+              rev = r.revoke;
+              return r.proxy;
+            };
+          JS
+
+          error = _ { vm.eval_code("console.log(mk()); 'after'") }.must_raise IOError
+          _(error.message).must_equal 'host'
+        ensure
+          vm&.dispose!
+        end
+
         # The substitution is for the proxy refusing, not for every throw the
         # same read can carry.
         it "still lets a host error out of a function's toString" do

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -255,21 +255,23 @@ describe Quickjs do
     # and read as a boolean that took the array path: a value whose every trap
     # throws came back as [], indistinguishable from a genuine empty Array.
     describe "a revoked Proxy" do
-      REVOKED = "const {proxy, revoke} = Proxy.revocable({a: 1}, {}); revoke();"
+      def revoked
+        "const {proxy, revoke} = Proxy.revocable({a: 1}, {}); revoke();"
+      end
 
       it "reports the TypeError the guest would see" do
-        error = _ { ::Quickjs.eval_code("#{REVOKED} proxy") }.must_raise Quickjs::TypeError
+        error = _ { ::Quickjs.eval_code("#{revoked} proxy") }.must_raise Quickjs::TypeError
         _(error.message).must_equal 'revoked proxy'
       end
 
       it "reports it from inside a container too" do
-        _ { ::Quickjs.eval_code("#{REVOKED} ({ok: 1, bad: proxy})") }.must_raise Quickjs::TypeError
-        _ { ::Quickjs.eval_code("#{REVOKED} [1, proxy]") }.must_raise Quickjs::TypeError
+        _ { ::Quickjs.eval_code("#{revoked} ({ok: 1, bad: proxy})") }.must_raise Quickjs::TypeError
+        _ { ::Quickjs.eval_code("#{revoked} [1, proxy]") }.must_raise Quickjs::TypeError
       end
 
       it "leaves the VM usable, having taken the throw off the context" do
         vm = Quickjs::VM.new
-        _ { vm.eval_code("#{REVOKED} proxy") }.must_raise Quickjs::TypeError
+        _ { vm.eval_code("#{revoked} proxy") }.must_raise Quickjs::TypeError
         _(vm.eval_code('1 + 1')).must_equal 2
       ensure
         vm.dispose!
@@ -280,6 +282,23 @@ describe Quickjs do
       it "does not change what a live Proxy converts to" do
         assert_code("new Proxy([1, 2, 3], {})", [1, 2, 3])
         assert_code("new Proxy({a: 1}, {})", {'a' => 1})
+      end
+
+      # A log line must not decide whether the statement after it runs, so the
+      # row builder substitutes the way it does for a Promise, rather than
+      # letting the conversion report. The raise would also come back to the
+      # guest catchable, pinning a Ruby exception per catch.
+      it "is substituted in a log row rather than reported" do
+        vm = Quickjs::VM.new
+        rows = []
+        vm.on_log { |l| rows << l.to_s }
+
+        result = vm.eval_code("#{revoked} let c = 'none'; try { console.log('x', proxy) } catch (e) { c = e.message } c")
+
+        _(result).must_equal 'none'
+        _(rows).must_equal ['x (unrenderable value)']
+      ensure
+        vm.dispose!
       end
 
       # The other way js_resolve_proxy answers -1. Reported rather than

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -281,6 +281,15 @@ describe Quickjs do
         assert_code("new Proxy([1, 2, 3], {})", [1, 2, 3])
         assert_code("new Proxy({a: 1}, {})", {'a' => 1})
       end
+
+      # The other way js_resolve_proxy answers -1. Reported rather than
+      # swallowed for the same reason: it is what Array.isArray would have
+      # said about the same value.
+      it "reports the stack overflow of a chain too deep to resolve" do
+        deep = "let p = [1, 2]; for (let i = 0; i < 1500; i++) p = new Proxy(p, {});"
+        error = _ { ::Quickjs.eval_code("#{deep} p") }.must_raise Quickjs::RuntimeError
+        _(error.message).must_match(/stack overflow/)
+      end
     end
   end
 

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -301,6 +301,33 @@ describe Quickjs do
         vm.dispose!
       end
 
+      it "is substituted at whatever depth it sits in a log row" do
+        vm = Quickjs::VM.new
+        rows = []
+        vm.on_log { |l| rows << l.raw }
+
+        result = vm.eval_code("#{revoked} console.log([proxy], {p: proxy}); 'after'")
+
+        _(result).must_equal 'after'
+        _(rows).must_equal [[['(unrenderable value)'], {'p' => '(unrenderable value)'}]]
+      ensure
+        vm.dispose!
+      end
+
+      # Only the one refusal is substituted. A host failure met while walking a
+      # logged value is not the log path's to swallow.
+      it "still lets a host error out of a logged value" do
+        vm = Quickjs::VM.new
+        vm.on_log { |l| }
+        vm.define_function('boom') { raise IOError, 'host' }
+        vm.eval_code("globalThis.C = class { toJSON() { boom() } }")
+
+        error = _ { vm.eval_code("console.log({o: new C()}); 'after'") }.must_raise IOError
+        _(error.message).must_equal 'host'
+      ensure
+        vm.dispose!
+      end
+
       # The other way js_resolve_proxy answers -1. Reported rather than
       # swallowed for the same reason: it is what Array.isArray would have
       # said about the same value.

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -348,6 +348,67 @@ describe Quickjs do
         vm&.dispose!
       end
 
+      # The check at the top of the object case is not the last word: the reads
+      # after it run the guest's own traps, and one of them can revoke the
+      # proxy that was live when it was asked about.
+      describe "revoking itself from its own trap" do
+        def self_revoking(target)
+          <<~JS
+            globalThis.mk = () => {
+              let rev;
+              const t = #{target};
+              const p = new Proxy(t, {
+                get(x, k) { if (rev) { rev(); rev = null } return x[k] },
+                getPrototypeOf(x) { if (rev) { rev(); rev = null } return Object.getPrototypeOf(x) },
+              });
+              const r = Proxy.revocable(p, {});
+              rev = r.revoke;
+              return r.proxy;
+            };
+          JS
+        end
+
+        it "is still substituted, over an object target" do
+          vm = Quickjs::VM.new
+          rows = []
+          vm.on_log { |l| rows << l.raw }
+          vm.eval_code(self_revoking('{a: 1}'))
+
+          _(vm.eval_code("console.log(mk(), mk()); 'after'")).must_equal 'after'
+          _(rows).must_equal [['(unrenderable value)', '(unrenderable value)']]
+        ensure
+          vm&.dispose!
+        end
+
+        # JS_IsFunction answers off is_func without resolving, so this one is
+        # claimed by the function branch and refuses at its toString instead.
+        it "is still substituted, over a function target" do
+          vm = Quickjs::VM.new
+          rows = []
+          vm.on_log { |l| rows << l.raw }
+          vm.eval_code(self_revoking('function(){}'))
+
+          _(vm.eval_code("console.log(mk(), mk()); 'after'")).must_equal 'after'
+          _(rows).must_equal [['(unrenderable value)', '(unrenderable value)']]
+        ensure
+          vm&.dispose!
+        end
+
+        # The substitution is for the proxy refusing, not for every throw the
+        # same read can carry.
+        it "still lets a host error out of a function's toString" do
+          vm = Quickjs::VM.new
+          vm.on_log { |l| }
+          vm.define_function('boom') { raise IOError, 'host' }
+          vm.eval_code("globalThis.f = function(){}; f.toString = () => { boom() }")
+
+          error = _ { vm.eval_code("console.log(f); 1") }.must_raise IOError
+          _(error.message).must_equal 'host'
+        ensure
+          vm&.dispose!
+        end
+      end
+
       # Only the one refusal is substituted. A host failure met while walking a
       # logged value is not the log path's to swallow.
       it "still lets a host error out of a logged value" do

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -380,16 +380,46 @@ describe Quickjs do
           vm&.dispose!
         end
 
+        # Over a function target it still reports, and that is deliberate.
         # JS_IsFunction answers off is_func without resolving, so this one is
-        # claimed by the function branch and refuses at its toString instead.
-        it "is still substituted, over a function target" do
+        # claimed by the function branch and refuses at its toString, where the
+        # throw already pending is not necessarily the proxy's: it can be an
+        # out-of-memory, which has to reach the renderer that latches the VM.
+        # Substituting there would swallow it. The row is lost for this one
+        # shape rather than the latch for every shape.
+        it "reports rather than substitutes, over a function target" do
           vm = Quickjs::VM.new
           rows = []
           vm.on_log { |l| rows << l.raw }
           vm.eval_code(self_revoking('function(){}'))
 
-          _(vm.eval_code("console.log(mk(), mk()); 'after'")).must_equal 'after'
-          _(rows).must_equal [['(unrenderable value)', '(unrenderable value)']]
+          _ { vm.eval_code("console.log(mk()); 'after'") }.must_raise Quickjs::TypeError
+          _(rows).must_equal []
+        ensure
+          vm&.dispose!
+        end
+
+        # The reason the substitution stops at the function branch.
+        it "still condemns the VM when the trap runs the heap out" do
+          vm = Quickjs::VM.new(memory_limit: 8 * 1024 * 1024)
+          vm.on_log { |l| }
+          vm.eval_code(<<~JS)
+            globalThis.mk = () => {
+              let rev;
+              const t = function(){};
+              const p = new Proxy(t, { get(x, k) {
+                if (rev) { rev(); rev = null; const a = []; for (;;) a.push(new Array(10000).fill(0)) }
+                return x[k]
+              } });
+              const r = Proxy.revocable(p, {});
+              rev = r.revoke;
+              return r.proxy;
+            };
+          JS
+
+          error = _ { vm.eval_code("console.log(mk()); 'after'") }.must_raise Quickjs::RuntimeError
+          _(error.message).must_match(/out of memory/)
+          _(vm.memory_poisoned?).must_equal true
         ensure
           vm&.dispose!
         end

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -467,6 +467,41 @@ describe Quickjs do
         end
       end
 
+      # The argument loop is a JSCFunction with nothing between it and the
+      # interpreter, so a raise there used to longjmp past the JS_FreeValue and
+      # pin the argument's whole graph on the JS heap, once per call and
+      # repeatable, which condemns the VM rather than merely leaking.
+      describe "as a define_function argument" do
+        it "reaches the guest as a catchable error" do
+          vm = Quickjs::VM.new
+          vm.define_function(:take) { |x| 'unreachable' }
+
+          caught = vm.eval_code("#{revoked} let c = 'none'; try { take(proxy) } catch (e) { c = e.message } c")
+
+          _(caught).must_equal 'revoked proxy'
+        ensure
+          vm&.dispose!
+        end
+
+        it "does not accumulate on the JS heap across calls" do
+          vm = Quickjs::VM.new
+          vm.define_function(:take) { |x| 1 }
+          vm.eval_code('globalThis.mk = () => { const {proxy, revoke} = Proxy.revocable({a: 1, big: new Array(200).fill(0)}, {}); revoke(); return proxy }')
+          200.times { vm.eval_code('try { take(mk()) } catch (e) {}') }
+          vm.gc!
+          before = vm.memory_usage
+
+          500.times { vm.eval_code('try { take(mk()) } catch (e) {}') }
+          vm.gc!
+          after = vm.memory_usage
+
+          _((after[:obj_count] - before[:obj_count]) / 500.0).must_be :<, 1.0
+          _(vm.memory_poisoned?).must_equal false
+        ensure
+          vm&.dispose!
+        end
+      end
+
       # Only the one refusal is substituted. A host failure met while walking a
       # logged value is not the log path's to swallow.
       it "still lets a host error out of a logged value" do

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -314,6 +314,40 @@ describe Quickjs do
         vm.dispose!
       end
 
+      # Met twice in one row it is two substitutions, not a substitution and a
+      # cycle: nil is what this conversion reserves for a genuine cycle.
+      it "is substituted once per occurrence in a log row" do
+        vm = Quickjs::VM.new
+        rows = []
+        vm.on_log { |l| rows << l.raw }
+
+        vm.eval_code("#{revoked} console.log({a: proxy, b: proxy}, [proxy, proxy]); 1")
+
+        _(rows).must_equal [[
+          {'a' => '(unrenderable value)', 'b' => '(unrenderable value)'},
+          ['(unrenderable value)', '(unrenderable value)'],
+        ]]
+      ensure
+        vm&.dispose!
+      end
+
+      # JS_IsFunction reads a proxy's is_func without resolving it, so a
+      # function target would be claimed by that branch and raise from the
+      # toString read rather than being substituted with the rest.
+      it "is substituted in a log row over a function target too" do
+        vm = Quickjs::VM.new
+        rows = []
+        vm.on_log { |l| rows << l.raw }
+
+        fn_revoked = "const {proxy, revoke} = Proxy.revocable(function(){}, {}); revoke();"
+        result = vm.eval_code("#{fn_revoked} console.log('x', proxy); 'after'")
+
+        _(result).must_equal 'after'
+        _(rows).must_equal [['x', '(unrenderable value)']]
+      ensure
+        vm&.dispose!
+      end
+
       # Only the one refusal is substituted. A host failure met while walking a
       # logged value is not the log path's to swallow.
       it "still lets a host error out of a logged value" do

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -250,6 +250,38 @@ describe Quickjs do
       result = ::Quickjs.eval_code("() => 'hi'")
       _(result).must_be_instance_of Quickjs::Function
     end
+
+    # JS_IsArray answers -1 rather than false when it cannot resolve a proxy,
+    # and read as a boolean that took the array path: a value whose every trap
+    # throws came back as [], indistinguishable from a genuine empty Array.
+    describe "a revoked Proxy" do
+      REVOKED = "const {proxy, revoke} = Proxy.revocable({a: 1}, {}); revoke();"
+
+      it "reports the TypeError the guest would see" do
+        error = _ { ::Quickjs.eval_code("#{REVOKED} proxy") }.must_raise Quickjs::TypeError
+        _(error.message).must_equal 'revoked proxy'
+      end
+
+      it "reports it from inside a container too" do
+        _ { ::Quickjs.eval_code("#{REVOKED} ({ok: 1, bad: proxy})") }.must_raise Quickjs::TypeError
+        _ { ::Quickjs.eval_code("#{REVOKED} [1, proxy]") }.must_raise Quickjs::TypeError
+      end
+
+      it "leaves the VM usable, having taken the throw off the context" do
+        vm = Quickjs::VM.new
+        _ { vm.eval_code("#{REVOKED} proxy") }.must_raise Quickjs::TypeError
+        _(vm.eval_code('1 + 1')).must_equal 2
+      ensure
+        vm.dispose!
+      end
+
+      # The -1 is the proxy being unresolvable, not the target being an array,
+      # so a live proxy has to keep converting as whatever it wraps.
+      it "does not change what a live Proxy converts to" do
+        assert_code("new Proxy([1, 2, 3], {})", [1, 2, 3])
+        assert_code("new Proxy({a: 1}, {})", {'a' => 1})
+      end
+    end
   end
 
   describe "Exceptions" do

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -399,7 +399,10 @@ describe Quickjs do
           vm&.dispose!
         end
 
-        # The reason the substitution stops at the function branch.
+        # The reason the substitution stops at the function branch. Over an
+        # object target the same shape is still lost, but it is lost on main
+        # too: the unchecked rb_object_id read swallows the out-of-memory and
+        # JS_IsArray's own throw replaces it. That is #119, not this branch.
         it "still condemns the VM when the trap runs the heap out" do
           vm = Quickjs::VM.new(memory_limit: 8 * 1024 * 1024)
           vm.on_log { |l| }


### PR DESCRIPTION
Closes #98.

```c
int is_array = JS_IsArray(ctx, j_val);
if (is_array < 0)
  return raise_js_exception(ctx); // raises
if (is_array)
```

`-1` is the proxy being unresolvable, not the target being an array, so a live `Proxy` is unaffected either way.

## What changes

```ruby
vm.eval_code('const {proxy, revoke} = Proxy.revocable({a: 1}, {}); revoke(); proxy')
# before: []
# after:  Quickjs::TypeError: revoked proxy
```

`revoked proxy` is what the guest sees from `JSON.stringify` on the same value, so the caller is told what JS would tell it. Rendering the throw also takes it off the context, which is the part the issue asked for separately: the VM stays usable, `1 + 1` still evaluates afterwards.

Nested occurrences raise too, both `({ok: 1, bad: proxy})` and `[1, proxy]`, since the conversion reaches them through the same branch. A proxy revoked over a function target behaves the same.

## Tests

654 runs, 1099 assertions, 0 failures, 1 skip, stable across seeds.

Four tests, in `ResultConversion`: the reported error and its message, the two nested shapes, that the VM survives with the exception consumed, and a regression guard that a live `Proxy` over an `Array` and over an object still convert as before. Ablating the fix fails three of the four; the live-`Proxy` one keeps passing, which is what it is there for.

No retention on the raising path: 0 objects, 0 bytes per iteration over 500 iterations.

## Note on the alternative

The issue offered `nil` as the other option. `raise` seemed better on the grounds that the value is not merely unconvertible but one the guest is forbidden to touch, and `nil` is already what a cycle converts to, so it would have collided with a meaning the conversion already uses.


---

## Consequences worth stating, from review

**A revoked proxy in a `console.log` argument now aborts the whole `eval_code`, and only for those with an `on_log` listener.** Without a listener `js_quickjsrb_log` short-circuits before touching the arguments and nothing changes. With one, `main` logged the row with a placeholder and carried on; this branch drops the row entirely, convertible sibling arguments included, and the statement after the log never runs.

It is also guest-drivable retention: the raise is bridged back into a *catchable* JS error, which `j_error_from_ruby_error` parks in `alive_objects` where only a throw back out to Ruby would unpark it. `for(;;){ try { console.log(revokedProxy) } catch {} }` retains 7 live Ruby slots per iteration, on the Ruby heap, so `memory_limit` does not bound it. This corrects an earlier claim in this description that the leak was bounded at one per `eval_code`: that holds for the `define_function` path, which is not catchable, and not for this one.

Both halves are pre-existing with a nested `Promise`, which is the commoner way in and measures 3 slots per iteration on `main` and on this branch alike. So this adds a trigger rather than a capability, the same reasoning that kept the `oom_poisoned` latch on every path in #110. Filed as #120 rather than fixed here, because the fix is a decision about whether the log path may raise at all, and about what should happen to a host error met while converting a logged value.

**Passing one to a `define_function` block leaks.** The argument loop has no `rb_protect`, so the raise skips the `JS_FreeValue`s: about 10 objects and 2.4KB per call, 3000 objects and 716800 bytes over 300 iterations, where `main` retains nothing on this shape. The mechanism is #107 rather than this diff, and a `Promise` argument leaks 1800 objects and 507904 bytes on both branches. Bounded at one per `eval_code` call here, since that raise is not bridged into a catchable throw. Noted on #107.

**A proxy chain deeper than 1000 now raises too.** `js_resolve_proxy`'s other `-1` path is a stack overflow, so a deep chain of live proxies reports `Quickjs::RuntimeError: stack overflow` where `main` returned `[]`. The guest gets the same "stack overflow" from `JSON.stringify` and `Array.isArray` at that depth, so it holds to the same rationale, but the comment in the diff says "the guest's own TypeError" and that is narrower than what the branch actually renders.

