### PR TITLE
Tell define_function's caller what resolving the path ran into

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ vm.define_function(["a", "b", "c", "double"]) { |x| x * 2 }
 vm.eval_code("a.b.c.double(21)") #=> 42
 ```
 
-`define_function` returns the registered name as a `Symbol` (or an `Array` of `Symbol`s for array paths).
+`define_function` returns the registered name as a `Symbol` (or an `Array` of `Symbol`s for array paths). Resolving an array path runs JS — the first segment is evaluated, so a `const` binding works as well as a global, and any segment can be a getter — so an error met on the way is reported as itself: a getter that throws raises the matching `Quickjs::*Error`, one of your own bridges raising inside it raises your exception, and a lapsed `timeout_msec` raises `Quickjs::InterruptedError`. A segment that resolves to a non-object raises `ArgumentError`. A target that refuses the property — a frozen object, or a setter that throws — raises the JS error rather than reporting success, and nothing is registered.
 
 A Ruby exception raised inside the block is catchable in JS as an `Error`, and propagates back to Ruby as the original exception type if uncaught in JS.
 

--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -1400,10 +1400,13 @@ static JSValue js_quickjsrb_call_global(JSContext *ctx, JSValueConst _this, int 
 
   VMData *data = JS_GetContextOpaque(ctx);
   VALUE r_proc = rb_hash_aref(data->defined_functions, ID2SYM((ID)key_id));
-  // Shouldn't happen
+  // Entries are never removed, and the block is recorded once the property is
+  // installed, so the one way to get here is from inside that install: a
+  // setter on the target that calls the value it was handed. Say so, rather
+  // than report an internal fault to a caller whose setter did exactly that.
   if (r_proc == Qnil)
   {
-    return JS_ThrowReferenceError(ctx, "Proc is not defined");
+    return JS_ThrowReferenceError(ctx, "'%s' cannot be called yet: define_function has not finished installing it", rb_id2name((ID)key_id));
   }
 
   VALUE r_call_args = rb_ary_new();

--- a/ext/quickjsrb/quickjsrb.c
+++ b/ext/quickjsrb/quickjsrb.c
@@ -218,7 +218,14 @@ static VALUE r_backtrace_from_js_stack(const char *stack)
   if (stack == NULL || stack[0] == '\0')
     return Qnil;
 
-  VALUE r_lines = rb_str_split(rb_str_new_cstr(stack), "\n");
+  // Through rb_funcall and not rb_str_split: the latter enters String#split
+  // directly, so it honours whatever block the current C frame was called
+  // with. Any entry point has one if the caller passed one — eval_code with a
+  // stray block, define_function always — and there split yielded every line
+  // of the JS stack to that block and answered the String instead of an
+  // Array, which rb_ary_entry then dereferenced as one. rb_funcall never
+  // forwards a block.
+  VALUE r_lines = rb_funcall(rb_str_new_cstr(stack), rb_intern("split"), 1, rb_str_new_cstr("\n"));
   VALUE r_filtered = rb_ary_new();
   for (long i = 0; i < RARRAY_LEN(r_lines); i++)
   {
@@ -3288,129 +3295,164 @@ struct define_function_call
   VALUE r_block;
 };
 
+// What a define holds while it resolves its path: the parent it is walking
+// and the two values the bridge function captures. Owned by an ensure from
+// before any of them exists, because resolution runs guest JS — the first
+// segment is an eval and every later one a property read, any of which can
+// be a getter that reaches a bridge, raises, or outlives the budget — and the
+// install itself can run a setter. Every one of those unwinds through here.
+struct define_function_install
+{
+  JSContext *ctx;
+  JSValue j_parent;
+  JSValue ruby_data[2];
+};
+
+static VALUE define_function_release(VALUE p)
+{
+  struct define_function_install *install = (struct define_function_install *)p;
+  JS_FreeValue(install->ctx, install->j_parent);
+  JS_FreeValue(install->ctx, install->ruby_data[0]);
+  JS_FreeValue(install->ctx, install->ruby_data[1]);
+  return Qnil;
+}
+
+struct define_function_run
+{
+  struct define_function_call *call;
+  struct define_function_install *install;
+  VALUE r_segs;    // the segments as Strings, stringified once, outside the region
+  VALUE r_key_sym; // the key the bridge looks the block up by
+};
+
+// Two answers a resolution step can give that are not the object asked for,
+// and they are different failures. A pending exception is the guest's own —
+// a bridge raising in a getter, the budget lapsing, a dispose! reached from
+// the path — and folding it into "not an object" both blamed the caller's
+// path for it and left the Ruby exception behind it parked in alive_objects
+// for the life of the VM. Only a value that really is not an object is the
+// caller's mistake.
+static void check_path_segment(JSContext *ctx, JSValueConst j_val, const char *segment)
+{
+  if (JS_IsException(j_val))
+    raise_js_exception(ctx);
+  if (!JS_IsObject(j_val))
+    rb_raise(rb_eArgError, "cannot define function: '%s' is not an object", segment);
+}
+
+static VALUE define_function_resolve_and_install(VALUE p)
+{
+  struct define_function_run *run = (struct define_function_run *)p;
+  VMData *data = run->call->data;
+  JSContext *ctx = data->context;
+  struct define_function_install *install = run->install;
+  VALUE r_segs = run->r_segs;
+  long path_len = RARRAY_LEN(r_segs);
+
+  install->ruby_data[0] = JS_NewInt64(ctx, (int64_t)SYM2ID(run->r_key_sym));
+  install->ruby_data[1] = JS_NewBool(ctx, RTEST(rb_funcall(run->call->r_flags, rb_intern("include?"), 1, ID2SYM(rb_intern("async")))));
+
+  if (path_len > 1)
+  {
+    // Resolving the path runs guest JS under whatever interrupt handler the
+    // previous entry left armed. Refresh the clock, or a lapsed budget fires in
+    // the first getter and is reported as that getter's fault. Unconditional,
+    // as it always was here: nested under a bridge this resets the enclosing
+    // eval's clock, which vm_m_compile's comment records as a class deferred to
+    // its own PR rather than something to change one entry point at a time.
+    arm_eval_timer(data);
+
+    // The first segment is not a lookup, it is an eval: `myLib` can be a
+    // lexical binding as well as a global property, and either can be an
+    // accessor.
+    const char *first_seg = StringValueCStr(RARRAY_AREF(r_segs, 0));
+    install->j_parent = JS_Eval(ctx, first_seg, strlen(first_seg), vmInternalFilename, JS_EVAL_TYPE_GLOBAL);
+    check_path_segment(ctx, install->j_parent, first_seg);
+
+    for (long i = 1; i < path_len - 1; i++)
+    {
+      const char *seg = StringValueCStr(RARRAY_AREF(r_segs, i));
+      JSValue j_next = JS_GetPropertyStr(ctx, install->j_parent, seg);
+      JS_FreeValue(ctx, install->j_parent);
+      install->j_parent = j_next;
+      check_path_segment(ctx, j_next, seg);
+    }
+  }
+  else
+  {
+    // A plain name never armed before, and the only JS it can run is a setter
+    // on globalThis. It gets a clock of its own only as the outermost entry:
+    // nested under a bridge, the enclosing eval's budget governs, and arming
+    // here unconditionally let a bridge that defined a function on every
+    // call keep the enclosing eval alive past its timeout_msec.
+    if (data->evals_in_flight == 1)
+      arm_eval_timer(data);
+    install->j_parent = JS_GetGlobalObject(ctx);
+  }
+
+  const char *funcName = StringValueCStr(RARRAY_AREF(r_segs, path_len - 1));
+
+  JSValue j_func = JS_NewCFunctionData(ctx, js_quickjsrb_call_global, 1, 0, 2, install->ruby_data);
+  if (JS_IsException(j_func))
+    return raise_js_exception(ctx);
+
+  // JS_SetPropertyStr consumes j_func on every path and, with JS_PROP_THROW,
+  // answers -1 with the TypeError pending when the target refuses — a frozen
+  // parent, a frozen globalThis, a setter that throws. Ignored, that was a
+  // define that reported success for a function which did not exist, and a
+  // stale exception left on the context for whatever ran next.
+  if (JS_SetPropertyStr(ctx, install->j_parent, funcName, j_func) < 0)
+    return raise_js_exception(ctx);
+
+  // Recorded only now that the property is installed. can_eval_gvl_free reads
+  // this table as "a bridge can fire during eval", and an entry left behind by
+  // a define that failed took the VM off the GVL-release path for good.
+  rb_hash_aset(data->defined_functions, run->r_key_sym, run->call->r_block);
+  return Qnil;
+}
+
 static VALUE define_global_function_body(VALUE p)
 {
   struct define_function_call *call = (struct define_function_call *)p;
   VMData *data = call->data;
   VALUE r_name = call->r_name;
-  VALUE r_flags = call->r_flags;
-  VALUE r_block = call->r_block;
 
-  if (RB_TYPE_P(r_name, T_ARRAY))
+  // A plain name is a path of one segment whose parent is the global object;
+  // the only difference is what the caller gets back.
+  bool as_path = RB_TYPE_P(r_name, T_ARRAY);
+  VALUE r_path = as_path ? r_name : rb_ary_new3(1, r_name);
+  long path_len = RARRAY_LEN(r_path);
+  if (path_len < 1)
+    rb_raise(rb_eArgError, "function's path array must not be empty");
+
+  for (long i = 0; i < path_len; i++)
   {
-    long path_len = RARRAY_LEN(r_name);
-    if (path_len < 1)
-      rb_raise(rb_eArgError, "function's path array must not be empty");
-
-    for (long i = 0; i < path_len; i++)
-    {
-      VALUE r_seg = RARRAY_AREF(r_name, i);
-      if (!(SYMBOL_P(r_seg) || RB_TYPE_P(r_seg, T_STRING)))
-        rb_raise(rb_eTypeError, "function's name should be a Symbol or a String");
-    }
-
-    // Build internal lookup key by joining path segments with "."
-    // e.g. ["myLib", "hello"] -> :"myLib.hello"
-    VALUE r_segs = rb_ary_new();
-    for (long i = 0; i < path_len; i++)
-      rb_ary_push(r_segs, rb_funcall(RARRAY_AREF(r_name, i), rb_intern("to_s"), 0));
-    VALUE r_key_str = rb_funcall(r_segs, rb_intern("join"), 1, rb_str_new2("."));
-    VALUE r_key_sym = rb_funcall(r_key_str, rb_intern("to_sym"), 0);
-    rb_hash_aset(data->defined_functions, r_key_sym, r_block);
-
-    VALUE r_func_seg_str = rb_funcall(RARRAY_AREF(r_name, path_len - 1), rb_intern("to_s"), 0);
-    char *funcName = StringValueCStr(r_func_seg_str);
-
-    JSValueConst ruby_data[2];
-    ruby_data[0] = JS_NewInt64(data->context, (int64_t)SYM2ID(r_key_sym));
-    ruby_data[1] = JS_NewBool(data->context, RTEST(rb_funcall(r_flags, rb_intern("include?"), 1, ID2SYM(rb_intern("async")))));
-
-    // Resolve the parent object to attach the function to.
-    // For a single-element array, parent is the global object.
-    // For multi-element arrays, traverse path[0..n-2] using JS_Eval for the first
-    // segment (so lexical const/let bindings are resolved, not just global properties)
-    // and JS_GetPropertyStr for subsequent segments.
-    JSValue j_parent;
-    if (path_len == 1)
-    {
-      j_parent = JS_GetGlobalObject(data->context);
-    }
-    else
-    {
-      VALUE r_first_str = rb_funcall(RARRAY_AREF(r_name, 0), rb_intern("to_s"), 0);
-      const char *first_seg = StringValueCStr(r_first_str);
-      // Resolving the first segment is not a lookup, it is an eval: `myLib`
-      // can be an accessor property, so this runs arbitrary JS and can reach
-      // a Ruby bridge. It runs under whatever interrupt handler the previous
-      // eval left armed, so refresh the clock — a lapsed budget misfires here
-      // and masquerades as "'%s' is not an object", blaming the caller's path
-      // for what was a timeout.
-      arm_eval_timer(data);
-      j_parent = JS_Eval(data->context, first_seg, strlen(first_seg), vmInternalFilename, JS_EVAL_TYPE_GLOBAL);
-
-      if (JS_IsException(j_parent) || !JS_IsObject(j_parent))
-      {
-        JS_FreeValue(data->context, j_parent);
-        JS_FreeValue(data->context, ruby_data[0]);
-        JS_FreeValue(data->context, ruby_data[1]);
-        rb_raise(rb_eArgError, "cannot define function: '%s' is not an object", first_seg);
-      }
-
-      for (long i = 1; i < path_len - 1; i++)
-      {
-        VALUE r_seg_str = rb_funcall(RARRAY_AREF(r_name, i), rb_intern("to_s"), 0);
-        JSValue j_next = JS_GetPropertyStr(data->context, j_parent, StringValueCStr(r_seg_str));
-        JS_FreeValue(data->context, j_parent);
-
-        if (JS_IsException(j_next) || !JS_IsObject(j_next))
-        {
-          JS_FreeValue(data->context, j_next);
-          JS_FreeValue(data->context, ruby_data[0]);
-          JS_FreeValue(data->context, ruby_data[1]);
-          rb_raise(rb_eArgError, "cannot define function: '%s' is not an object", StringValueCStr(r_seg_str));
-        }
-        j_parent = j_next;
-      }
-    }
-
-    JS_SetPropertyStr(
-        data->context, j_parent, funcName,
-        JS_NewCFunctionData(data->context, js_quickjsrb_call_global, 1, 0, 2, ruby_data));
-    JS_FreeValue(data->context, j_parent);
-    JS_FreeValue(data->context, ruby_data[0]);
-    JS_FreeValue(data->context, ruby_data[1]);
-
-    VALUE r_result = rb_ary_new();
-    for (long i = 0; i < path_len; i++)
-      rb_ary_push(r_result, rb_funcall(RARRAY_AREF(r_name, i), rb_intern("to_sym"), 0));
-    return r_result;
+    VALUE r_seg = RARRAY_AREF(r_path, i);
+    if (!(SYMBOL_P(r_seg) || RB_TYPE_P(r_seg, T_STRING)))
+      rb_raise(rb_eTypeError, "function's name should be a Symbol or a String");
   }
-  else if (SYMBOL_P(r_name) || RB_TYPE_P(r_name, T_STRING))
-  {
-    VALUE r_name_sym = rb_funcall(r_name, rb_intern("to_sym"), 0);
 
-    rb_hash_aset(data->defined_functions, r_name_sym, r_block);
-    VALUE r_name_str = rb_funcall(r_name, rb_intern("to_s"), 0);
-    char *funcName = StringValueCStr(r_name_str);
+  // Stringified once, here, and handed to the resolution as Strings: to_s on
+  // a caller's object is a yield point and can raise, and neither belongs
+  // inside the region that holds JS values. The bridge looks its block up by
+  // the segments joined with ".", e.g. ["myLib", "hello"] -> :"myLib.hello",
+  // and a plain name as itself.
+  VALUE r_segs = rb_ary_new();
+  for (long i = 0; i < path_len; i++)
+    rb_ary_push(r_segs, rb_funcall(RARRAY_AREF(r_path, i), rb_intern("to_s"), 0));
+  VALUE r_key_sym = rb_funcall(rb_funcall(r_segs, rb_intern("join"), 1, rb_str_new2(".")), rb_intern("to_sym"), 0);
 
-    JSValueConst ruby_data[2];
-    ruby_data[0] = JS_NewInt64(data->context, (int64_t)SYM2ID(r_name_sym));
-    ruby_data[1] = JS_NewBool(data->context, RTEST(rb_funcall(r_flags, rb_intern("include?"), 1, ID2SYM(rb_intern("async")))));
+  struct define_function_install install = {data->context, JS_UNDEFINED, {JS_UNDEFINED, JS_UNDEFINED}};
+  struct define_function_run run = {call, &install, r_segs, r_key_sym};
+  rb_ensure(define_function_resolve_and_install, (VALUE)&run, define_function_release, (VALUE)&install);
 
-    JSValue j_global = JS_GetGlobalObject(data->context);
-    JS_SetPropertyStr(
-        data->context, j_global, funcName,
-        JS_NewCFunctionData(data->context, js_quickjsrb_call_global, 1, 0, 2, ruby_data));
-    JS_FreeValue(data->context, j_global);
-    JS_FreeValue(data->context, ruby_data[0]);
-    JS_FreeValue(data->context, ruby_data[1]);
+  if (!as_path)
+    return r_key_sym;
 
-    return r_name_sym;
-  }
-  else
-  {
-    rb_raise(rb_eTypeError, "function's name should be a Symbol or a String");
-  }
+  VALUE r_result = rb_ary_new();
+  for (long i = 0; i < path_len; i++)
+    rb_ary_push(r_result, rb_funcall(RARRAY_AREF(r_segs, i), rb_intern("to_sym"), 0));
+  return r_result;
 }
 
 // Registering a function is a JS entry point like any other, and was the one

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -2189,6 +2189,18 @@ end
           _(@vm.eval_code('typeof lonely')).must_equal 'undefined'
         end
 
+        # The block is recorded once the property is installed, and a setter on
+        # the target runs during that install. One that calls the value it was
+        # handed reaches a function with no block behind it yet, and used to be
+        # told "Proc is not defined" — the bridge's internal-fault message for
+        # a case that is not one.
+        it "tells a setter that calls the value that the define has not finished" do
+          @vm.eval_code("Object.defineProperty(globalThis, 'eager', {set(f) { f() }}); 0")
+
+          err = _ { @vm.define_function('eager') { 'from ruby' } }.must_raise Quickjs::ReferenceError
+          _(err.message).must_match(/'eager' cannot be called yet/)
+        end
+
         it "reports a setter that throws as that error" do
           @vm.eval_code("Object.defineProperty(globalThis, 'guarded', {set(v) { throw new RangeError('no') }}); 0")
 

--- a/test/quickjs_test.rb
+++ b/test/quickjs_test.rb
@@ -903,6 +903,22 @@ describe Quickjs::VM do
       vm.dispose!
     end
 
+    # The renderer split the JS stack with a call that enters String#split
+    # directly, which honours whatever block the calling C frame had — so a
+    # stray block on eval_code was handed every line of the stack and the
+    # String came back where an Array was expected. A segfault on main.
+    it "renders a JS error for a caller that passed a block" do
+      vm = Quickjs::VM.new
+      seen = []
+
+      error = _ { vm.eval_code("throw new RangeError('with block')") {|*args| seen << args } }.must_raise Quickjs::RangeError
+
+      _(error.message).must_equal 'with block'
+      _(seen).must_equal []
+    ensure
+      vm.dispose!
+    end
+
     it "still announces an error that reached the top level uncaught" do
       vm = Quickjs::VM.new
       logged = []
@@ -2039,8 +2055,12 @@ end
         _(@vm.eval_code("await lib.fetch().then(r => r + '!')")).must_equal "data!"
       end
 
-      it "raises ArgumentError when parent does not exist" do
-        err = _ { @vm.define_function(["nonexistent", "fn"]) { } }.must_raise ArgumentError
+      # The first segment is an eval, and evaluating a name that is not bound
+      # is a ReferenceError in JS. It is reported as that rather than folded
+      # into "is not an object", which is reserved for a value that resolved
+      # and simply is not one.
+      it "reports the ReferenceError when the parent does not exist" do
+        err = _ { @vm.define_function(["nonexistent", "fn"]) { } }.must_raise Quickjs::ReferenceError
         _(err.message).must_include "nonexistent"
       end
 
@@ -2053,6 +2073,184 @@ end
       it "single-element array registers on the global object" do
         @vm.define_function(["lone"]) { 42 }
         _(@vm.eval_code("lone()")).must_equal 42
+      end
+
+      # Resolving the path runs guest JS: the first segment is an eval and
+      # every later one a property read, and either can be a getter. What that
+      # getter did used to be folded into "is not an object" — a bridge
+      # raising, the budget lapsing, a dispose! — blaming the caller's path for
+      # it, and the Ruby exception behind a bridge stayed parked in
+      # alive_objects for the life of the VM since nothing ever retrieved it.
+      describe "when resolving the path runs into an error" do
+        it "reports a bridge error from a getter as that error" do
+          @vm.define_function('probe') { raise IOError, 'boom' }
+          @vm.eval_code("Object.defineProperty(globalThis, 'myLib', {get() { probe(); return {} }}); 0")
+
+          err = _ { @vm.define_function(['myLib', 'hello']) { 1 } }.must_raise IOError
+          _(err.message).must_equal 'boom'
+          _(@vm.eval_code('1 + 1')).must_equal 2
+        end
+
+        it "reports a getter's own throw as that error" do
+          @vm.eval_code("Object.defineProperty(globalThis, 'throwingLib', {get() { throw new RangeError('from getter') }}); 0")
+
+          err = _ { @vm.define_function(['throwingLib', 'hello']) { 1 } }.must_raise Quickjs::RangeError
+          _(err.message).must_equal 'from getter'
+        end
+
+        it "reports a lapsed budget as InterruptedError, not as a bad path" do
+          vm = Quickjs::VM.new(timeout_msec: 50)
+          vm.eval_code("Object.defineProperty(globalThis, 'slowLib', {get() { const t = Date.now(); while (Date.now() - t < 1000) {}; return {} }}); 0")
+
+          _ { vm.define_function(['slowLib', 'hello']) { 1 } }.must_raise Quickjs::InterruptedError
+        ensure
+          vm.dispose!
+        end
+
+        it "reports a dispose! reached from a getter as the ThreadError it owes" do
+          vm = Quickjs::VM.new
+          vm.define_function('bye') { vm.dispose! }
+          vm.eval_code("Object.defineProperty(globalThis, 'dyingLib', {get() { bye(); return {} }}); 0")
+
+          _ { vm.define_function(['dyingLib', 'hello']) { 1 } }.must_raise ThreadError
+          _(vm.disposed?).must_equal false
+          _(vm.eval_code('1 + 1')).must_equal 2
+        ensure
+          vm.dispose!
+        end
+
+        # The plain-name path never armed, and giving it a clock of its own
+        # unconditionally let a bridge that defines a function on every call
+        # reset the enclosing eval's clock each time, past its timeout_msec.
+        it "does not let a nested plain-name define reset the enclosing budget" do
+          vm = Quickjs::VM.new(timeout_msec: 100)
+          vm.define_function('redefine') { vm.define_function('b') { 1 }; 1 }
+
+          _ do
+            vm.eval_code('const t = Date.now(); while (Date.now() - t < 1500) redefine(); 1')
+          end.must_raise Quickjs::InterruptedError
+        ensure
+          vm.dispose!
+        end
+
+        it "still calls a genuinely non-object segment the caller's mistake" do
+          @vm.eval_code("globalThis.lib = {leaf: 42}; 0")
+          err = _ { @vm.define_function(['lib', 'leaf', 'fn']) { } }.must_raise ArgumentError
+          _(err.message).must_include 'leaf'
+        end
+
+        # The masked bridge error never reached find_ruby_error, the only
+        # thing that takes a bridged exception out of alive_objects.
+        it "no longer pins the bridge's Ruby exception for the life of the VM" do
+          marker = Class.new(StandardError)
+          @vm.define_function('probe') { raise marker, 'boom' }
+          @vm.eval_code("Object.defineProperty(globalThis, 'myLib', {get() { probe(); return {} }}); 0")
+          attempt = proc { @vm.define_function(['myLib', 'hello']) { 1 } rescue marker }
+
+          3.times(&attempt)
+          GC.start
+          before = ObjectSpace.each_object(marker).count
+          200.times(&attempt)
+          GC.start
+
+          _(ObjectSpace.each_object(marker).count - before).must_equal 0
+        end
+
+        # The renderer splits the JS stack into lines, and did so through a
+        # call that honours the current C frame's block — which define_function
+        # has. Every line of the stack was yielded to the caller's block, and
+        # the String came back where an Array was expected.
+        it "does not hand the JS stack trace to the block being defined" do
+          seen = []
+          @vm.eval_code("Object.defineProperty(globalThis, 'throwingLib', {get() { throw new RangeError('x') }}); 0")
+
+          _ { @vm.define_function(['throwingLib', 'hello']) {|*args| seen << args } }.must_raise Quickjs::RangeError
+
+          _(seen).must_equal []
+        end
+      end
+
+      # JS_SetPropertyStr answers -1 with a TypeError pending when the target
+      # refuses, and that answer was ignored: the define reported success for
+      # a function that did not exist, and the TypeError stayed pending on the
+      # context for whatever ran next.
+      describe "when the target refuses the property" do
+        it "raises the TypeError for a frozen parent instead of reporting success" do
+          @vm.eval_code('globalThis.frozenLib = Object.freeze({}); 0')
+
+          _ { @vm.define_function(['frozenLib', 'hello']) { 42 } }.must_raise Quickjs::TypeError
+          _(@vm.eval_code('typeof frozenLib.hello')).must_equal 'undefined'
+        end
+
+        it "raises the TypeError for a frozen globalThis and a plain name" do
+          @vm.eval_code('Object.freeze(globalThis); 0')
+
+          _ { @vm.define_function('lonely') { 42 } }.must_raise Quickjs::TypeError
+          _(@vm.eval_code('typeof lonely')).must_equal 'undefined'
+        end
+
+        it "reports a setter that throws as that error" do
+          @vm.eval_code("Object.defineProperty(globalThis, 'guarded', {set(v) { throw new RangeError('no') }}); 0")
+
+          err = _ { @vm.define_function('guarded') { 42 } }.must_raise Quickjs::RangeError
+          _(err.message).must_equal 'no'
+        end
+      end
+
+      # can_eval_gvl_free reads defined_functions as "a bridge can fire during
+      # eval". The block was recorded before the path resolved, so a define
+      # that failed left its entry behind and took the VM off the GVL-release
+      # path for good. The probe: a VM on that path refuses a bridge
+      # registration while another thread's eval is in flight, since the eval
+      # runs with the GVL released; a demoted one holds the GVL for the whole
+      # eval, so the same call blocks and then succeeds.
+      describe "when the define fails" do
+        def still_releases_the_gvl?(vm)
+          started = Queue.new
+          runner = Thread.new do
+            started << :go
+            vm.eval_code('const t = Date.now(); while (Date.now() - t < 400) {}; 1')
+          end
+          started.pop
+          sleep 0.05
+          begin
+            vm.define_function('probe_after_failure') { 1 }
+            false
+          rescue ThreadError => e
+            e.message.include?('GVL released')
+          ensure
+            runner.join
+          end
+        end
+
+        it "leaves no bridge behind after a path that does not resolve" do
+          vm = Quickjs::VM.new(timeout_msec: 5_000)
+          _ { vm.define_function(%w[nonexistent fn]) { 1 } }.must_raise Quickjs::ReferenceError
+
+          _(still_releases_the_gvl?(vm)).must_equal true
+        ensure
+          vm.dispose!
+        end
+
+        it "leaves no bridge behind after a target that refused" do
+          vm = Quickjs::VM.new(timeout_msec: 5_000)
+          vm.eval_code('Object.freeze(globalThis); 0')
+          _ { vm.define_function('lonely') { 1 } }.must_raise Quickjs::TypeError
+
+          _(still_releases_the_gvl?(vm)).must_equal true
+        ensure
+          vm.dispose!
+        end
+
+        it "still records the block once the property is installed" do
+          vm = Quickjs::VM.new(timeout_msec: 5_000)
+          vm.define_function('installed') { 1 }
+
+          _(still_releases_the_gvl?(vm)).must_equal false
+          _(vm.eval_code('installed()')).must_equal 1
+        ensure
+          vm.dispose!
+        end
       end
 
       it "single-element array returns a one-element array of symbols" do


### PR DESCRIPTION
Closes #84, #83 and #85.

Three issues from the same review of #79, in the same sixty lines, and they turn out to be one change. #84's fix is to own what the resolution holds and render the real error; #85's is to record the block only once the property is installed; and knowing it was installed *is* the check #83 says is missing. So this closes the three together as "`define_function`'s failure paths", rather than touching the same function three times.

## What a caller sees now

| | `main` | this branch |
|---|---|---|
| a bridge raises inside a path getter | `ArgumentError: 'myLib' is not an object` | the bridge's exception (`IOError: boom`) |
| a getter throws | `ArgumentError` | `Quickjs::RangeError: from getter` |
| the budget lapses inside a getter | `ArgumentError` | `Quickjs::InterruptedError` |
| `dispose!` reached from a getter | `ArgumentError` | `ThreadError` |
| first segment is not bound | `ArgumentError` | `Quickjs::ReferenceError: 'nonexistent' is not defined` |
| a segment resolves to a non-object | `ArgumentError` | `ArgumentError` (unchanged) |
| frozen parent / frozen `globalThis` | returns the name; the function does not exist | `Quickjs::TypeError: object is not extensible` |
| a setter on the target throws | returns the name | `Quickjs::RangeError: no` |

The one row that is a contract change rather than a correction is the `ReferenceError`: the first segment is an eval, and evaluating a name that is not bound is what JS calls it. Folding that into "is not an object" was the same masking as the rows above, so it is reported as itself, and the existing test moves with it. Say if you would rather keep `ArgumentError` there; it is one branch.

## Ownership

The parent being walked and the two values the bridge captures are owned by an `rb_ensure` from before any of them exists. Every exit above unwinds through it, and so does a `Thread#raise` landing in a getter's bridge, which had no ensure on this path at all. A plain name is now a path of one segment whose parent is the global object, so the two branches share one resolution instead of two copies of the install.

The masked bridge error also pinned its Ruby exception: `find_ruby_error` is the only thing that takes one out of `alive_objects`, and the masking never reached it. 300 masked calls left 300 `IOError`s on the Ruby heap until `dispose!`; now 0.

## The latent one

Rendering a JS exception from inside `define_function` had never happened before, and doing it crashed. `r_backtrace_from_js_stack` split the stack with `rb_str_split`, which enters `String#split` directly and so honours whatever block the current C frame was called with. `split` yielded every line of the JS stack **to the caller's block** and returned the String, which `rb_ary_entry` then dereferenced as an Array. Through `rb_funcall` now, which never forwards a block.

Adversarial review found the reach is wider than `define_function`: any entry point has a block if the caller passed one, so on `main` today

```ruby
vm.eval_code("throw new RangeError('x')") { }
```

segfaults — a stray block on `eval_code` and any JS error. Two tests: the block being defined is never invoked with stack lines, and `eval_code` with a block renders the error.

## One arm, deliberately asymmetric

The plain-name path never armed the eval timer, and my first version armed it unconditionally, which review caught as a regression: a bridge that calls `define_function('b')` on every call reset the enclosing eval's clock each time, and a 100 ms budget ran to 1500 ms where `main` interrupted at 120 ms. It now arms only as the outermost entry. The array path keeps `main`'s unconditional arm — nested under a bridge that resets the enclosing clock too, but `vm_m_compile`'s comment records that as a class to close across all entry points in one PR, not one at a time, so it is left exactly as it was. Test pins the plain-name case.

## #85, observed rather than timed

`can_eval_gvl_free` reads `defined_functions` as "a bridge can fire during eval". The test does not reproduce the two-thread timing table from the issue; it uses a deterministic observable instead: a VM on the GVL-release path refuses `define_function` with `ThreadError … GVL released` while another thread's eval is in flight, and a demoted one holds the GVL for the whole eval so the same call blocks and then succeeds. After a path that does not resolve, and after a target that refused, the VM still refuses — and after a define that succeeded it does not, which is the control.

## Measured

0 objects / 0 bytes retained per iteration over 300 for each failing shape: bridge in a getter, `ReferenceError`, a deep non-object, a frozen parent. 662 runs, 0 failures across four seeds. Sixteen tests are new or changed; thirteen fail on `main` (one of them by segfault), and the three that pass are the guards (a genuine non-object is still the caller's mistake; a successful define still registers; a nested plain-name define never defeated the budget on `main`).

README gains one paragraph on what a path resolution can raise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKYwniQEZWUcHG7puJd66x
