### PR TITLE
Ask the allocator whether the heap ran out, not the guest

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,12 +402,15 @@ vm.memory_usage
 #      atom_count: Integer, str_count: Integer, obj_count: Integer,
 #      prop_count: Integer, shape_count: Integer,
 #      js_func_count: Integer, js_func_code_size: Integer,
-#      c_func_count: Integer, array_count: Integer }
+#      c_func_count: Integer, array_count: Integer,
+#      alloc_refusals: Integer }
 
 vm.gc!             # trigger a QuickJS GC cycle; returns nil
 
 vm.memory_poisoned? #=> false (true once the VM has hit out-of-memory)
 ```
+
+`alloc_refusals` in `memory_usage` counts the allocations this VM asked for and did not get. QuickJS carries on correctly through some of them, so a nonzero count is not by itself a VM in trouble; it is the one number that says the ceiling was reached at all, which `malloc_size` cannot once the failed allocation has been rolled back.
 
 When the JS heap exhausts its memory limit, QuickJS enters a fragile state where further evaluation can segfault the process. `memory_poisoned?` flips to `true` after such an event, and subsequent `eval_code` / `call` calls raise `Quickjs::RuntimeError` immediately instead of risking a crash. Rescue it and recreate the VM.
 

--- a/README.md
+++ b/README.md
@@ -410,9 +410,15 @@ vm.gc!             # trigger a QuickJS GC cycle; returns nil
 vm.memory_poisoned? #=> false (true once the VM has hit out-of-memory)
 ```
 
+When the JS heap exhausts its memory limit, QuickJS enters a fragile state where further evaluation can segfault the process. `memory_poisoned?` flips to `true` after such an event, and subsequent `eval_code` / `call` calls raise `Quickjs::RuntimeError` immediately instead of risking a crash. Rescue it and recreate the VM.
+
+The flag takes two things together, and neither on its own. The allocator must have actually refused an allocation during the call, which no JavaScript can bring about by saying so, and QuickJS must be the one reporting it: its own out-of-memory error, an error whose message it could not afford to build, or no error object at all. So JavaScript that merely throws an error reading `out of memory` leaves the VM alone, and a real exhaustion is still caught at either end where there is nothing left to read, whether it arrives as a throw or as a promise rejection.
+
 `alloc_refusals` in `memory_usage` counts the allocations this VM asked for and did not get. QuickJS carries on correctly through some of them, so a nonzero count is not by itself a VM in trouble; it is the one number that says the ceiling was reached at all, which `malloc_size` cannot once the failed allocation has been rolled back.
 
-When the JS heap exhausts its memory limit, QuickJS enters a fragile state where further evaluation can segfault the process. `memory_poisoned?` flips to `true` after such an event, and subsequent `eval_code` / `call` calls raise `Quickjs::RuntimeError` immediately instead of risking a crash. Rescue it and recreate the VM.
+Whatever the guest says for itself is reported as itself. JavaScript that catches its own out-of-memory and then throws a `TypeError`, or hands you a rejection carrying its own error, or runs past its `timeout_msec`, gets that error and keeps its VM, exactly as it would have without the earlier exhaustion. The heap is condemned when QuickJS says the heap is the problem, and not when the guest happens to fail next.
+
+One asymmetry to know about: an exhaustion that arrives as a promise rejection is judged when the rejection is seen with no handler attached, so `f().catch(() => {})` around a real exhaustion condemns the VM where the synchronous `try { … } catch {}` around the same allocation does not. Nothing revisits that verdict once a handler attaches. A handler attached before the rejection happens, as in `async function f() { await null; BIG }`, is never seen by it at all and leaves the VM alone.
 
 ```rb
 vm = Quickjs::VM.new(memory_limit: 256 * 1024 * 1024)

--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -524,6 +524,10 @@ typedef struct
   // fired inside it. Sticky for the life of the hold rather than per-read: the
   // fact it records is about the evaluation, not about one property.
   bool interrupted;
+  // Set when a conversion was substituted away because the heap ran out inside
+  // it. The VM is condemned at the moment it is noticed; this is for the
+  // renderer to say so rather than report the substituted read.
+  bool oom;
   JsHeld held_inline[JS_HOLD_INLINE];
 } JsHold;
 
@@ -534,6 +538,7 @@ static void js_hold_init(JsHold *hold, JSContext *ctx)
   hold->count = 0;
   hold->capacity = JS_HOLD_INLINE;
   hold->interrupted = false;
+  hold->oom = false;
 }
 
 // The deepest block below holds eight references at once — an exception, three
@@ -585,6 +590,53 @@ static bool eval_budget_lapsed(VMData *data)
   return data->eval_timer_armed && eval_elapsed_ms(data->eval_time) >= data->eval_time->limit_ms;
 }
 
+// Whether a throw is QuickJS reporting that the heap ran out. Recognised by
+// the message alone, and only as an own data property: a real out-of-memory
+// error is built with `message` defined directly on it, and reading an own
+// data property runs nothing — where reading `name` walks the prototype and
+// either could be an accessor the guest installed, which is the hazard
+// eval_budget_lapsed was written to avoid. A Proxy is not JS_IsError, so its
+// traps never run either. Still forgeable with a plain data property, which is
+// the pre-existing weakness #111 records; what matters here is that nothing
+// guest-written runs on a throw that is about to be discarded.
+static bool js_is_out_of_memory(JSContext *ctx, JSValueConst j_val)
+{
+  if (!JS_IsError(ctx, j_val))
+    return false;
+
+  JSAtom message_atom = JS_NewAtom(ctx, "message");
+  JSPropertyDescriptor desc;
+  int found = JS_GetOwnProperty(ctx, &desc, j_val, message_atom);
+  JS_FreeAtom(ctx, message_atom);
+  if (found <= 0)
+    return false;
+
+  bool oom = false;
+  if ((desc.flags & JS_PROP_TMASK) == JS_PROP_NORMAL && JS_IsString(desc.value))
+  {
+    const char *message = JS_ToCString(ctx, desc.value);
+    if (message != NULL)
+    {
+      oom = strstr(message, "out of memory") != NULL;
+      JS_FreeCString(ctx, message);
+    }
+    else
+    {
+      // The value is already a string, so the only way this conversion fails
+      // is allocation — flattening a rope, transcoding non-ASCII — which on a
+      // heap that just ran out is the same news one level deeper. QuickJS's
+      // own message is flat ASCII and converts without allocating, so this
+      // branch is only ever the inspection itself running out.
+      JS_FreeValue(ctx, JS_GetException(ctx));
+      oom = true;
+    }
+  }
+  JS_FreeValue(ctx, desc.value);
+  JS_FreeValue(ctx, desc.getter);
+  JS_FreeValue(ctx, desc.setter);
+  return oom;
+}
+
 // JS_ToCString converts through the value's own toString, so it answers NULL
 // whenever that throws — a getter that raises, a Symbol, a Proxy that refuses —
 // and not only when it runs out of memory. This keeps the NULL, for the two
@@ -612,8 +664,20 @@ static const char *js_hold_cstring_or_null(JsHold *hold, JSValue j_val)
   if (!NIL_P(r_ruby_error))
     rb_exc_raise(r_ruby_error);
 
-  if (eval_budget_lapsed(JS_GetContextOpaque(hold->ctx)))
+  VMData *data = JS_GetContextOpaque(hold->ctx);
+  if (eval_budget_lapsed(data))
     hold->interrupted = true;
+
+  // A heap that ran out inside the read is the one throw here that must not
+  // be quietly substituted: the latch check_oom_poisoned depends on would
+  // otherwise never set, and the next evaluation would run on the heap the
+  // latch exists to refuse. Latched here, at every hold, rather than left to
+  // the renderer, since the log row and the rejection reason have no renderer.
+  if (js_is_out_of_memory(hold->ctx, j_pending))
+  {
+    data->oom_poisoned = true;
+    hold->oom = true;
+  }
 
   return NULL;
 }
@@ -706,6 +770,21 @@ static void raise_if_interrupted(JsHold *hold)
     rb_exc_raise(r_interrupted_error());
 }
 
+// The heap running out inside a read outranks both the read and the budget:
+// the VM is already condemned, and the caller is told what a top-level
+// out-of-memory tells it, so the advice to recreate the VM reads the same.
+static VALUE r_out_of_memory_error(void)
+{
+  VALUE r_message = rb_str_new2("out of memory");
+  return rb_funcall(QUICKJSRB_ERROR_FOR(QUICKJSRB_ROOT_RUNTIME_ERROR), rb_intern("new"), 2, r_message, Qnil);
+}
+
+static void raise_if_out_of_memory(JsHold *hold)
+{
+  if (hold->oom)
+    rb_exc_raise(r_out_of_memory_error());
+}
+
 struct js_exception_render
 {
   JSContext *ctx;
@@ -739,6 +818,7 @@ static VALUE js_exception_render_run(VALUE r_render)
       VALUE r_headline = rb_str_new2(js_hold_format(hold, "Uncaught '%s'", errorMessage));
       dispatch_log(data, "error", rb_ary_new3(1, r_log_body_new(r_headline, r_headline)));
     }
+    raise_if_out_of_memory(hold);
     raise_if_interrupted(hold);
 
     rb_exc_raise(rb_funcall(QUICKJSRB_ERROR_FOR(QUICKJSRB_ROOT_RUNTIME_ERROR), rb_intern("new"), 2, rb_str_new2(errorMessage), Qnil));
@@ -770,6 +850,7 @@ static VALUE js_exception_render_run(VALUE r_render)
     VALUE r_headline = rb_str_new2(js_hold_format(hold, "Uncaught %s: %s\n%s", errorClassName, errorClassMessage, stackTrace));
     dispatch_log(data, "error", rb_ary_new3(1, r_log_body_new(r_headline, r_headline)));
   }
+  raise_if_out_of_memory(hold);
   raise_if_interrupted(hold);
 
   VALUE r_error_class, r_error_message = rb_str_new2(errorClassMessage);
@@ -1304,9 +1385,12 @@ static VALUE r_exception_from_js_reason(JSContext *ctx, JSValueConst j_reason)
   conversion.j_reason = j_reason;
   js_hold_init(&conversion.hold, ctx);
   VALUE r_exc = rb_ensure(js_reason_conversion_run, (VALUE)&conversion, js_hold_release, (VALUE)&conversion.hold);
-  // The flag outlives the release, which is why it is sticky: a budget that
-  // lapsed while the reason was read is what the listener hears about, since
-  // the tracker cannot raise out and there may be no next interrupt check.
+  // The flags outlive the release, which is why they are sticky: a heap that
+  // ran out or a budget that lapsed while the reason was read is what the
+  // listener hears about, since the tracker cannot raise out and there may be
+  // no next interrupt check. The same precedence as the renderer.
+  if (conversion.hold.oom)
+    return r_out_of_memory_error();
   return conversion.hold.interrupted ? r_interrupted_error() : r_exc;
 }
 

--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -524,10 +524,6 @@ typedef struct
   // fired inside it. Sticky for the life of the hold rather than per-read: the
   // fact it records is about the evaluation, not about one property.
   bool interrupted;
-  // Set when a conversion was substituted away because the heap ran out inside
-  // it. The VM is condemned at the moment it is noticed; this is for the
-  // renderer to say so rather than report the substituted read.
-  bool oom;
   JsHeld held_inline[JS_HOLD_INLINE];
 } JsHold;
 
@@ -538,7 +534,6 @@ static void js_hold_init(JsHold *hold, JSContext *ctx)
   hold->count = 0;
   hold->capacity = JS_HOLD_INLINE;
   hold->interrupted = false;
-  hold->oom = false;
 }
 
 // The deepest block below holds eight references at once — an exception, three
@@ -590,53 +585,6 @@ static bool eval_budget_lapsed(VMData *data)
   return data->eval_timer_armed && eval_elapsed_ms(data->eval_time) >= data->eval_time->limit_ms;
 }
 
-// Whether a throw is QuickJS reporting that the heap ran out. Recognised by
-// the message alone, and only as an own data property: a real out-of-memory
-// error is built with `message` defined directly on it, and reading an own
-// data property runs nothing — where reading `name` walks the prototype and
-// either could be an accessor the guest installed, which is the hazard
-// eval_budget_lapsed was written to avoid. A Proxy is not JS_IsError, so its
-// traps never run either. Still forgeable with a plain data property, which is
-// the pre-existing weakness #111 records; what matters here is that nothing
-// guest-written runs on a throw that is about to be discarded.
-static bool js_is_out_of_memory(JSContext *ctx, JSValueConst j_val)
-{
-  if (!JS_IsError(ctx, j_val))
-    return false;
-
-  JSAtom message_atom = JS_NewAtom(ctx, "message");
-  JSPropertyDescriptor desc;
-  int found = JS_GetOwnProperty(ctx, &desc, j_val, message_atom);
-  JS_FreeAtom(ctx, message_atom);
-  if (found <= 0)
-    return false;
-
-  bool oom = false;
-  if ((desc.flags & JS_PROP_TMASK) == JS_PROP_NORMAL && JS_IsString(desc.value))
-  {
-    const char *message = JS_ToCString(ctx, desc.value);
-    if (message != NULL)
-    {
-      oom = strstr(message, "out of memory") != NULL;
-      JS_FreeCString(ctx, message);
-    }
-    else
-    {
-      // The value is already a string, so the only way this conversion fails
-      // is allocation — flattening a rope, transcoding non-ASCII — which on a
-      // heap that just ran out is the same news one level deeper. QuickJS's
-      // own message is flat ASCII and converts without allocating, so this
-      // branch is only ever the inspection itself running out.
-      JS_FreeValue(ctx, JS_GetException(ctx));
-      oom = true;
-    }
-  }
-  JS_FreeValue(ctx, desc.value);
-  JS_FreeValue(ctx, desc.getter);
-  JS_FreeValue(ctx, desc.setter);
-  return oom;
-}
-
 // JS_ToCString converts through the value's own toString, so it answers NULL
 // whenever that throws — a getter that raises, a Symbol, a Proxy that refuses —
 // and not only when it runs out of memory. This keeps the NULL, for the two
@@ -664,20 +612,8 @@ static const char *js_hold_cstring_or_null(JsHold *hold, JSValue j_val)
   if (!NIL_P(r_ruby_error))
     rb_exc_raise(r_ruby_error);
 
-  VMData *data = JS_GetContextOpaque(hold->ctx);
-  if (eval_budget_lapsed(data))
+  if (eval_budget_lapsed(JS_GetContextOpaque(hold->ctx)))
     hold->interrupted = true;
-
-  // A heap that ran out inside the read is the one throw here that must not
-  // be quietly substituted: the latch check_oom_poisoned depends on would
-  // otherwise never set, and the next evaluation would run on the heap the
-  // latch exists to refuse. Latched here, at every hold, rather than left to
-  // the renderer, since the log row and the rejection reason have no renderer.
-  if (js_is_out_of_memory(hold->ctx, j_pending))
-  {
-    data->oom_poisoned = true;
-    hold->oom = true;
-  }
 
   return NULL;
 }
@@ -770,21 +706,6 @@ static void raise_if_interrupted(JsHold *hold)
     rb_exc_raise(r_interrupted_error());
 }
 
-// The heap running out inside a read outranks both the read and the budget:
-// the VM is already condemned, and the caller is told what a top-level
-// out-of-memory tells it, so the advice to recreate the VM reads the same.
-static VALUE r_out_of_memory_error(void)
-{
-  VALUE r_message = rb_str_new2("out of memory");
-  return rb_funcall(QUICKJSRB_ERROR_FOR(QUICKJSRB_ROOT_RUNTIME_ERROR), rb_intern("new"), 2, r_message, Qnil);
-}
-
-static void raise_if_out_of_memory(JsHold *hold)
-{
-  if (hold->oom)
-    rb_exc_raise(r_out_of_memory_error());
-}
-
 struct js_exception_render
 {
   JSContext *ctx;
@@ -818,7 +739,6 @@ static VALUE js_exception_render_run(VALUE r_render)
       VALUE r_headline = rb_str_new2(js_hold_format(hold, "Uncaught '%s'", errorMessage));
       dispatch_log(data, "error", rb_ary_new3(1, r_log_body_new(r_headline, r_headline)));
     }
-    raise_if_out_of_memory(hold);
     raise_if_interrupted(hold);
 
     rb_exc_raise(rb_funcall(QUICKJSRB_ERROR_FOR(QUICKJSRB_ROOT_RUNTIME_ERROR), rb_intern("new"), 2, rb_str_new2(errorMessage), Qnil));
@@ -850,7 +770,6 @@ static VALUE js_exception_render_run(VALUE r_render)
     VALUE r_headline = rb_str_new2(js_hold_format(hold, "Uncaught %s: %s\n%s", errorClassName, errorClassMessage, stackTrace));
     dispatch_log(data, "error", rb_ary_new3(1, r_log_body_new(r_headline, r_headline)));
   }
-  raise_if_out_of_memory(hold);
   raise_if_interrupted(hold);
 
   VALUE r_error_class, r_error_message = rb_str_new2(errorClassMessage);
@@ -1385,12 +1304,9 @@ static VALUE r_exception_from_js_reason(JSContext *ctx, JSValueConst j_reason)
   conversion.j_reason = j_reason;
   js_hold_init(&conversion.hold, ctx);
   VALUE r_exc = rb_ensure(js_reason_conversion_run, (VALUE)&conversion, js_hold_release, (VALUE)&conversion.hold);
-  // The flags outlive the release, which is why they are sticky: a heap that
-  // ran out or a budget that lapsed while the reason was read is what the
-  // listener hears about, since the tracker cannot raise out and there may be
-  // no next interrupt check. The same precedence as the renderer.
-  if (conversion.hold.oom)
-    return r_out_of_memory_error();
+  // The flag outlives the release, which is why it is sticky: a budget that
+  // lapsed while the reason was read is what the listener hears about, since
+  // the tracker cannot raise out and there may be no next interrupt check.
   return conversion.hold.interrupted ? r_interrupted_error() : r_exc;
 }
 
@@ -4043,6 +3959,12 @@ static VALUE vm_m_memoryUsage(VALUE r_self)
   rb_hash_aset(h, ID2SYM(rb_intern("js_func_code_size")), LL2NUM(s.js_func_code_size));
   rb_hash_aset(h, ID2SYM(rb_intern("c_func_count")), LL2NUM(s.c_func_count));
   rb_hash_aset(h, ID2SYM(rb_intern("array_count")), LL2NUM(s.array_count));
+  // Ours rather than QuickJS's: the number of allocations this VM asked for
+  // and did not get. QuickJS carries on correctly through some of them, so a
+  // nonzero count is not by itself a VM in trouble; it is the one number that
+  // says the ceiling was reached at all, which memory_poisoned? cannot, and
+  // malloc_size cannot either once the failed allocation is rolled back.
+  rb_hash_aset(h, ID2SYM(rb_intern("alloc_refusals")), ULL2NUM(data->alloc_refusals));
   return h;
 }
 

--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -585,6 +585,161 @@ static bool eval_budget_lapsed(VMData *data)
   return data->eval_timer_armed && eval_elapsed_ms(data->eval_time) >= data->eval_time->limit_ms;
 }
 
+// Whether the allocator refused an allocation inside the operation now
+// running. The refusal happens in quickjsrb_malloc, below the guest, before
+// QuickJS has decided whether it can even afford to build an error, so no
+// property is read to find it and there is no sentence for a guest to write.
+// The scope is opened by enter_oom_scope at every public entry point.
+//
+// Necessary, and on its own not sufficient. QuickJS tolerates some refusals:
+// JS_NewShape and JS_NewAtom ignore what resize_shape_hash and
+// JS_ResizeAtomHash answer, and the threshold only advances on success, so
+// near the ceiling every later shape retries the refused block while the
+// runtime stays correct and nothing ever throws. A reader that condemned on
+// the count alone would condemn a healthy VM for whatever the guest threw
+// next, which is the sentence #111 opened with, re-entered through a key the
+// guest cannot write but also cannot see.
+static bool allocator_refused(VMData *data)
+{
+  return data->alloc_refusals > data->alloc_refusals_at_scope;
+}
+
+// Whether a value is a Ruby exception the bridge parked, read the way the
+// message is read: an own data property only, so nothing guest-written runs,
+// and a lookup that leaves alive_objects alone (find_ruby_error is the one
+// thing allowed to take an entry out of it). A bridged error is the host's
+// news and never QuickJS's, whatever its message happens to say.
+static bool js_carries_bridged_error(JSContext *ctx, JSValueConst j_val, VMData *data)
+{
+  // The lookup below reads the Ruby heap, and the rejection tracker reaches
+  // this from inside a GVL-released evaluation: the latch sits above the
+  // listener check on purpose, and that check was what used to keep every
+  // Ruby call here on the GVL-held path. Nothing is lost by refusing to look,
+  // because can_eval_gvl_free releases the GVL only for a VM with no bridges
+  // of any kind, and alive_objects is filled by bridges alone, so there is
+  // nothing to find on that path by construction.
+  if (data->gvl_released_js)
+    return false;
+
+  if (!JS_IsObject(j_val))
+    return false;
+
+  JSAtom id_atom = JS_NewAtom(ctx, "rb_object_id");
+  JSPropertyDescriptor desc;
+  int found = JS_GetOwnProperty(ctx, &desc, j_val, id_atom);
+  JS_FreeAtom(ctx, id_atom);
+  if (found <= 0)
+    return false;
+
+  bool bridged = false;
+  if ((desc.flags & JS_PROP_TMASK) == JS_PROP_NORMAL && JS_VALUE_GET_NORM_TAG(desc.value) == JS_TAG_INT)
+  {
+    int32_t object_id = 0;
+    JS_ToInt32(ctx, &object_id, desc.value);
+    if (object_id > 0)
+      bridged = !NIL_P(rb_hash_aref(data->alive_objects, INT2NUM(object_id)));
+  }
+  JS_FreeValue(ctx, desc.value);
+  JS_FreeValue(ctx, desc.getter);
+  JS_FreeValue(ctx, desc.setter);
+  return bridged;
+}
+
+// The other half: QuickJS's own report that it ran out, taken together with a
+// refusal that really happened. Three shapes count, and the same three are
+// asked of a pending exception and of a rejection reason alike, because an
+// exhaustion that rejects is the same exhaustion as one that throws.
+//
+// Its out-of-memory error carries "out of memory" in message, read as an own
+// data property only. QuickJS defines it directly on the error it builds; an
+// accessor is not QuickJS's and is not consulted, and a Proxy is not
+// JS_IsError, so nothing guest-written runs on a throw that is about to be
+// discarded. The sentence alone is forgeable and always was, which is why it
+// is only ever asked alongside the count, and why a bridged host error is
+// turned away inside that branch rather than believed.
+//
+// The exhaustion that built its Error and got no further leaves the
+// JS_EXCEPTION sentinel as that message: an Error whose message is not a
+// string, which only QuickJS can make.
+//
+// And the end with no error at all, which is two values rather than one.
+// JS_ThrowError2 gives up with JS_NULL when it cannot allocate the object it
+// was going to report with, and __JS_NewAtom growing rt->atom_array has no
+// context to throw from, so the interpreter throws with the exception still
+// uninitialised. #116 is the first of those and a twelve-thousand-key object
+// is the second.
+//
+// A guest can write `throw null`, and `Promise.reject(null)`, and nothing in
+// the value tells either apart from JS_ThrowError2 giving up. So that last
+// shape is the one a guest can enter: after any refusal in the call, tolerated
+// ones included, both read as the heap having run out. Measured against
+// dropping it, which costs #116 its diagnosis and takes the rejection end with
+// it, so it stays and the exposure is written down instead. An uninitialised
+// value has no such twin, since the guest cannot produce one.
+static bool js_reports_out_of_memory(JSContext *ctx, JSValueConst j_val, bool refused)
+{
+  if (!refused)
+    return false;
+
+  // Two values QuickJS leaves where an error should be, and a guest can write
+  // neither as a throw: JS_ThrowError2 gives up with JS_NULL when it cannot
+  // build the object, and __JS_NewAtom growing rt->atom_array has no context to
+  // throw from at all, so the interpreter throws with the exception still
+  // uninitialised. The second reads as "[unsupported type]" without this.
+  if (JS_IsNull(j_val) || JS_IsUninitialized(j_val))
+    return true;
+
+  if (!JS_IsError(ctx, j_val))
+    return false;
+
+  JSAtom message_atom = JS_NewAtom(ctx, "message");
+  JSPropertyDescriptor desc;
+  int found = JS_GetOwnProperty(ctx, &desc, j_val, message_atom);
+  JS_FreeAtom(ctx, message_atom);
+  if (found <= 0)
+    return false;
+
+  bool reported = false;
+  // The exhaustion that got as far as an Error and no further. JS_ThrowError2
+  // allocates the object, and JS_NewString("out of memory") is then refused
+  // inside in_out_of_memory, so JS_DefinePropertyValue stores the JS_EXCEPTION
+  // sentinel as the own message: an Error whose message is not a string, which
+  // is a thing only QuickJS can make. Nothing a guest writes can put that
+  // value in a property, so it needs no sentence to back it up.
+  if ((desc.flags & JS_PROP_TMASK) == JS_PROP_NORMAL && JS_IsException(desc.value))
+  {
+    reported = true;
+  }
+  else if ((desc.flags & JS_PROP_TMASK) == JS_PROP_NORMAL && JS_IsString(desc.value))
+  {
+    const char *message = JS_ToCString(ctx, desc.value);
+    if (message != NULL)
+    {
+      // Asked here rather than of the value on the way in: JS_IsError above has
+      // already turned away a Proxy, so reading an own property runs no trap,
+      // and this is the only shape a bridged host error can satisfy. A bridge
+      // reporting a failure of its own is the host's news whatever its message
+      // happens to say.
+      reported = strstr(message, "out of memory") != NULL &&
+                 !js_carries_bridged_error(ctx, j_val, JS_GetContextOpaque(ctx));
+      JS_FreeCString(ctx, message);
+    }
+    else
+    {
+      // The value is already a string, so the only way this conversion fails
+      // is allocation, which on a heap that just refused is the same news one
+      // level deeper. QuickJS's own message is flat ASCII and converts without
+      // allocating, so this branch is only ever the inspection running out.
+      JS_FreeValue(ctx, JS_GetException(ctx));
+      reported = true;
+    }
+  }
+  JS_FreeValue(ctx, desc.value);
+  JS_FreeValue(ctx, desc.getter);
+  JS_FreeValue(ctx, desc.setter);
+  return reported;
+}
+
 // JS_ToCString converts through the value's own toString, so it answers NULL
 // whenever that throws — a getter that raises, a Symbol, a Proxy that refuses —
 // and not only when it runs out of memory. This keeps the NULL, for the two
@@ -592,6 +747,12 @@ static bool eval_budget_lapsed(VMData *data)
 // stand in for it.
 static const char *js_hold_cstring_or_null(JsHold *hold, JSValue j_val)
 {
+  VMData *data = JS_GetContextOpaque(hold->ctx);
+  // The window is this read, not the call it sits in. Asked of the whole
+  // scope, a read that answers NULL for its own reasons — a Symbol, a toString
+  // written to throw — would report a refusal the guest had already caught and
+  // recovered from, and condemn a VM whose call went on to return normally.
+  uint64_t refusals_before = data->alloc_refusals;
   const char *str = JS_ToCString(hold->ctx, j_val);
   if (str != NULL)
     return js_hold_own_cstring(hold, str);
@@ -608,11 +769,27 @@ static const char *js_hold_cstring_or_null(JsHold *hold, JSValue j_val)
   // remembering is not the throw but the clock: a read the budget outlived says
   // nothing about the value and everything about the evaluation.
   JSValue j_pending = js_hold_value(hold, JS_GetException(hold->ctx));
+
+  // Before the bridge exit below, which raises: a read that ran out and then
+  // found a host error waiting would unwind past the latch and leave the VM
+  // running on the heap that refused. What is pending is the throw that ended
+  // the read, so it is the thing to ask whether QuickJS is reporting a heap
+  // that ran out or the value simply having no string form.
+  // The window covers this read, and the fetch above it when that is where
+  // the failure happened: a caller handing in JS_EXCEPTION has already had its
+  // JS_GetPropertyStr run a getter and come back empty, and a getter that ran
+  // out did so before this window opened. Reading the call scope for that case
+  // is safe because the pending value still has to be QuickJS reporting.
+  bool refused = data->alloc_refusals > refusals_before ||
+                 (JS_IsException(j_val) && allocator_refused(data));
+  if (js_reports_out_of_memory(hold->ctx, j_pending, refused))
+    data->oom_poisoned = true;
+
   VALUE r_ruby_error = find_ruby_error(hold->ctx, j_pending);
   if (!NIL_P(r_ruby_error))
     rb_exc_raise(r_ruby_error);
 
-  if (eval_budget_lapsed(JS_GetContextOpaque(hold->ctx)))
+  if (eval_budget_lapsed(data))
     hold->interrupted = true;
 
   return NULL;
@@ -706,16 +883,65 @@ static void raise_if_interrupted(JsHold *hold)
     rb_exc_raise(r_interrupted_error());
 }
 
+// The heap running out inside a read outranks both the read and the budget:
+// the VM is already condemned, and the caller is told what a top-level
+// out-of-memory tells it, so the advice to recreate the VM reads the same.
+static VALUE r_out_of_memory_error(void)
+{
+  VALUE r_message = rb_str_new2("out of memory");
+  return rb_funcall(QUICKJSRB_ERROR_FOR(QUICKJSRB_ROOT_RUNTIME_ERROR), rb_intern("new"), 2, r_message, Qnil);
+}
+
+// Asked of the scope rather than of one hold. The flag a hold used to carry
+// was set only where allocator_refused was already true and read where it
+// still is, so it said nothing the counter does not, and a flag copied along
+// a path that can raise is a flag that can be lost. The scope also covers the
+// throw being rendered, including the end where QuickJS could not allocate
+// the error object either and what is pending is not an Error at all.
+//
+// A refusal outranks the class the throw carries: a guest that catches an
+// out-of-memory and then throws a TypeError hears "out of memory" rather than
+// TypeError. That is the heap talking rather than the guest, and the VM is
+// condemned either way, so the caller is better told why.
+// Condemns the heap, and answers whether it did. Split from the raise below
+// because the latch has to be set before dispatch_log runs: an on_log listener
+// can re-enter the VM, and a nested entry consults oom_poisoned to refuse.
+// Ordered before it the listener is turned away; after it, it ran JS on the
+// heap that had just refused.
+static bool condemn_if_out_of_memory(VMData *data, JSContext *ctx, JSValueConst j_val)
+{
+  if (!js_reports_out_of_memory(ctx, j_val, allocator_refused(data)))
+    return false;
+
+  data->oom_poisoned = true;
+  return true;
+}
+
+// A refusal QuickJS reported outranks the class the throw carries: a guest that
+// catches an out-of-memory and then throws a TypeError hears "out of memory".
+// That is the heap talking rather than the guest, and the VM is condemned
+// either way, so the caller is better told why. A guest that catches it and
+// returns keeps its VM, and so does one whose next throw is its own: nothing
+// QuickJS wrote is pending by then, and the count alone does not decide.
+static void raise_if_out_of_memory(bool out_of_memory)
+{
+  if (out_of_memory)
+    rb_exc_raise(r_out_of_memory_error());
+}
+
 struct js_exception_render
 {
   JSContext *ctx;
   // Whether the exception is the evaluation's own result. Only then is it news:
-  // it gets the "Uncaught" row the console would have printed, and an
-  // out-of-memory in it condemns the VM. An exception raised part-way through
-  // converting a value that did return is on its way to the caller as that
-  // call's error — telling the log listener it went uncaught would be the
-  // opposite of what happened, and the heap it was found on is the heap of a
-  // run that finished.
+  // it gets the "Uncaught" row the console would have printed. An exception
+  // raised part-way through converting a value that did return is on its way to
+  // the caller as that call's error, and telling the log listener it went
+  // uncaught would be the opposite of what happened.
+  //
+  // The out-of-memory latch is not keyed on this and reads the same either way.
+  // It was, while the latch lived in the class cascade below and only the
+  // uncaught path reached it; the heap is a fact about the call rather than
+  // about which of its exceptions is being rendered.
   bool uncaught;
   JsHold hold;
 };
@@ -727,18 +953,27 @@ static VALUE js_exception_render_run(VALUE r_render)
   JsHold *hold = &render->hold;
   VMData *data = JS_GetContextOpaque(ctx);
 
+  // What this render condemns the VM for, told apart from what it inherited.
+  bool was_condemned = data->oom_poisoned;
+
   JSValue j_exceptionVal = js_hold_value(hold, JS_GetException(ctx));
 
   if (!JS_IsError(ctx, j_exceptionVal))
   {
     // A thrown string, number or bare object: there is no name or stack to ask
     // for, only what the value itself says.
+    bool out_of_memory = condemn_if_out_of_memory(data, ctx, j_exceptionVal);
     const char *errorMessage = js_hold_cstring(hold, j_exceptionVal, QUICKJSRB_UNRENDERABLE);
+    // The read itself can be the thing that runs out, and the hold condemns
+    // the VM when it does. Asked after the read for that reason, and before
+    // the row is dispatched, so a listener that re-enters is turned away.
+    out_of_memory = out_of_memory || (!was_condemned && data->oom_poisoned);
     if (render->uncaught)
     {
       VALUE r_headline = rb_str_new2(js_hold_format(hold, "Uncaught '%s'", errorMessage));
       dispatch_log(data, "error", rb_ary_new3(1, r_log_body_new(r_headline, r_headline)));
     }
+    raise_if_out_of_memory(out_of_memory);
     raise_if_interrupted(hold);
 
     rb_exc_raise(rb_funcall(QUICKJSRB_ERROR_FOR(QUICKJSRB_ROOT_RUNTIME_ERROR), rb_intern("new"), 2, rb_str_new2(errorMessage), Qnil));
@@ -746,8 +981,20 @@ static VALUE js_exception_render_run(VALUE r_render)
 
   VALUE r_maybe_ruby_error = find_ruby_error(ctx, j_exceptionVal);
   if (!NIL_P(r_maybe_ruby_error))
+  {
+    // The host error is what comes back out: it is the bridge reporting a
+    // failure of its own, and find_ruby_error is the only thing that takes it
+    // out of alive_objects.
+    // No reader here. What is pending is the bridged error itself, carrying
+    // the Ruby exception message rather than anything QuickJS wrote, so there
+    // is nothing on this exit that could be the heap reporting: a refusal the
+    // guest met and recovered from before calling the bridge is the guest's
+    // business, and one QuickJS reported would not be wearing an rb_object_id.
     rb_exc_raise(r_maybe_ruby_error);
+  }
   // will support other errors like just returning an instance of Error
+
+  bool out_of_memory = condemn_if_out_of_memory(data, ctx, j_exceptionVal);
 
   JSValue j_errorClassName = js_hold_value(hold, JS_GetPropertyStr(ctx, j_exceptionVal, "name"));
   const char *readClassName = js_hold_cstring_or_null(hold, j_errorClassName);
@@ -765,11 +1012,16 @@ static VALUE js_exception_render_run(VALUE r_render)
   // apology reads as a frame there.
   const char *stackTrace = js_hold_cstring(hold, j_stackTrace, "");
 
+  // As above: any of the three reads can run out, and the hold condemns when
+  // one does.
+  out_of_memory = out_of_memory || (!was_condemned && data->oom_poisoned);
+
   if (render->uncaught)
   {
     VALUE r_headline = rb_str_new2(js_hold_format(hold, "Uncaught %s: %s\n%s", errorClassName, errorClassMessage, stackTrace));
     dispatch_log(data, "error", rb_ary_new3(1, r_log_body_new(r_headline, r_headline)));
   }
+  raise_if_out_of_memory(out_of_memory);
   raise_if_interrupted(hold);
 
   VALUE r_error_class, r_error_message = rb_str_new2(errorClassMessage);
@@ -786,23 +1038,6 @@ static VALUE js_exception_render_run(VALUE r_render)
   else if (strcmp(errorClassName, "Quickjs::InterruptedError") == 0)
   {
     r_error_class = QUICKJSRB_ERROR_FOR(QUICKJSRB_INTERRUPTED_ERROR);
-  }
-  else if (strcmp(errorClassName, "InternalError") == 0 && strstr(errorClassMessage, "out of memory") != NULL)
-  {
-    // Once OOM has fired, the QuickJS heap is in a state where another
-    // throw inside the parser-error path can corrupt the shape table and
-    // segfault. Mark the VM so further eval/call calls refuse cleanly.
-    //
-    // This is the one thing the uncaught path does not keep to itself. Running
-    // out of memory is a fact about the heap, not about who was asking: a
-    // getter on an object the evaluation successfully returned allocates on the
-    // same heap as the evaluation did, and `({get x() { return new
-    // Array(2_000_000).fill(0) }})` reaches OOM here with the result already in
-    // hand. Both strings are guest-writable, so a forged InternalError condemns
-    // the VM too — but that is reachable from any getter and always has been,
-    // and refusing to latch here would trade a real guard for no ground.
-    data->oom_poisoned = true;
-    r_error_class = QUICKJSRB_ERROR_FOR(QUICKJSRB_ROOT_RUNTIME_ERROR);
   }
   else
   {
@@ -1303,10 +1538,21 @@ static VALUE r_exception_from_js_reason(JSContext *ctx, JSValueConst j_reason)
   conversion.ctx = ctx;
   conversion.j_reason = j_reason;
   js_hold_init(&conversion.hold, ctx);
+  VMData *data = JS_GetContextOpaque(ctx);
+  // The window is the conversion, for the reason the hold's own read narrows
+  // to itself: a refusal the guest met and caught earlier in the call says
+  // nothing about this reason, and reporting it here would hand the listener
+  // "out of memory" in place of the rejection it is waiting to hear about.
+  bool was_condemned = data->oom_poisoned;
   VALUE r_exc = rb_ensure(js_reason_conversion_run, (VALUE)&conversion, js_hold_release, (VALUE)&conversion.hold);
-  // The flag outlives the release, which is why it is sticky: a budget that
-  // lapsed while the reason was read is what the listener hears about, since
-  // the tracker cannot raise out and there may be no next interrupt check.
+  // Read after the release: a heap that ran out or a budget that lapsed while
+  // the reason was read is what the listener hears about, since the tracker
+  // cannot raise out and there may be no next interrupt check. The lapse is a
+  // flag the hold carries, because a re-armed clock forgets; the refusal is a
+  // count on the VM, which forgets nothing. The same precedence as the
+  // renderer.
+  if (!was_condemned && data->oom_poisoned)
+    return r_out_of_memory_error();
   return conversion.hold.interrupted ? r_interrupted_error() : r_exc;
 }
 
@@ -1342,6 +1588,36 @@ static void quickjsrb_promise_rejection_tracker(
     return;
 
   VMData *data = JS_GetContextOpaque(ctx);
+
+  // A rejection nobody handled is not a recovery, so the heap is condemned
+  // here when QuickJS is the one reporting the reason, and before the listener
+  // check: with no listener registered there is no reader below at all, and a
+  // job that ran out inside drain_jobs! left the VM running on the heap that
+  // refused.
+  //
+  // The reason is asked the same questions a pending exception is, absent
+  // object included, because an exhaustion that arrives as a rejection is the
+  // same exhaustion: `async function f() { let n = null; for (;;) n = {n} }`
+  // rejects with the JS_NULL that JS_ThrowError2 could not replace with an
+  // Error, and asking a narrower question here meant the diagnosis depended on
+  // whether the chain was thrown or awaited. It costs the symmetric exposure:
+  // Promise.reject(null) after any refusal reads as the heap, as throw null
+  // does. Promise.reject() does not, since undefined is nothing QuickJS leaves.
+  //
+  // This fires at rejection time, and QuickJS calls the tracker again with
+  // is_handled once a handler attaches, which nothing here undoes. So a
+  // rejection carrying a real out-of-memory condemns even when the guest goes
+  // on to handle it, where the same exhaustion caught synchronously does not.
+  // Conservative and deliberate, but not symmetric with try/catch; deferring
+  // the latch to the end of the call is what would make them agree.
+  // Every uncaught throw reaches this tracker before the renderer does, since
+  // eval is async-wrapped, so the bridged errors pass through here too. The
+  // renderer answers them at its find_ruby_error exit, above every reader;
+  // here that has to be said out loud, or a host exception whose own message
+  // says the words is read as the heap.
+  if (js_reports_out_of_memory(ctx, reason, allocator_refused(data)))
+    data->oom_poisoned = true;
+
   if (NIL_P(data->on_unhandled_rejection))
     return;
 
@@ -1552,7 +1828,23 @@ struct log_row_build
 {
   struct quickjsrb_log_call *call;
   JsHold hold;
+  // The build is its own scope. Every reader reached from inside it — the row's
+  // own reads, and the renderers those reach through to_rb_value — then measures
+  // the build rather than the call, so a refusal the guest already caught and
+  // recovered from earlier in the call cannot be reported as this row's.
+  // Restored by the ensure, on the raising path too.
+  uint64_t scope_before;
 };
+
+// Owns the build's exit, raising or not: releases what the row held and
+// closes the scope the build opened.
+static VALUE r_log_row_ensure(VALUE r_build)
+{
+  struct log_row_build *build = (struct log_row_build *)r_build;
+  VMData *data = JS_GetContextOpaque(build->hold.ctx);
+  data->alloc_refusals_at_scope = build->scope_before;
+  return js_hold_release((VALUE)&build->hold);
+}
 
 static VALUE r_build_log_row(VALUE r_build)
 {
@@ -1613,7 +1905,9 @@ static VALUE r_build_and_dispatch_log(VALUE r_call)
   struct log_row_build build;
   build.call = call;
   js_hold_init(&build.hold, call->ctx);
-  VALUE r_row = rb_ensure(r_build_log_row, (VALUE)&build, js_hold_release, (VALUE)&build.hold);
+  build.scope_before = data->alloc_refusals_at_scope;
+  data->alloc_refusals_at_scope = data->alloc_refusals;
+  VALUE r_row = rb_ensure(r_build_log_row, (VALUE)&build, r_log_row_ensure, (VALUE)&build);
 
   // Carried out rather than raised here: a Ruby exception would be bridged
   // into a catchable JS Error, and a guest wrapping console.log in try/catch
@@ -1631,9 +1925,37 @@ static VALUE r_build_and_dispatch_log(VALUE r_call)
 // JS exception instead of a cross-boundary longjmp.
 static JSValue js_quickjsrb_log_inner(JSContext *ctx, int argc, JSValueConst *argv, const char *severity)
 {
+  VMData *data = JS_GetContextOpaque(ctx);
+  // Asked of the VM either side of the protect rather than carried out on the
+  // call. It covers the whole of it, the listener included: a listener that
+  // re-enters the VM and exhausts the heap in its own call condemns this one
+  // too, and the guest went on running here with nothing said. A nested call
+  // that merely meets a refusal and recovers is still its own business, since
+  // what is read is the verdict rather than the count.
   struct quickjsrb_log_call call = {ctx, argc, argv, severity, JS_UNDEFINED, false};
   int error;
   rb_protect(r_build_and_dispatch_log, (VALUE)&call, &error);
+  // The flag rather than a transition in it: inside a call it can only have
+  // been set by this call, since enter_oom_scope turns a condemned VM away at
+  // the door, so a heap something else in this call already exhausted stops
+  // the guest here too rather than letting it run to the end.
+  if (data->oom_poisoned)
+  {
+    // Ahead of the lapse, as in the renderer: a heap that ran out is a fact
+    // about the VM rather than about this evaluation. Without this the
+    // evaluation ran on, because QuickJS was never told its heap had run out:
+    // the throw that said so was substituted away for the log row, or bridged
+    // back as an ordinary catchable Error for the guest to swallow.
+    data->oom_poisoned = true;
+    if (error)
+      rb_set_errinfo(Qnil);
+    // Uncatchable for the reason the lapse is: a catchable Error here is one
+    // the guest can swallow, and it would pin a Ruby exception in
+    // alive_objects per catch on a heap that has nothing left to give.
+    JS_ThrowInternalError(ctx, "out of memory");
+    JS_SetUncatchableException(ctx, TRUE);
+    return JS_EXCEPTION;
+  }
   if (call.interrupted)
   {
     // The lapse outranks a raise from the listener, as it does in the uncaught
@@ -1684,6 +2006,19 @@ static void *quickjsrb_log_with_gvl(void *p)
 static JSValue js_quickjsrb_log(JSContext *ctx, int argc, JSValueConst *argv, const char *severity)
 {
   VMData *data = JS_GetContextOpaque(ctx);
+  // Ahead of the listener check, because stopping a guest on a heap this call
+  // has already exhausted is not a thing to make conditional on anyone
+  // listening. Inside a call the flag can only have been set by that call,
+  // since enter_oom_scope turns a condemned VM away at the door. Both this and
+  // the listener read below are plain aligned loads, safe without the GVL, and
+  // the throw is pure QuickJS.
+  if (data->oom_poisoned)
+  {
+    JS_ThrowInternalError(ctx, "out of memory");
+    JS_SetUncatchableException(ctx, TRUE);
+    return JS_EXCEPTION;
+  }
+
   // With no listener registered the built row would be discarded, so skip
   // the whole pipeline — most importantly the GVL re-acquire below, which
   // would otherwise turn every console.log of a log-heavy pure-path script
@@ -2028,6 +2363,19 @@ static VALUE vm_m_initialize(int argc, VALUE *argv, VALUE r_self)
   JS_SetPropertyStr(data->context, j_global, "console", j_console);
   JS_FreeValue(data->context, j_global);
 
+  // Construction opens no scope, since there is no earlier call to be told
+  // apart from: every refusal counted so far happened building this VM. Some
+  // of them raise on their way out, but the feature module loads free their
+  // results unchecked, so a std or os module that ran out is discarded here
+  // and the VM is handed back on a heap that has already refused. The first
+  // call would find it only by refusing too, and the scope it opens masks
+  // the count that would have said so.
+  if (data->alloc_refusals > 0)
+  {
+    data->oom_poisoned = true;
+    data->condemned_at_build = true;
+  }
+
   return r_self;
 }
 
@@ -2074,13 +2422,32 @@ static VALUE to_rb_return_value(JSContext *ctx, JSValue j_val)
   return rb_ensure(to_rb_return_value_body, (VALUE)&owned, to_rb_return_value_release, (VALUE)&owned);
 }
 
-static void check_oom_poisoned(VMData *data)
+// Refuses a VM the heap has already condemned, and then opens the scope the
+// out-of-memory readers measure against: one public API call is one
+// operation, and "the allocator refused" means it refused inside this one.
+//
+// The snapshot lives here, rather than beside each caller, because every
+// public entry point already begins with this line — and because the scope
+// cannot be a JS entry. An evaluation is two counted entries, the run and
+// then the rendering of what it left pending, so a snapshot taken as an
+// entry opens would be re-taken after the refusal and before the renderer
+// that has to see it.
+static void enter_oom_scope(VMData *data)
 {
   if (data->oom_poisoned)
   {
-    VALUE r_msg = rb_str_new2("VM is poisoned: a previous evaluation hit out-of-memory; further evaluation may segfault. Recreate the Quickjs::VM.");
+    VALUE r_msg = data->condemned_at_build
+                      ? rb_str_new2("VM is poisoned: the heap refused while this VM was being built, before any evaluation ran; memory_limit is too small for the features requested. Raise it.")
+                      : rb_str_new2("VM is poisoned: a previous evaluation hit out-of-memory; further evaluation may segfault. Recreate the Quickjs::VM.");
     rb_exc_raise(rb_funcall(QUICKJSRB_ERROR_FOR(QUICKJSRB_ROOT_RUNTIME_ERROR), rb_intern("new"), 2, r_msg, Qnil));
   }
+
+  // Only the outermost call opens a scope. A nested one — a define_function
+  // proc or an on_log listener re-entering the VM while JS is in flight —
+  // inherits the scope it was made from, because taking its own would drop a
+  // refusal the enclosing call has already met and is still going to report.
+  if (data->evals_in_flight == 0)
+    data->alloc_refusals_at_scope = data->alloc_refusals;
 }
 
 static void check_disposed(VMData *data)
@@ -2634,7 +3001,7 @@ static VALUE vm_m_evalCode(int argc, VALUE *argv, VALUE r_self)
   TypedData_Get_Struct(r_self, VMData, &vm_type, data);
 
   check_disposed(data);
-  check_oom_poisoned(data);
+  enter_oom_scope(data);
   check_js_entry_owner(data);
 
   VALUE r_code, r_opts;
@@ -2851,7 +3218,7 @@ static VALUE vm_m_compile(int argc, VALUE *argv, VALUE r_self)
   TypedData_Get_Struct(r_self, VMData, &vm_type, data);
 
   check_disposed(data);
-  check_oom_poisoned(data);
+  enter_oom_scope(data);
   check_js_entry_owner(data);
 
   VALUE r_code, r_opts;
@@ -2965,7 +3332,7 @@ static VALUE vm_m_compileModule(VALUE r_self, VALUE r_code, VALUE r_name)
   TypedData_Get_Struct(r_self, VMData, &vm_type, data);
 
   check_disposed(data);
-  check_oom_poisoned(data);
+  enter_oom_scope(data);
   check_js_entry_owner(data);
   Check_Type(r_code, T_STRING);
   Check_Type(r_name, T_STRING);
@@ -3054,7 +3421,7 @@ static VALUE vm_m_preloadModuleBytecode(VALUE r_self, VALUE r_bytecode, VALUE r_
   TypedData_Get_Struct(r_self, VMData, &vm_type, data);
 
   check_disposed(data);
-  check_oom_poisoned(data);
+  enter_oom_scope(data);
   check_js_entry_owner(data);
 
   // Strict String rather than StringValue's coercion, matching
@@ -3160,7 +3527,7 @@ static VALUE vm_m_evalBytecode(VALUE r_self, VALUE r_bytecode)
   TypedData_Get_Struct(r_self, VMData, &vm_type, data);
 
   check_disposed(data);
-  check_oom_poisoned(data);
+  enter_oom_scope(data);
   check_js_entry_owner(data);
 
   if (!RB_TYPE_P(r_bytecode, T_STRING))
@@ -3245,7 +3612,7 @@ static VALUE vm_m_loadPolyfillBytecode(VALUE r_self, VALUE r_bytecode)
   }
 
   check_disposed(data);
-  check_oom_poisoned(data);
+  enter_oom_scope(data);
   check_js_entry_owner(data);
 
   // "Unbudgeted" needs enforcing, not just skipping arm_eval_timer: the
@@ -3505,6 +3872,12 @@ static VALUE vm_m_defineGlobalFunction(int argc, VALUE *argv, VALUE r_self)
   TypedData_Get_Struct(r_self, VMData, &vm_type, data);
 
   check_disposed(data);
+  // The one entry point that opened no scope. Two things followed: it ran on a
+  // condemned VM instead of refusing, and the readers it reaches through its
+  // own JS_Eval measured against whatever call last opened a scope, so a
+  // refusal an earlier call had already recovered from could be reported here
+  // as this one running out.
+  enter_oom_scope(data);
   check_no_gvl_release_in_flight(data);
 
   struct define_function_call call = {
@@ -3717,7 +4090,7 @@ static VALUE vm_m_callGlobalFunction(int argc, VALUE *argv, VALUE r_self)
   TypedData_Get_Struct(r_self, VMData, &vm_type, data);
 
   check_disposed(data);
-  check_oom_poisoned(data);
+  enter_oom_scope(data);
   check_js_entry_owner(data);
 
   // evals_in_flight stays elevated for the whole call, not just the
@@ -3885,7 +4258,7 @@ static VALUE vm_m_import(int argc, VALUE *argv, VALUE r_self)
   TypedData_Get_Struct(r_self, VMData, &vm_type, data);
 
   check_disposed(data);
-  check_oom_poisoned(data);
+  enter_oom_scope(data);
   check_js_entry_owner(data);
 
   // Module top-level code is user JS like any eval — budget it. Without
@@ -4001,7 +4374,7 @@ static VALUE vm_m_drainJobs(VALUE r_self)
   TypedData_Get_Struct(r_self, VMData, &vm_type, data);
 
   check_disposed(data);
-  check_oom_poisoned(data);
+  enter_oom_scope(data);
   check_js_entry_owner(data);
 
   if (!JS_IsJobPending(JS_GetRuntime(data->context)))

--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -37,6 +37,9 @@ VALUE to_rb_value(JSContext *ctx, JSValue j_val);
 typedef struct ConvState ConvState;
 static VALUE to_rb_value_inner(JSContext *ctx, JSValue j_val, ConvState *conv);
 static VALUE raise_js_exception(JSContext *ctx);
+// Defined beside the renderer that is its main caller; needed here because the
+// conversion meets an exhaustion it cannot raise for one level earlier.
+static bool condemn_if_out_of_memory(VMData *data, JSContext *ctx, JSValueConst j_val);
 static VALUE vm_m_memoryUsage(VALUE r_self);
 static VALUE vm_m_runGC(VALUE r_self);
 static VALUE vm_m_memoryPoisoned(VALUE r_self);
@@ -442,6 +445,22 @@ static VALUE js_plain_object_to_rb(JSContext *ctx, JSValue j_val, ConvState *con
   if (JS_GetOwnPropertyNames(ctx, &ptab, &plen, j_val, JS_GPN_STRING_MASK | JS_GPN_ENUM_ONLY) < 0)
   {
     conv_frame_pop(conv);
+    // The empty hash is what this has always answered for an enumeration it
+    // could not make, and #119 owns the question of whether that should raise.
+    // What it must not do is swallow the heap running out: this is the one
+    // failure here that outlives the value, and the caller would go on
+    // evaluating on the heap that refused.
+    JSValue j_pending = JS_GetException(ctx);
+    if (condemn_if_out_of_memory(JS_GetContextOpaque(ctx), ctx, j_pending))
+    {
+      // Handed back rather than dropped: the string site below reports its
+      // refusal and so does this one now, or the caller is told {} for an
+      // object it had and finds out at the next call. A guest trap that threw
+      // still answers {}, which is #119.
+      JS_Throw(ctx, j_pending);
+      return raise_js_exception(ctx);
+    }
+    JS_FreeValue(ctx, j_pending);
     return rb_hash_new();
   }
   CONV_FRAME(conv, depth)->ptab = ptab;
@@ -1155,8 +1174,12 @@ static VALUE to_rb_value_inner(JSContext *ctx, JSValue j_val, ConvState *conv)
     // transparently, so both tags share the same conversion path.
     size_t len;
     const char *str = JS_ToCStringLen(ctx, &len, j_val);
+    // The value is already a string, so nothing guest-written runs here and
+    // only a failed allocation answers NULL, as for the atom above. Returning
+    // nil handed the caller an empty result for a string it did have and left
+    // the refusal unreported, so the next call ran on the heap that refused.
     if (str == NULL)
-      return Qnil;
+      return raise_js_exception(ctx);
     VALUE r_str = rb_utf8_str_new(str, (long)len);
     JS_FreeCString(ctx, str);
     return r_str;
@@ -3483,7 +3506,22 @@ static VALUE vm_m_preloadModuleBytecode(VALUE r_self, VALUE r_bytecode, VALUE r_
   js_module_set_import_meta(data->context, j_mod, FALSE, FALSE);
 
   JSAtom j_baked = JS_GetModuleName(data->context, JS_VALUE_GET_PTR(j_mod));
+  // An atom is already a string, so only a refusal answers NULL here, and it
+  // takes a non-ASCII name to get that far: JS_ToCStringLen2 hands back the
+  // string's own buffer for a pure-ASCII one, which cannot fail. The empty name
+  // it used to fall back to is compared against the name the caller filed the
+  // blob under two checks below, so an exhaustion was reported as a
+  // disagreement about names, on a VM the latch had already condemned.
+  uint64_t refusals_before = data->alloc_refusals;
   const char *baked = JS_AtomToCString(data->context, j_baked);
+  if (baked == NULL && data->alloc_refusals > refusals_before)
+  {
+    data->oom_poisoned = true;
+    JS_FreeAtom(data->context, j_baked);
+    JS_FreeValue(data->context, j_mod);
+    JS_FreeValue(data->context, JS_GetException(data->context));
+    rb_exc_raise(r_out_of_memory_error());
+  }
   VALUE r_baked = rb_str_new_cstr(baked ? baked : "");
   if (baked)
     JS_FreeCString(data->context, baked);

--- a/ext/quickjsrb/quickjsrb.h
+++ b/ext/quickjsrb/quickjsrb.h
@@ -16,6 +16,17 @@
 #include <string.h>
 #include <time.h>
 
+// The same ladder quickjs.c walks for its own allocator, mirrored rather than
+// referenced: js_def_malloc_usable_size is static, and the submodule is not
+// ours to change.
+#if defined(__APPLE__)
+#include <malloc/malloc.h>
+#elif defined(__linux__) || defined(__GLIBC__)
+#include <malloc.h>
+#elif defined(__FreeBSD__)
+#include <malloc_np.h>
+#endif
+
 extern const uint32_t qjsc_polyfill_file_min_size;
 extern const uint8_t qjsc_polyfill_file_min;
 extern const uint32_t qjsc_polyfill_encoding_min_size;
@@ -81,6 +92,30 @@ typedef struct VMData
   // ReferenceError when the loader doesn't know the name.
   VALUE preloaded_module_names;
   JSValue j_file_proxy_creator;
+  // Number of allocations the runtime asked this extension for and did not
+  // get, either because the request would have crossed memory_limit or
+  // because the system refused. Monotonic for the life of the VM, and read
+  // by taking a snapshot and comparing: the question the readers ask is
+  // whether the allocator refused during a window they name, which is the
+  // one signal a guest cannot write to. Only mutated from the thread running
+  // JS, which is one at a time per VM.
+  //
+  // It counts a refusal QuickJS goes on to tolerate as well as one it reports:
+  // resize_shape_hash and compact_properties ignore what they get back and
+  // carry on correctly with the smaller table. A reader would then answer for
+  // a heap that had recovered. Reachable only where such an allocation is the
+  // one that fails while the ones around it do not, which 120 shapings against
+  // the ceiling did not produce, and every reader below is already in a
+  // something-has-gone-wrong path except construction, where a refusal means
+  // the limit cannot hold the runtime. Recorded here rather than guarded
+  // against, since the allocator cannot see which of its callers will care.
+  uint64_t alloc_refusals;
+  // The count as the current public API call began. What the readers compare
+  // against: allocator_refused asks whether the number moved inside the call
+  // they are reporting on, not whether this VM ever refused. A guest that
+  // catches an out-of-memory and returns normally is left alone, as it is
+  // today.
+  uint64_t alloc_refusals_at_scope;
   // Once the runtime has hit JS-level "out of memory", the QuickJS heap is in
   // a fragile state where further evaluation can trigger a use-after-free in
   // the parser-error-during-OOM cascade (segfault inside js_shape_hash_unlink).
@@ -188,7 +223,9 @@ static void vm_free(void *ptr)
   VMData *data = (VMData *)ptr;
   free(data->eval_time);
 
-  if (!data->disposed)
+  // NULL when the runtime could not be allocated at all: vm_alloc raises,
+  // and the half-built object still reaches here.
+  if (!data->disposed && data->context != NULL)
   {
     if (!JS_IsUndefined(data->j_file_proxy_creator))
       JS_FreeValue(data->context, data->j_file_proxy_creator);
@@ -245,15 +282,130 @@ static const rb_data_type_t vm_type = {
     .flags = RUBY_TYPED_FREE_IMMEDIATELY,
 };
 
+// quickjs.c reports "out of memory" by throwing an error, and a guest can
+// write that same sentence. The refusal itself cannot be written: it happens
+// below the guest, in the allocator, before QuickJS has decided whether it
+// can even afford an error object. So the runtime is created with our own
+// JSMallocFunctions, which are js_def_malloc and friends with one line
+// added, and every refusal is counted on the VM.
+//
+// The accounting has to be reproduced exactly rather than approximated:
+// js_def_malloc is where memory_limit is enforced, and malloc_count and
+// malloc_size are what JS_ComputeMemoryUsage reports through VM#memory_usage.
+// Both the limit comparison and the usable-size bookkeeping below are
+// therefore copied from quickjs.c as they stand.
+#if defined(__APPLE__)
+#define QUICKJSRB_MALLOC_OVERHEAD 0
+#else
+#define QUICKJSRB_MALLOC_OVERHEAD 8
+#endif
+
+static size_t quickjsrb_malloc_usable_size(const void *ptr)
+{
+#if defined(__APPLE__)
+  return malloc_size(ptr);
+#elif defined(_WIN32)
+  return _msize((void *)ptr);
+#elif defined(__EMSCRIPTEN__)
+  return 0;
+#elif defined(__linux__) || defined(__GLIBC__)
+  return malloc_usable_size((void *)ptr);
+#else
+  return malloc_usable_size((void *)ptr);
+#endif
+}
+
+// The added line, in the one place both refusal paths pass through. The
+// opaque is the VMData handed to JS_NewRuntime2; it is NULL-checked because
+// the first allocation JS_NewRuntime2 makes is the runtime itself, before
+// any runtime exists to hold it.
+static void *quickjsrb_malloc_refused(JSMallocState *s)
+{
+  VMData *data = s->opaque;
+  if (data != NULL)
+    data->alloc_refusals++;
+  return NULL;
+}
+
+static void *quickjsrb_malloc(JSMallocState *s, size_t size)
+{
+  void *ptr;
+
+  if (unlikely(s->malloc_size + size > s->malloc_limit))
+    return quickjsrb_malloc_refused(s);
+
+  ptr = malloc(size);
+  if (!ptr)
+    return quickjsrb_malloc_refused(s);
+
+  s->malloc_count++;
+  s->malloc_size += quickjsrb_malloc_usable_size(ptr) + QUICKJSRB_MALLOC_OVERHEAD;
+  return ptr;
+}
+
+static void quickjsrb_free(JSMallocState *s, void *ptr)
+{
+  if (!ptr)
+    return;
+
+  s->malloc_count--;
+  s->malloc_size -= quickjsrb_malloc_usable_size(ptr) + QUICKJSRB_MALLOC_OVERHEAD;
+  free(ptr);
+}
+
+static void *quickjsrb_realloc(JSMallocState *s, void *ptr, size_t size)
+{
+  size_t old_size;
+
+  if (!ptr)
+  {
+    if (size == 0)
+      return NULL;
+    return quickjsrb_malloc(s, size);
+  }
+  old_size = quickjsrb_malloc_usable_size(ptr);
+  // A resize to zero is a free that answers NULL. Nothing was refused.
+  if (size == 0)
+  {
+    s->malloc_count--;
+    s->malloc_size -= old_size + QUICKJSRB_MALLOC_OVERHEAD;
+    free(ptr);
+    return NULL;
+  }
+  if (s->malloc_size + size - old_size > s->malloc_limit)
+    return quickjsrb_malloc_refused(s);
+
+  ptr = realloc(ptr, size);
+  if (!ptr)
+    return quickjsrb_malloc_refused(s);
+
+  s->malloc_size += quickjsrb_malloc_usable_size(ptr) - old_size;
+  return ptr;
+}
+
+static const JSMallocFunctions quickjsrb_malloc_funcs = {
+    quickjsrb_malloc,
+    quickjsrb_free,
+    quickjsrb_realloc,
+    quickjsrb_malloc_usable_size,
+};
+
 struct vm_create_args
 {
+  VMData *data;
   JSContext *context;
 };
 
 static void *vm_create_no_gvl(void *p)
 {
   struct vm_create_args *args = p;
-  args->context = JS_NewContext(JS_NewRuntime());
+  // JS_NewRuntime2 answers NULL when it cannot allocate the runtime, and
+  // JS_NewContext(NULL) dereferences it. Nothing checked this before, when
+  // the same NULL was reachable through JS_NewRuntime.
+  JSRuntime *runtime = JS_NewRuntime2(&quickjsrb_malloc_funcs, args->data);
+  args->context = runtime == NULL ? NULL : JS_NewContext(runtime);
+  if (runtime != NULL && args->context == NULL)
+    JS_FreeRuntime(runtime);
   return NULL;
 }
 
@@ -270,6 +422,8 @@ static VALUE vm_alloc(VALUE r_self)
   data->module_source_cache = rb_hash_new();
   data->preloaded_module_names = rb_hash_new();
   data->j_file_proxy_creator = JS_UNDEFINED;
+  data->alloc_refusals = 0;
+  data->alloc_refusals_at_scope = 0;
   data->oom_poisoned = false;
   data->eval_timer_armed = false;
   data->disposed = false;
@@ -287,9 +441,11 @@ static VALUE vm_alloc(VALUE r_self)
   // JSRuntime / JSContext creation is pure QuickJS C work — no Ruby state
   // touched. Release the GVL so a background warmer thread can run this in
   // parallel with the main thread on multi-core hosts.
-  struct vm_create_args args = {NULL};
+  struct vm_create_args args = {data, NULL};
   rb_thread_call_without_gvl(vm_create_no_gvl, &args, NULL, NULL);
   data->context = args.context;
+  if (data->context == NULL)
+    rb_raise(rb_eNoMemError, "failed to allocate a JS runtime");
 
   return obj;
 }

--- a/ext/quickjsrb/quickjsrb.h
+++ b/ext/quickjsrb/quickjsrb.h
@@ -116,6 +116,12 @@ typedef struct VMData
   // catches an out-of-memory and returns normally is left alone, as it is
   // today.
   uint64_t alloc_refusals_at_scope;
+  // Whether the refusal that condemned this VM happened while it was being
+  // built, so the refusal it hands its caller can say so. "A previous
+  // evaluation" is not true of a VM that has never run one, and "recreate the
+  // VM" is advice that fails identically forever when the limit is the thing
+  // that is wrong.
+  bool condemned_at_build;
   // Once the runtime has hit JS-level "out of memory", the QuickJS heap is in
   // a fragile state where further evaluation can trigger a use-after-free in
   // the parser-error-during-OOM cascade (segfault inside js_shape_hash_unlink).
@@ -424,6 +430,7 @@ static VALUE vm_alloc(VALUE r_self)
   data->j_file_proxy_creator = JS_UNDEFINED;
   data->alloc_refusals = 0;
   data->alloc_refusals_at_scope = 0;
+  data->condemned_at_build = false;
   data->oom_poisoned = false;
   data->eval_timer_armed = false;
   data->disposed = false;

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -473,6 +473,62 @@ describe Quickjs::VM do
     end
   end
 
+  # The runtime is created with our own JSMallocFunctions rather than QuickJS’s
+  # default ones, so malloc_size and malloc_count are ours to maintain: they are
+  # what memory_limit is compared against and what memory_usage reports. A
+  # mismatch between the malloc and free sides does not fail loudly, it drifts,
+  # and the limit is then enforced against a number that is not the heap.
+  describe "OwnedAllocator" do
+    it "accounts an allocation while it is held and gives the bytes back when it is released" do
+      vm = Quickjs::VM.new
+      vm.eval_code("void 0")
+      vm.gc!
+      baseline = vm.memory_usage[:malloc_size]
+
+      vm.eval_code("globalThis.hold = new Array(50_000).fill(7); void 0")
+      vm.gc!
+      held = vm.memory_usage[:malloc_size]
+
+      vm.eval_code("globalThis.hold = null; void 0")
+      vm.gc!
+      released = vm.memory_usage[:malloc_size]
+
+      _(held - baseline).must_be :>, 350_000
+      # Shapes and atoms the first evaluation interned stay for the life of the
+      # VM, so this is the array’s bytes coming back rather than an exact return.
+      _(released - baseline).must_be :<, 50_000
+    ensure
+      vm.dispose!
+    end
+
+    it "does not drift over repeated allocation and release" do
+      vm = Quickjs::VM.new
+      cycle = "globalThis.hold = new Array(2_000).fill(1); globalThis.hold = null; void 0"
+      5.times { vm.eval_code(cycle) }
+      vm.gc!
+      before = vm.memory_usage[:malloc_size]
+
+      200.times { vm.eval_code(cycle) }
+      vm.gc!
+
+      # Measured at 0 on macOS and Linux. The slack is for a platform whose
+      # malloc rounds a request differently between the two sides, not for an
+      # asymmetry in the bookkeeping, which would grow with the iteration count.
+      _(vm.memory_usage[:malloc_size] - before).must_be :<, 4_096
+    ensure
+      vm.dispose!
+    end
+
+    it "still enforces memory_limit, and reports the limit it was given" do
+      vm = Quickjs::VM.new(memory_limit: 1024 * 1024)
+      _(vm.memory_usage[:malloc_limit]).must_equal 1024 * 1024
+
+      _ { vm.eval_code("new Array(2_000_000).fill(0); void 0") }.must_raise Quickjs::RuntimeError
+    ensure
+      vm.dispose!
+    end
+  end
+
   # A conversion that raises partway through — a Promise nested in the graph is
   # the reachable case — must release everything it was holding on that exit.
   # What leaks is guest-chosen and never returned, so a long-lived VM fills up
@@ -936,75 +992,6 @@ describe Quickjs::VM do
     # memory is a fact about the heap rather than about who was asking, and this
     # is the shape that proves the split cannot own it: the evaluation returns
     # its object and the allocation that fails is in a getter read afterwards.
-    # The heap can run out inside one of the renderer's own reads. The getter
-    # here succeeds — big + big is a rope — and it is the read's own
-    # JS_ToCString, flattening it, that runs out. That throw took the
-    # substitution path like any other, so the caller got a normal-looking
-    # RuntimeError, the latch never set, and the next evaluation ran on the
-    # heap the latch exists to refuse.
-    it "condemns the VM for an out-of-memory met inside a read it was rendering" do
-      vm = Quickjs::VM.new(memory_limit: 1024 * 1024)
-
-      error = _ do
-        vm.eval_code(<<~JS)
-          const big = 'x'.repeat(480 * 1024);
-          const e = new Error('m');
-          Object.defineProperty(e, 'message', {get() { return big + big }});
-          throw e;
-        JS
-      end.must_raise Quickjs::RuntimeError
-
-      _(error.message).must_match(/out of memory/)
-      _(vm.memory_poisoned?).must_equal true
-      err = _ { vm.eval_code('1 + 1') }.must_raise Quickjs::RuntimeError
-      _(err.message).must_match(/poisoned/)
-    ensure
-      vm.dispose!
-    end
-
-    # One level deeper: the discarded throw says "out of memory" as an own data
-    # property, but converting that message to look at it is itself an
-    # allocation — a non-ASCII string transcodes — and it fails on the same
-    # exhausted heap. A string that will not convert is the heap running out.
-    it "condemns the VM when inspecting the discarded throw itself runs out of memory" do
-      vm = Quickjs::VM.new(memory_limit: 1024 * 1024)
-
-      error = _ do
-        vm.eval_code(<<~JS)
-          const big = 'x'.repeat(600 * 1024);
-          const e = new Error('m');
-          Object.defineProperty(e, 'message', {get() {
-            const inner = new Error('q');
-            inner.message = 'out of memory ' + 'é'.repeat(150 * 1024);
-            throw inner;
-          }});
-          throw e;
-        JS
-      end.must_raise Quickjs::RuntimeError
-
-      _(error.message).must_match(/out of memory/)
-      _(vm.memory_poisoned?).must_equal true
-    ensure
-      vm.dispose!
-    end
-
-    it "hands the listener the out-of-memory met while a rejection reason was read" do
-      vm = Quickjs::VM.new(memory_limit: 1024 * 1024)
-      seen = []
-      vm.on_unhandled_rejection {|err| seen << err }
-      vm.eval_code(<<~JS)
-        const big = 'x'.repeat(480 * 1024);
-        const e = new Error('r');
-        Object.defineProperty(e, 'message', {get() { return big + big }});
-        void Promise.reject(e);
-      JS
-
-      _(seen.map(&:message)).must_equal ['out of memory']
-      _(vm.memory_poisoned?).must_equal true
-    ensure
-      vm.dispose!
-    end
-
     it "still condemns the VM for an out-of-memory a getter hit during conversion" do
       vm = Quickjs::VM.new(memory_limit: 1024 * 1024)
 

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -992,6 +992,842 @@ describe Quickjs::VM do
     # memory is a fact about the heap rather than about who was asking, and this
     # is the shape that proves the split cannot own it: the evaluation returns
     # its object and the allocation that fails is in a getter read afterwards.
+    # The heap can run out inside one of the renderer's own reads. The getter
+    # here succeeds — big + big is a rope — and it is the read's own
+    # JS_ToCString, flattening it, that runs out. That throw took the
+    # substitution path like any other, so the caller got a normal-looking
+    # RuntimeError, the latch never set, and the next evaluation ran on the
+    # heap the latch exists to refuse.
+    it "condemns the VM for an out-of-memory met inside a read it was rendering" do
+      vm = Quickjs::VM.new(memory_limit: 1024 * 1024)
+
+      error = _ do
+        vm.eval_code(<<~JS)
+          const big = 'x'.repeat(480 * 1024);
+          const e = new Error('m');
+          Object.defineProperty(e, 'message', {get() { return big + big }});
+          throw e;
+        JS
+      end.must_raise Quickjs::RuntimeError
+
+      _(error.message).must_match(/out of memory/)
+      _(vm.memory_poisoned?).must_equal true
+      err = _ { vm.eval_code('1 + 1') }.must_raise Quickjs::RuntimeError
+      _(err.message).must_match(/poisoned/)
+    ensure
+      vm.dispose!
+    end
+
+    # The same shape with nothing actually running out. The getter throws an
+    # error whose message is large and non-ASCII, which is what it took to make
+    # the old detector — the one that read the discarded throw's message
+    # looking for a sentence — run out of memory inside its own inspection and
+    # condemn the VM on the strength of it. Nothing reads that message now, so
+    # the heap is never asked for the string, and a throwing getter is a
+    # throwing getter.
+    it "substitutes for a throwing getter whose error is expensive to render, without condemning the VM" do
+      vm = Quickjs::VM.new(memory_limit: 1024 * 1024)
+
+      error = _ do
+        vm.eval_code(<<~JS)
+          const big = 'x'.repeat(600 * 1024);
+          const e = new Error('m');
+          Object.defineProperty(e, 'message', {get() {
+            const inner = new Error('q');
+            inner.message = 'out of memory ' + 'é'.repeat(150 * 1024);
+            throw inner;
+          }});
+          throw e;
+        JS
+      end.must_raise Quickjs::RuntimeError
+
+      _(error.message).must_equal "(unrenderable value)"
+      _(vm.memory_poisoned?).must_equal false
+      _(vm.eval_code('1 + 1')).must_equal 2
+    ensure
+      vm.dispose!
+    end
+
+    # The sentence is the guest's to write, so it cannot be the signal. Every
+    # forgery below reached the latch before the allocator was ours, and each
+    # one condemned a VM whose heap was never touched.
+    it "does not condemn the VM for an InternalError the guest wrote itself" do
+      vm = Quickjs::VM.new(memory_limit: 1024 * 1024)
+
+      _ do
+        vm.eval_code("const e = new Error('out of memory'); e.name = 'InternalError'; throw e;")
+      end.must_raise Quickjs::RuntimeError
+
+      _(vm.memory_poisoned?).must_equal false
+      _(vm.eval_code('1 + 1')).must_equal 2
+    ensure
+      vm.dispose!
+    end
+
+    it "does not condemn the VM for a forged out-of-memory thrown from a logged value" do
+      vm = Quickjs::VM.new(memory_limit: 1024 * 1024)
+      logged = []
+      vm.on_log {|log| logged << log.to_s }
+
+      _(vm.eval_code(<<~JS)).must_equal 'done'
+        console.log({toString() {
+          const e = new Error('out of memory');
+          e.name = 'InternalError';
+          throw e;
+        }});
+        'done';
+      JS
+
+      _(logged).must_equal ['(unrenderable value)']
+      _(vm.memory_poisoned?).must_equal false
+    ensure
+      vm.dispose!
+    end
+
+    # The sentence this issue is really about: application code reporting that
+    # something else ran out of memory, in a message the VM has no business
+    # reading as news about its own heap.
+    it "does not condemn the VM for a guest error that merely says it ran out of memory" do
+      vm = Quickjs::VM.new(memory_limit: 1024 * 1024)
+
+      error = _ do
+        vm.eval_code("'' + {toString() { throw new Error('worker ran out of memory, retrying') }}")
+      end.must_raise Quickjs::RuntimeError
+
+      _(error.message).must_equal 'worker ran out of memory, retrying'
+      _(vm.memory_poisoned?).must_equal false
+      _(vm.eval_code('1 + 1')).must_equal 2
+    ensure
+      vm.dispose!
+    end
+
+    # The row build is its own scope, so every reader reached from inside it
+    # measures the build. Without that, the renderer the getter's throw reaches
+    # through to_rb_value read the whole call, found the refusal the guest had
+    # already caught, and handed the guest a catchable "out of memory" for its
+    # own TypeError while condemning a VM whose call went on to return.
+    it "reports a logged getter's own throw after the call recovered from an out-of-memory" do
+      vm = Quickjs::VM.new(memory_limit: 1024 * 1024)
+      vm.on_log {|log| }
+
+      _(vm.eval_code(<<~JS)).must_equal 'Error: t'
+        try { new Array(2_000_000).fill(0) } catch (e) {}
+        let m = 'none';
+        try { console.log({get x() { throw new TypeError('t') }}) } catch (e) { m = String(e) }
+        m
+      JS
+
+      _(vm.memory_poisoned?).must_equal false
+      _(vm.eval_code('1 + 1')).must_equal 2
+    ensure
+      vm.dispose!
+    end
+
+    # QuickJS calls the tracker with is_handled false at rejection time and
+    # again with true when a reaction is attached, and nothing retracts the
+    # first. Keyed on the call's refusals alone, the most ordinary async shape
+    # there is condemned a VM that had recovered; the reason decides now.
+    it "leaves the VM alone when a rejection the guest handles follows a recovered out-of-memory" do
+      vm = Quickjs::VM.new(memory_limit: 1024 * 1024)
+
+      _(vm.eval_code(<<~JS)).must_equal 'TypeError: x'
+        try { new Array(2_000_000).fill(0) } catch (e) {}
+        async function f() { throw new TypeError('x') }
+        let m = 'none'; try { await f() } catch (e) { m = String(e) }
+        m
+      JS
+
+      _(vm.memory_poisoned?).must_equal false
+      _(vm.eval_code('1 + 1')).must_equal 2
+    ensure
+      vm.dispose!
+    end
+
+    # The host's own interrupt is not the heap's news. A caller that rescues
+    # InterruptedError to retry with a larger budget was losing both the class
+    # and the VM to a refusal the guest had already caught.
+    it "reports a timeout after a recovered out-of-memory as the interrupt it is" do
+      vm = Quickjs::VM.new(memory_limit: 1024 * 1024, timeout_msec: 50)
+
+      _ do
+        vm.eval_code('try { new Array(2_000_000).fill(0) } catch (e) {}; for (;;) {}')
+      end.must_raise Quickjs::InterruptedError
+
+      _(vm.memory_poisoned?).must_equal false
+    ensure
+      vm.dispose!
+    end
+
+    # The latch is set before the row is dispatched, because an on_log listener
+    # can re-enter the VM and a nested entry consults it to refuse. Dispatched
+    # first, the listener ran JS on the heap that had just refused.
+    it "turns away a log listener that re-enters the VM on the heap that just refused" do
+      vm = Quickjs::VM.new(memory_limit: 1024 * 1024)
+      seen = []
+      vm.on_log do |log|
+        seen << begin
+          vm.eval_code('globalThis.after = new Array(1000).fill(1); after.length')
+        rescue Quickjs::RuntimeError => e
+          e.message[/poisoned/] ? :refused : :other
+        end
+      end
+
+      _ { vm.eval_code('new Array(2_000_000).fill(0); void 0', async: false) }.must_raise Quickjs::RuntimeError
+
+      _(seen).must_equal [:refused]
+      _(vm.memory_poisoned?).must_equal true
+    ensure
+      vm.dispose!
+    end
+
+    # `Promise.reject()` is an ordinary thing to write and its reason is
+    # undefined, which is nothing QuickJS leaves behind. `Promise.reject(null)`
+    # is the symmetric twin of `throw null`: the reason is the value
+    # JS_ThrowError2 leaves when it cannot build the error, so after a refusal
+    # it reads as the heap, and that exposure is the price of catching an
+    # exhaustion that arrives as a rejection at all.
+    it "reads an empty rejection as the guest's own after a recovered out-of-memory" do
+      vm = Quickjs::VM.new(memory_limit: 1024 * 1024)
+
+      _(vm.eval_code("try { new Array(2_000_000).fill(0) } catch (e) {}\nvoid Promise.reject(); 'ok'")).must_equal 'ok'
+      _(vm.memory_poisoned?).must_equal false
+      _(vm.eval_code('1 + 1')).must_equal 2
+    ensure
+      vm.dispose!
+    end
+
+    # The end the null branch exists for, in the clothes it actually arrives
+    # in. JS_ThrowError2 gives up and leaves JS_NULL when it cannot build the
+    # error to report with, and until the reason was asked the same questions a
+    # pending exception is, the diagnosis depended on whether the chain was
+    # thrown or awaited: the listener heard "null", the VM stayed usable, and
+    # the next call ran on a heap at its ceiling.
+    it "condemns the VM for an exhaustion that arrives as a rejection with nothing to read" do
+      vm = Quickjs::VM.new(memory_limit: 1024 * 1024)
+      seen = []
+      vm.on_unhandled_rejection {|err| seen << err }
+
+      _(vm.eval_code("async function f() { let n = null; for (;;) n = {n} } f(); 'ok'")).must_equal 'ok'
+
+      _(seen.size).must_equal 1
+      _(vm.memory_poisoned?).must_equal true
+      _ { vm.eval_code('1 + 1') }.must_raise Quickjs::RuntimeError
+    ensure
+      vm.dispose!
+    end
+
+    # The same chain thrown rather than rejected, which is what makes the two
+    # comparable: both are condemned, and neither depends on a sentence.
+    it "condemns the VM for the same exhaustion when it is thrown" do
+      vm = Quickjs::VM.new(memory_limit: 1024 * 1024)
+
+      error = _ { vm.eval_code("let n = null; for (;;) n = {n}") }.must_raise Quickjs::RuntimeError
+
+      _(error.message).must_equal 'out of memory'
+      _(vm.memory_poisoned?).must_equal true
+    ensure
+      vm.dispose!
+    end
+
+    # Nor is undefined a shape QuickJS leaves: it throws null, and only null.
+    it "reports a thrown undefined as itself after a recovered out-of-memory" do
+      vm = Quickjs::VM.new(memory_limit: 1024 * 1024)
+
+      error = _ do
+        vm.eval_code("try { new Array(2_000_000).fill(0) } catch (e) {} ; throw undefined")
+      end.must_raise Quickjs::RuntimeError
+
+      _(error.message).must_equal 'undefined'
+      _(vm.memory_poisoned?).must_equal false
+    ensure
+      vm.dispose!
+    end
+
+    # The exhaustion that got as far as an Error and no further. JS_ThrowError2
+    # allocates the object, JS_NewString("out of memory") is then refused
+    # inside in_out_of_memory, and the JS_EXCEPTION sentinel is stored as the
+    # own message: an Error whose message is not a string, which is a thing
+    # only QuickJS can make. It failed both halves before, so the heap was at
+    # 95% of its limit, the caller was told "(unrenderable value)", and the
+    # next call ran on it.
+    it "condemns the VM for an exhaustion that could not build its own message" do
+      vm = Quickjs::VM.new(memory_limit: 2 * 1024 * 1024, timeout_msec: 30_000)
+
+      error = _ { vm.eval_code("let s = ''; for (;;) s += 'x'") }.must_raise Quickjs::RuntimeError
+
+      _(error.message).must_equal 'out of memory'
+      _(vm.memory_poisoned?).must_equal true
+      _ { vm.eval_code('1 + 1') }.must_raise Quickjs::RuntimeError
+    ensure
+      vm.dispose!
+    end
+
+    # The window a read measures has to cover the fetch above it. The getter
+    # here runs out while JS_GetPropertyStr is reading `stack`, so the hold is
+    # handed JS_EXCEPTION with QuickJS's own error pending and the refusal
+    # already behind it: asked only about its own conversion, the read saw
+    # nothing and the renderer reported the error's message instead.
+    it "condemns the VM when a getter the renderer reads runs out of memory" do
+      vm = Quickjs::VM.new(memory_limit: 1024 * 1024)
+
+      error = _ do
+        vm.eval_code(<<~JS)
+          const e = new Error('m');
+          Object.defineProperty(e, 'stack', {get() { new Array(2_000_000).fill(0); return 'x' }});
+          throw e;
+        JS
+      end.must_raise Quickjs::RuntimeError
+
+      _(error.message).must_equal 'out of memory'
+      _(vm.memory_poisoned?).must_equal true
+    ensure
+      vm.dispose!
+    end
+
+    # The same shape on the log row, where the evaluation used to run on: the
+    # row was substituted for, nothing was reported, and the refusal arrived
+    # only at the next call.
+    it "stops the evaluation when a getter inside a logged value runs out of memory" do
+      vm = Quickjs::VM.new(memory_limit: 1024 * 1024)
+      vm.on_log {|log| }
+
+      _ do
+        vm.eval_code(<<~JS)
+          const e = new Error('m');
+          Object.defineProperty(e, 'stack', {get() { new Array(2_000_000).fill(0); return 'x' }});
+          console.log(e);
+          'ran on';
+        JS
+      end.must_raise Quickjs::RuntimeError
+
+      _(vm.memory_poisoned?).must_equal true
+    ensure
+      vm.dispose!
+    end
+
+    # The listener runs inside the log bridge and can re-enter the VM. When its
+    # own call exhausts the heap, this call is condemned too, and reading a
+    # flag the row build had already written left the guest running on it: the
+    # statement after the console.log ran and the evaluation returned. A nested
+    # call that merely meets a refusal and recovers is still its own business,
+    # since what is read is the verdict rather than the count.
+    it "stops the evaluation when a log listener's own call exhausts the heap" do
+      vm = Quickjs::VM.new(memory_limit: 1024 * 1024)
+      reached = []
+      vm.define_function(:mark) {|m| reached << m }
+      vm.on_log do |log|
+        begin
+          vm.eval_code('new Array(2_000_000).fill(0); void 0')
+        rescue Quickjs::RuntimeError
+          nil
+        end
+      end
+
+      _ { vm.eval_code("console.log('hi'); mark('after the log'); 'ran on'") }.must_raise Quickjs::RuntimeError
+
+      _(reached).must_equal []
+      _(vm.memory_poisoned?).must_equal true
+    ensure
+      vm.dispose!
+    end
+
+    # The third value QuickJS leaves where an error should be. __JS_NewAtom
+    # grows rt->atom_array through js_realloc_rt, which has no context to throw
+    # from, so the interpreter throws with the exception still uninitialised and
+    # the render read it as "[unsupported type]" on a VM it left usable. A guest
+    # cannot produce an uninitialised value, which is what makes it as good a
+    # signal as the sentinel.
+    it "condemns the VM for an exhaustion the atom table could not report" do
+      vm = Quickjs::VM.new(memory_limit: 1024 * 1024)
+
+      error = _ do
+        vm.eval_code("const o = {}; for (let i = 0; i < 12000; i++) o['k' + i] = i; 'done'")
+      end.must_raise Quickjs::RuntimeError
+
+      _(error.message).must_equal 'out of memory'
+      _(vm.memory_poisoned?).must_equal true
+    ensure
+      vm.dispose!
+    end
+
+    # Every uncaught throw reaches the rejection tracker before the renderer,
+    # since eval is async-wrapped, so a bridged host error passes through the
+    # reason test on its way out. The renderer answers those at its
+    # find_ruby_error exit, above every reader; the tracker has to say it out
+    # loud, or a host exception whose own message says the words is read as the
+    # heap once anything in the call has refused.
+    it "leaves a bridged host error to the host, whatever its message says" do
+      vm = Quickjs::VM.new(memory_limit: 1024 * 1024)
+      vm.define_function(:boom) { raise Quickjs::RuntimeError.new('out of memory', nil) }
+      churn = <<~JS
+        globalThis.filler = new Float64Array(90_000);
+        globalThis.objs = new Array(510);
+        for (let i = 0; i < 510; i++) { const o = {}; o['p' + i] = i; objs[i] = o }
+        filler = null; objs = null;
+      JS
+
+      error = _ { vm.eval_code("#{churn} boom(); 'ok'") }.must_raise Quickjs::RuntimeError
+
+      _(error.message).must_equal 'out of memory'
+      _(vm.memory_poisoned?).must_equal false
+      _(vm.eval_code('1 + 1')).must_equal 2
+    ensure
+      vm.dispose!
+    end
+
+    # The bridged-error question is asked inside the message branch, where
+    # JS_IsError has already turned a Proxy away, and not of the reason on the
+    # way in. Asked there it reached the exotic getOwnPropertyDescriptor hook:
+    # a trap ran inside the rejection tracker, on every unhandled rejection
+    # with an object reason and on VMs under no pressure at all, and a bridge
+    # reached from that trap could longjmp a Ruby exception out of a QuickJS
+    # host callback, which is the corruption the tracker's two rb_set_errinfo
+    # blocks exist to prevent.
+    it "runs no trap of the guest's while it looks at a rejection reason" do
+      vm = Quickjs::VM.new
+      vm.on_unhandled_rejection {|err| }
+      vm.define_function(:rb) {|x| x }
+
+      _(vm.eval_code(<<~JS)).must_equal 'ok'
+        globalThis.hit = 0;
+        void Promise.reject(new Proxy({}, {
+          getOwnPropertyDescriptor(t, k) { hit++; rb(Promise.resolve(1)); return undefined }
+        }));
+        'ok';
+      JS
+
+      _(vm.eval_code('hit')).must_equal 0
+      _(vm.eval_code('1 + 1')).must_equal 2
+    ensure
+      vm.dispose!
+    end
+
+    # A VM condemned before it ever ran anything cannot be told that a previous
+    # evaluation hit out-of-memory, and cannot be told to recreate itself: the
+    # limit is the thing that is wrong, and recreating it fails the same way
+    # forever.
+    it "tells a VM condemned while it was built what actually happened" do
+      vm = nil
+      begin
+        vm = Quickjs::VM.new(memory_limit: 128 * 1024, features: [:feature_std, :feature_os])
+      rescue Quickjs::RuntimeError => e
+        _(e.message).must_match(/out of memory/)
+        next
+      end
+
+      _(vm.memory_poisoned?).must_equal true
+      error = _ { vm.eval_code('1 + 1') }.must_raise Quickjs::RuntimeError
+      _(error.message).must_match(/while this VM was being built/)
+      _(error.message).must_match(/memory_limit/)
+    ensure
+      vm&.dispose!
+    end
+
+    # console.log with no listener is a no-op, deliberately: the row would be
+    # discarded and building it would cost a GVL round trip for nothing. The
+    # stop cannot live behind that gate, though, or whether a guest is halted
+    # on a heap this call already exhausted depends on whether anyone happens
+    # to be listening. Both shapes stop here.
+    [true, false].each do |listening|
+      it "stops a guest on a condemned heap at console.log, listener #{listening ? 'registered' : 'absent'}" do
+        vm = Quickjs::VM.new(memory_limit: 1024 * 1024)
+        reached = []
+        vm.define_function(:mark) {|m| reached << m }
+        vm.on_log {|log| } if listening
+
+        _ do
+          vm.eval_code(<<~JS)
+            let err;
+            try { new Array(2_000_000).fill(0) } catch (x) { err = x }
+            void Promise.reject(err);
+            mark('after the rejection');
+            console.log('hi');
+            mark('after the log');
+            'ran on';
+          JS
+        end.must_raise Quickjs::RuntimeError
+
+        _(reached).must_equal ['after the rejection']
+        _(vm.memory_poisoned?).must_equal true
+      ensure
+        vm.dispose!
+      end
+    end
+
+    # A VM with no bridges of any kind evaluates with the GVL released, and the
+    # rejection tracker runs inside that. The bridged-error lookup reads the
+    # Ruby heap, so it refuses to look there: can_eval_gvl_free releases the
+    # GVL only for a VM whose alive_objects nothing can fill, so there is
+    # nothing to find, and a forged id buys the guest no more than it would
+    # have with the lookup. That half is what this pins; the half that matters
+    # is that no Ruby call happens off the GVL, which no assertion can see.
+    it "condemns on a bridge-less VM whose guest forged an rb_object_id" do
+      vm = Quickjs::VM.new(memory_limit: 1024 * 1024)
+
+      _(vm.eval_code(<<~JS)).must_equal 'ok'
+        try { const a = []; for (;;) a.push(new ArrayBuffer(1 << 16)); } catch (e) {}
+        Promise.reject(Object.assign(new Error('out of memory'), { rb_object_id: 7 }));
+        'ok';
+      JS
+
+      _(vm.memory_poisoned?).must_equal true
+    ensure
+      vm.dispose!
+    end
+
+    # QuickJS tolerates some refusals. JS_NewShape and JS_NewAtom ignore what
+    # resize_shape_hash and JS_ResizeAtomHash answer, and the threshold only
+    # advances on success, so near the ceiling every later shape retries the
+    # refused block: the count climbs while the runtime stays correct and
+    # nothing ever throws. Keyed on the count alone, the verdict then depended
+    # on whether the guest happened to throw afterwards.
+    #
+    # The window is a different filler on every platform, so the test finds it
+    # rather than assuming it: alloc_refusals says whether a refusal actually
+    # happened, which is what tells "healthy and refused" apart from "never
+    # near the ceiling" and is what the earlier version of this test could not
+    # see. Measured here at 89_000 and 90_000, nine refusals each, VM healthy.
+    it "keeps a VM that a tolerated refusal left healthy, whatever the guest throws next" do
+      churn = ->(filler, tail) do
+        <<~JS
+          globalThis.filler = new Float64Array(#{filler});
+          globalThis.objs = new Array(510);
+          for (let i = 0; i < 510; i++) { const o = {}; o['p' + i] = i; objs[i] = o; }
+          filler = null; objs = null;
+          #{tail}
+        JS
+      end
+
+      tolerated = []
+      (60_000..140_000).step(1_000) do |filler|
+        vm = Quickjs::VM.new(memory_limit: 1024 * 1024)
+        begin
+          quiet = vm.eval_code(churn.(filler, "'done'"))
+          tolerated << filler if quiet == 'done' && vm.memory_usage[:alloc_refusals] > 0 && !vm.memory_poisoned?
+        rescue Quickjs::RuntimeError
+          break # a genuine exhaustion: past the window, and not the case under test
+        ensure
+          vm.dispose!
+        end
+        break if tolerated.size >= 2
+      end
+
+      refute_empty tolerated, "no filler provoked a tolerated refusal; widen the sweep for this platform"
+
+      tolerated.each do |filler|
+        vm = Quickjs::VM.new(memory_limit: 1024 * 1024)
+        begin
+          error = _ { vm.eval_code(churn.(filler, "throw new TypeError('mine')")) }.must_raise Quickjs::TypeError
+          _(error.message).must_equal 'mine'
+          _(vm.memory_poisoned?).must_equal false
+          _(vm.memory_usage[:alloc_refusals]).must_be :>, 0
+        ensure
+          vm.dispose!
+        end
+      end
+    end
+
+    # The count alone cannot decide this. A guest that catches its own
+    # out-of-memory and then throws is telling the truth about its own error,
+    # and nothing QuickJS wrote is pending by the time the renderer looks, so
+    # the throw is reported as itself and the VM is left alone. It is the same
+    # answer as catching and returning, which is what makes the rule sayable.
+    it "reports the guest's own throw after it recovered from an out-of-memory" do
+      vm = Quickjs::VM.new(memory_limit: 1024 * 1024)
+
+      error = _ do
+        vm.eval_code("try { new Array(2_000_000).fill(0) } catch (e) {} ; throw new TypeError('after')")
+      end.must_raise Quickjs::TypeError
+
+      _(error.message).must_equal 'after'
+      _(vm.memory_poisoned?).must_equal false
+      _(vm.eval_code('1 + 1')).must_equal 2
+    ensure
+      vm.dispose!
+    end
+
+    # A nested call must not open a scope of its own. Here the refusal happens
+    # before a bridge re-enters the VM, and what is rendered afterwards is the
+    # out-of-memory error QuickJS itself built, rethrown: the report is the
+    # same either way, and only the count tells whether it is backed by a
+    # refusal this call actually met. A snapshot taken by the inner call would
+    # move the window past it and hand back a VM nobody had condemned.
+    it "keeps the scope of the enclosing call when a bridge re-enters the VM" do
+      vm = Quickjs::VM.new(memory_limit: 1024 * 1024)
+      vm.define_function(:reenter) { vm.eval_code('1 + 1') }
+
+      error = _ do
+        vm.eval_code("try { new Array(2_000_000).fill(0) } catch (e) { reenter(); throw e }")
+      end.must_raise Quickjs::RuntimeError
+
+      _(error.message).must_equal 'out of memory'
+      _(vm.memory_poisoned?).must_equal true
+    ensure
+      vm.dispose!
+    end
+
+    # Every reader below asks about the conversion it is reporting on, not
+    # about the call the conversion sits in. Asked of the whole call, each one
+    # answers for a refusal the guest already caught and recovered from, and
+    # condemns a VM whose call went on to return normally.
+    it "leaves the VM alone when an unrelated value cannot be stringified after a recovered out-of-memory" do
+      vm = Quickjs::VM.new(memory_limit: 1024 * 1024)
+      vm.on_log {|log| }
+
+      _(vm.eval_code(<<~JS)).must_equal 'ok'
+        try { new Array(2_000_000).fill(0) } catch (e) {}
+        console.log(Symbol('s'));
+        'ok';
+      JS
+
+      _(vm.memory_poisoned?).must_equal false
+      _(vm.eval_code('1 + 1')).must_equal 2
+    ensure
+      vm.dispose!
+    end
+
+    # The listener hears the rejection it was waiting for, and the VM survives:
+    # the reason is the guest's own TypeError, so nothing QuickJS reported is
+    # in play, whatever the count says about a refusal the guest already caught.
+    it "hands the listener the real rejection reason after a recovered out-of-memory" do
+      vm = Quickjs::VM.new(memory_limit: 1024 * 1024)
+      seen = []
+      vm.on_unhandled_rejection {|err| seen << err }
+
+      _(vm.eval_code(<<~JS)).must_equal 'ok'
+        try { new Array(2_000_000).fill(0) } catch (e) {}
+        void Promise.reject(new TypeError('real reason'));
+        'ok';
+      JS
+
+      _(seen.map(&:class)).must_equal [Quickjs::TypeError]
+      _(seen.map(&:message)).must_equal ['real reason']
+      _(vm.memory_poisoned?).must_equal false
+      _(vm.eval_code('1 + 1')).must_equal 2
+    ensure
+      vm.dispose!
+    end
+
+    # The rejection nobody handled, with no listener to read its reason: the
+    # only reader below the tracker is one nobody registered, so a job that ran
+    # out inside drain_jobs! left the VM running on the heap that refused.
+    it "condemns the VM for an out-of-memory a drained job left unhandled" do
+      vm = Quickjs::VM.new(memory_limit: 1024 * 1024)
+      ran = []
+      vm.define_function(:mark) {|m| ran << m }
+
+      _(vm.eval_code(<<~JS)).must_equal 'ok'
+        Promise.resolve().then(() => { mark('job ran'); new Array(2_000_000).fill(0); mark('allocated') });
+        'ok';
+      JS
+      _(vm.memory_poisoned?).must_equal false
+
+      vm.drain_jobs!
+
+      _(ran).must_equal ['job ran']
+      _(vm.memory_poisoned?).must_equal true
+      _ { vm.eval_code('1 + 1') }.must_raise Quickjs::RuntimeError
+    ensure
+      vm.dispose!
+    end
+    # The listener runs after the row is built and can re-enter the VM, so the
+    # window has to close before it: a nested call that meets a refusal and
+    # recovers from it is that call's business, not this row's.
+    it "does not condemn the outer call for an out-of-memory a log listener's own call recovered from" do
+      vm = Quickjs::VM.new(memory_limit: 1024 * 1024)
+      vm.on_log {|log| vm.eval_code('try { new Array(2_000_000).fill(0) } catch (e) {} ; 1') }
+
+      _(vm.eval_code("console.log('hi'); 'done'")).must_equal 'done'
+      _(vm.memory_poisoned?).must_equal false
+    ensure
+      vm.dispose!
+    end
+
+    # The bridge's exit is above every reader, so the latch is set before the
+    # host error unwinds past it. With the guest having caught the refusal
+    # itself there is nothing for it to latch, and the host error is all the
+    # caller hears; the ordering matters for the case where QuickJS is the one
+    # reporting, and this pins that the host error still comes back out.
+    it "hands back the bridge's own error when it raises over a recovered out-of-memory" do
+      vm = Quickjs::VM.new(memory_limit: 1024 * 1024)
+      vm.define_function(:boom) { raise IOError, 'host error' }
+
+      error = _ do
+        vm.eval_code('try { new Array(2_000_000).fill(0) } catch (e) { boom() }')
+      end.must_raise IOError
+
+      _(error.message).must_equal 'host error'
+      _(vm.memory_poisoned?).must_equal false
+      _(vm.eval_code('1 + 1')).must_equal 2
+    ensure
+      vm.dispose!
+    end
+
+    # define_function evaluates JS and renders what that evaluation throws, so
+    # it belongs with the entry points that refuse a condemned VM rather than
+    # with the ones that only read.
+    it "refuses define_function on a VM the heap has condemned" do
+      vm = Quickjs::VM.new(memory_limit: 1024 * 1024)
+      _ { vm.eval_code('new Array(2_000_000).fill(0); void 0') }.must_raise Quickjs::RuntimeError
+      _(vm.memory_poisoned?).must_equal true
+
+      error = _ { vm.define_function(:hello) { 1 } }.must_raise Quickjs::RuntimeError
+      _(error.message).must_match(/poisoned/)
+    ensure
+      vm.dispose!
+    end
+
+    # Construction opens no scope, because there is no earlier call to tell it
+    # apart from, so every refusal counted while a VM is built belongs to that
+    # VM. Some of them raise on the way out. The feature module loads do not:
+    # they free their results unchecked, so a std module that ran out is
+    # discarded and the VM handed back on a heap that had already refused,
+    # with the first call finding it only by refusing too.
+    #
+    # Either outcome below is correct, and which one a platform takes depends
+    # on where its own allocations fall. Neither hands back a usable VM.
+    it "does not hand back a VM whose heap refused while it was being built" do
+      vm = nil
+      refused_at_construction = nil
+
+      begin
+        vm = Quickjs::VM.new(memory_limit: 64 * 1024, features: [:feature_std])
+      rescue Quickjs::RuntimeError => e
+        refused_at_construction = e
+      end
+
+      if vm
+        _(vm.memory_poisoned?).must_equal true
+        error = _ { vm.eval_code('1 + 1') }.must_raise Quickjs::RuntimeError
+        _(error.message).must_match(/poisoned/)
+      else
+        _(refused_at_construction.message).must_match(/out of memory/)
+      end
+    ensure
+      vm&.dispose!
+    end
+
+    # Scoped to the call rather than to the VM: a guest that runs out, catches
+    # it and returns is left alone, which is what it was before the allocator
+    # was ours. The scope is what makes that possible to say at all.
+    it "leaves the VM alone when the guest catches its own out-of-memory and returns" do
+      vm = Quickjs::VM.new(memory_limit: 1024 * 1024)
+
+      _(vm.eval_code("try { new Array(2_000_000).fill(0) } catch (e) { 'caught' }")).must_equal 'caught'
+      _(vm.memory_poisoned?).must_equal false
+      _(vm.eval_code('1 + 1')).must_equal 2
+    ensure
+      vm.dispose!
+    end
+
+    it "hands the listener the out-of-memory met while a rejection reason was read" do
+      vm = Quickjs::VM.new(memory_limit: 1024 * 1024)
+      seen = []
+      vm.on_unhandled_rejection {|err| seen << err }
+      vm.eval_code(<<~JS)
+        const big = 'x'.repeat(480 * 1024);
+        const e = new Error('r');
+        Object.defineProperty(e, 'message', {get() { return big + big }});
+        void Promise.reject(e);
+      JS
+
+      _(seen.map(&:message)).must_equal ['out of memory']
+      _(vm.memory_poisoned?).must_equal true
+    ensure
+      vm.dispose!
+    end
+
+    # The log path has no renderer to report through, so the latch it sets was
+    # written and never read: the evaluation carried on over a heap that had
+    # already run out, and the refusal arrived only at the next call. The flag
+    # is carried out to the QuickJS side of the protect and thrown there, the
+    # same shape a lapsed budget takes.
+    it "stops the evaluation when the heap ran out inside a logged value" do
+      vm = Quickjs::VM.new(memory_limit: 1024 * 1024)
+      logged = []
+      vm.on_log {|log| logged << log.to_s }
+      reached = []
+      vm.define_function(:mark) {|m| reached << m }
+
+      error = _ do
+        vm.eval_code(<<~JS)
+          const big = 'x'.repeat(480 * 1024);
+          console.log({toString() { return big + big }});
+          mark('after the log');
+          'returned';
+        JS
+      end.must_raise Quickjs::RuntimeError
+
+      _(error.message).must_equal 'out of memory'
+      _(reached).must_equal []
+      _(logged.first).must_equal '(unrenderable value)'
+      _(vm.memory_poisoned?).must_equal true
+    ensure
+      vm.dispose!
+    end
+
+    # The row is built one logged argument at a time, and any of them can raise:
+    # here the first runs out of memory and is substituted for, and the second
+    # throws from a getter while it converts. That raise unwinds the whole
+    # builder, so a flag copied out after it was never copied, and the heap
+    # having run out was bridged back to the guest as an ordinary catchable
+    # Error. Measured on the branch before this: the guest caught it, ran on,
+    # and the evaluation returned its value with the VM already condemned.
+    it "stops the evaluation when a later logged argument raises over the out-of-memory" do
+      vm = Quickjs::VM.new(memory_limit: 1024 * 1024)
+      vm.on_log {|log| }
+      reached = []
+      vm.define_function(:mark) {|m| reached << m }
+
+      error = _ do
+        vm.eval_code(<<~JS)
+          const big = 'x'.repeat(480 * 1024);
+          try {
+            console.log({toString() { return big + big }},
+                        {get x() { throw new RangeError('g') }});
+          } catch (e) {
+            mark('swallowed');
+          }
+          mark('kept running');
+          'returned';
+        JS
+      end.must_raise Quickjs::RuntimeError
+
+      _(error.message).must_equal 'out of memory'
+      _(reached).must_equal []
+      _(vm.memory_poisoned?).must_equal true
+    ensure
+      vm.dispose!
+    end
+
+    # Uncatchable, for the reason the lapse is: an error the guest can swallow
+    # is one it can go round again, and each catch would pin a Ruby exception
+    # in alive_objects on a heap with nothing left to give.
+    it "does not let the guest catch the out-of-memory thrown from the log path" do
+      vm = Quickjs::VM.new(memory_limit: 1024 * 1024)
+      vm.on_log {|log| }
+      reached = []
+      vm.define_function(:mark) {|m| reached << m }
+
+      error = _ do
+        vm.eval_code(<<~JS)
+          const big = 'x'.repeat(480 * 1024);
+          try {
+            console.log({toString() { return big + big }});
+          } catch (e) {
+            mark('swallowed');
+          }
+          'returned';
+        JS
+      end.must_raise Quickjs::RuntimeError
+
+      _(error.message).must_equal 'out of memory'
+      _(reached).must_equal []
+      _(vm.memory_poisoned?).must_equal true
+    ensure
+      vm.dispose!
+    end
+
     it "still condemns the VM for an out-of-memory a getter hit during conversion" do
       vm = Quickjs::VM.new(memory_limit: 1024 * 1024)
 

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -1243,6 +1243,23 @@ describe Quickjs::VM do
       vm.dispose!
     end
 
+    # The string branch of the conversion answered nil for a failed
+    # JS_ToCStringLen, which on a string value is an allocation and nothing
+    # else. The caller got nil for a string it did have, the refusal went
+    # unreported, and the next call ran on the heap that refused.
+    it "reports the out-of-memory when a returned string cannot be converted" do
+      vm = Quickjs::VM.new(memory_limit: 1024 * 1024)
+
+      error = _ do
+        vm.eval_code("const big = 'x'.repeat(480 * 1024); big + big")
+      end.must_raise Quickjs::RuntimeError
+
+      _(error.message).must_equal 'out of memory'
+      _(vm.memory_poisoned?).must_equal true
+    ensure
+      vm.dispose!
+    end
+
     # The exhaustion that got as far as an Error and no further. JS_ThrowError2
     # allocates the object, JS_NewString("out of memory") is then refused
     # inside in_out_of_memory, and the JS_EXCEPTION sentinel is stored as the
@@ -1350,6 +1367,21 @@ describe Quickjs::VM do
       vm.dispose!
     end
 
+    # An enumeration that could not allocate its own property table answered an
+    # empty hash for an object that had 71,680 of them, and the caller learned
+    # only at the next call. It reports now, like the string conversion beside
+    # it; a guest trap that threw still answers {}, which is #119.
+    it "reports the out-of-memory when an object's properties cannot be enumerated" do
+      vm = Quickjs::VM.new(memory_limit: 1024 * 1024)
+
+      error = _ { vm.eval_code('new Float64Array(71680)') }.must_raise Quickjs::RuntimeError
+
+      _(error.message).must_equal 'out of memory'
+      _(vm.memory_poisoned?).must_equal true
+    ensure
+      vm.dispose!
+    end
+
     # Every uncaught throw reaches the rejection tracker before the renderer,
     # since eval is async-wrapped, so a bridged host error passes through the
     # reason test on its way out. The renderer answers those at its
@@ -1373,6 +1405,37 @@ describe Quickjs::VM do
       _(vm.eval_code('1 + 1')).must_equal 2
     ensure
       vm.dispose!
+    end
+
+    # The baked module name is only unreadable for a non-ASCII one, since
+    # JS_ToCStringLen2 hands back the string's own buffer for pure ASCII. The
+    # empty name it fell back to was then compared against the name the caller
+    # filed the blob under, so an exhaustion arrived as a disagreement about
+    # names on a VM the latch had already condemned.
+    it "reports the out-of-memory when a module's baked name cannot be read" do
+      importable = Quickjs.compile_module('export const x = 1', filename: 'あ' * 50_000)
+      bytecode = importable.send(:bytecode)
+      raised = []
+
+      (79_000..97_000).step(3_000) do |filler|
+        vm = Quickjs::VM.new(memory_limit: 1024 * 1024)
+        begin
+          vm.eval_code("globalThis.f = new Float64Array(#{filler}); void 0")
+          vm.send(:_preload_module_bytecode, bytecode, importable.canonical_name)
+        rescue Quickjs::RuntimeError => e
+          raised << [e.message, vm.memory_poisoned?]
+        rescue ArgumentError => e
+          raised << [e.message, vm.memory_poisoned?]
+        ensure
+          vm.dispose!
+        end
+      end
+
+      refute_empty raised, 'no filler left the name unreadable; widen the sweep for this platform'
+      raised.each do |message, poisoned|
+        _(message).must_equal 'out of memory'
+        _(poisoned).must_equal true
+      end
     end
 
     # The bridged-error question is asked inside the message branch, where

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -936,6 +936,75 @@ describe Quickjs::VM do
     # memory is a fact about the heap rather than about who was asking, and this
     # is the shape that proves the split cannot own it: the evaluation returns
     # its object and the allocation that fails is in a getter read afterwards.
+    # The heap can run out inside one of the renderer's own reads. The getter
+    # here succeeds — big + big is a rope — and it is the read's own
+    # JS_ToCString, flattening it, that runs out. That throw took the
+    # substitution path like any other, so the caller got a normal-looking
+    # RuntimeError, the latch never set, and the next evaluation ran on the
+    # heap the latch exists to refuse.
+    it "condemns the VM for an out-of-memory met inside a read it was rendering" do
+      vm = Quickjs::VM.new(memory_limit: 1024 * 1024)
+
+      error = _ do
+        vm.eval_code(<<~JS)
+          const big = 'x'.repeat(480 * 1024);
+          const e = new Error('m');
+          Object.defineProperty(e, 'message', {get() { return big + big }});
+          throw e;
+        JS
+      end.must_raise Quickjs::RuntimeError
+
+      _(error.message).must_match(/out of memory/)
+      _(vm.memory_poisoned?).must_equal true
+      err = _ { vm.eval_code('1 + 1') }.must_raise Quickjs::RuntimeError
+      _(err.message).must_match(/poisoned/)
+    ensure
+      vm.dispose!
+    end
+
+    # One level deeper: the discarded throw says "out of memory" as an own data
+    # property, but converting that message to look at it is itself an
+    # allocation — a non-ASCII string transcodes — and it fails on the same
+    # exhausted heap. A string that will not convert is the heap running out.
+    it "condemns the VM when inspecting the discarded throw itself runs out of memory" do
+      vm = Quickjs::VM.new(memory_limit: 1024 * 1024)
+
+      error = _ do
+        vm.eval_code(<<~JS)
+          const big = 'x'.repeat(600 * 1024);
+          const e = new Error('m');
+          Object.defineProperty(e, 'message', {get() {
+            const inner = new Error('q');
+            inner.message = 'out of memory ' + 'é'.repeat(150 * 1024);
+            throw inner;
+          }});
+          throw e;
+        JS
+      end.must_raise Quickjs::RuntimeError
+
+      _(error.message).must_match(/out of memory/)
+      _(vm.memory_poisoned?).must_equal true
+    ensure
+      vm.dispose!
+    end
+
+    it "hands the listener the out-of-memory met while a rejection reason was read" do
+      vm = Quickjs::VM.new(memory_limit: 1024 * 1024)
+      seen = []
+      vm.on_unhandled_rejection {|err| seen << err }
+      vm.eval_code(<<~JS)
+        const big = 'x'.repeat(480 * 1024);
+        const e = new Error('r');
+        Object.defineProperty(e, 'message', {get() { return big + big }});
+        void Promise.reject(e);
+      JS
+
+      _(seen.map(&:message)).must_equal ['out of memory']
+      _(vm.memory_poisoned?).must_equal true
+    ensure
+      vm.dispose!
+    end
+
     it "still condemns the VM for an out-of-memory a getter hit during conversion" do
       vm = Quickjs::VM.new(memory_limit: 1024 * 1024)
 


### PR DESCRIPTION
Closes #111.

The latch that condemns a VM after an out-of-memory was keyed on two strings a guest can write: an error named `InternalError` whose message contains `out of memory`. Both ends of #111 follow from that. A guest writes them and the VM is condemned on a heap that was never touched. A real exhaustion that cannot allocate its own error object has no strings to match, so it never latched at all.

The first commit here is @ursm's 94dd85b, unchanged, the one stripped from #110 so that PR could land as the NULL-conversion work. It is the detector and the plumbing: a latch at every hold rather than only in the renderer, so the log row and the rejection reason (which have no renderer) are covered. What changes on top is only what the latch keys on.

## Heap occupancy is not available

It was the obvious candidate and it does not work. Measured on a genuine out-of-memory with `memory_limit: 1 MiB`, `malloc_size` at the moment the latch fires is 158,976 bytes, 15.2% of the limit, because QuickJS rolls back the allocation it could not make. The latch records an event; occupancy is a state, and after the rollback the state carries no trace of the event.

## Owning the allocator

`JS_NewRuntime2` takes a `JSMallocFunctions`, so the runtime is created with ours: `js_def_malloc` and its siblings with one line added, counting every refusal on the VM. The refusal happens below the guest, before QuickJS has decided whether it can afford an error object, so a guest cannot move that number by saying anything, and it moves whether or not an error object is ever built.

The accounting is copied rather than approximated. `js_def_malloc` is where `memory_limit` is enforced, and `malloc_count` / `malloc_size` are what `JS_ComputeMemoryUsage` reports through `VM#memory_usage`; an asymmetry between the malloc and free sides would not fail, it would drift, and the limit would then be compared against a number that is not the heap. Measured at zero drift over 200 allocate-and-release cycles, which a test pins. The submodule stays untouched: `js_def_malloc_usable_size` is static, so its platform ladder is mirrored here, `MALLOC_OVERHEAD` with it.

`JS_NewRuntime2` also answers NULL when it cannot allocate the runtime, and `JS_NewContext(NULL)` dereferences it. That NULL was reachable through `JS_NewRuntime` too and nothing checked it.

## The count is necessary, not sufficient

QuickJS tolerates some refusals. `JS_NewShape` and `JS_NewAtom` ignore what `resize_shape_hash` and `JS_ResizeAtomHash` answer, **and the threshold only advances on success**, so near the ceiling every later shape retries the refused block: the count climbs while the runtime stays correct and nothing ever throws. Keyed on the count alone, the verdict was then decided by whether the guest happened to throw afterwards, which is #111's first end reached through a key the guest cannot write but also cannot see. Found by @ursm's review; measured here with a 90,000-element filler under 1 MiB:

| tail | count alone | this branch |
|---|---|---|
| `'done'` | `"done"`, healthy | `"done"`, healthy |
| `throw new TypeError('mine')` | `out of memory`, condemned | `TypeError: mine`, healthy |

So the count is the necessary condition and QuickJS's own report is the sufficient one. `js_reports_out_of_memory` asks the pending value for either shape QuickJS leaves behind: `out of memory` in `message`, read as an own data property so nothing guest-written runs on a throw about to be discarded, or no error object at all when it could not afford to build one, which is the end #116 reaches. The sentence is forgeable and always was, which is why it is only ever asked alongside a refusal that really happened.

## The scope

One public API call, opened by `enter_oom_scope`, which every entry point already called under its previous name `check_oom_poisoned`. It cannot be the JS entry: an evaluation is two counted entries, the run and then the rendering of what it left pending, so a snapshot taken as an entry opens would be re-taken after the refusal and before the renderer that has to see it. Nested calls inherit rather than opening their own. The log row build is a sub-scope, so the readers it reaches through `to_rb_value` measure the build and not the call around it.

Construction opens no scope, because there is nothing earlier to tell it apart from: any refusal counted while a VM is built condemns that VM. Reachable through the feature module loads, which free their `JS_Eval` results unchecked (#124).

## What each reader answers

| | result | `memory_poisoned?` |
|---|---|---|
| forged `InternalError`, top level | `RuntimeError: out of memory` | false |
| forged `InternalError` from a logged `toString` | returned `"done"` | false |
| guest error saying a worker ran out | `RuntimeError: worker ran out of memory, retrying` | false |
| genuine out-of-memory, top level | `RuntimeError: out of memory` | **true** |
| genuine out-of-memory inside a rendered read | `RuntimeError: out of memory` | **true** |
| genuine out-of-memory inside a logged value | `RuntimeError: out of memory`, evaluation stops | **true** |
| genuine out-of-memory a drained job left unhandled | reported to the listener | **true** |
| genuine out-of-memory, caught, returns | returned `"caught"` | false |
| genuine out-of-memory, caught, throws a `TypeError` over it | `Quickjs::TypeError: after` | false |
| timeout after a recovered out-of-memory | `Quickjs::InterruptedError` | false |
| rejection the guest handles, after a recovered one | reported to the listener as itself | false |

Rows 1 and 3 are #111's first end. Rows 4 to 7 are its second. The last four are the tolerated-refusal finding: the guest's own failures are reported as the guest's, and the VM survives them.

Separately, #116's `RuntimeError: null` at a 2 MiB limit is now `out of memory` with the VM condemned, which is the end #116 said this issue owns. The SIGSEGV at the other limits is untouched and upstream.

## Behaviour change

`memory_poisoned?` means what it says now and only that: the allocator refused during the call **and** QuickJS reported the refusal. Anyone who was relying on `e.name = 'InternalError'` to condemn a VM deliberately has no way to do it, which is the point. Nothing else about the flag's contract moves: a real exhaustion still condemns, and a condemned VM still refuses every subsequent call.

The log path stops an evaluation that meets a real out-of-memory inside a logged value, where it used to run on and be refused only at the next call. The throw is uncatchable, the shape f95ec6a gave a lapsed budget, so a guest cannot swallow it and pin one exception in `alive_objects` per catch.

## Tests

690 runs, 1223 assertions, 0 failures, stable across seeds 1, 4242 and 99991. Every test added here fails on its own parent commit except three, each deliberate and each saying so where it stands: a guest error reading `worker ran out of memory, retrying` was already spared by the old match, which wanted the `InternalError` name too; the catch-and-return case is the behaviour the scope preserves; and the substitution test from 94dd85b pins that detector rather than a regression.

One test from 94dd85b changed meaning. It asserted that a getter throwing a large non-ASCII error condemns the VM, because converting that message to look for the sentence was itself an allocation that failed, on a heap at 79% of its limit with nothing else having failed: the detector ran out of memory inside its own inspection and condemned the VM on the strength of it. Nothing reads that message now, so it pins the substitution instead. Four more changed meaning with the necessary-and-sufficient rule and say so where they stand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013YKja4SUywdKje4NTWTCpc
